### PR TITLE
Add basic support for legacy version files (e.g. .ruby-version)

### DIFF
--- a/docs/creating-plugins.md
+++ b/docs/creating-plugins.md
@@ -50,6 +50,10 @@ Setup the env to run the binaries in the package.
 
 Uninstalls a specific version of a tool.
 
+#### bin/get_version_from_legacy_file
+
+Prints the version of the tool to use if a legacy version file is found in the current directory (e.g. rbenv's `.ruby-version`). Current directory is passed as the only argument to this script.
+
 ### Custom shim templates
 
 **PLEASE use this feature only if absolutely required**

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -135,8 +135,8 @@ get_tool_version_from_legacy_file() {
   local plugin_path=$(get_plugin_path $plugin_name)
   check_if_plugin_exists $plugin_path
 
-  if [ -f ${plugin_path}/bin/get_version_from_legacy_file ]; then
-    local legacy_tool_version=$(bash ${plugin_path}/bin/get_version_from_legacy_file $(pwd))
+  if [ -f ${plugin_path}/bin/get-version-from-legacy-file ]; then
+    local legacy_tool_version=$(bash ${plugin_path}/bin/get-version-from-legacy-file $(pwd))
   fi
 
   # Should return the version/tag/commit/branch/path

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -137,7 +137,7 @@ get_tool_version_from_legacy_file() {
   local legacy_version_script="${plugin_path}/bin/get-version-from-legacy-file"
   check_if_plugin_exists $plugin_path
 
-  if [ -f $legacy_tool_version ]; then
+  if [ -f $legacy_version_script ]; then
     local legacy_tool_version=$(bash $legacy_version_script $directory)
   fi
 

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -78,11 +78,11 @@ get_preset_version_for() {
   if [ "$asdf_versions_path" != "$(pwd)/.tool-versions" ]; then
     # Check for legacy version file
     matching_tool_version=$(get_tool_version_from_legacy_file $tool_name)
-  fi
 
-  # No legacy file, see if we can use .tool-versions file
-  if [ "$asdf_versions_path" != "" ]; then
-    matching_tool_version=$(get_tool_version_from_file $asdf_versions_path $tool_name)
+    # If no legacy version file, see if we can use a .tool-versions file higher in the directory tree
+    if [ "$matching_tool_version" = "" ] && [ "$asdf_versions_path" != "" ]; then
+        matching_tool_version=$(get_tool_version_from_file $asdf_versions_path $tool_name)
+    fi
   fi
 
 

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -132,9 +132,9 @@ get_tool_version_from_file() {
 get_tool_version_from_legacy_file() {
   local plugin_name=$1
   local directory=$2
-  local legacy_version_script="${plugin_path}/bin/get-version-from-legacy-file"
   local legacy_tool_version=""
   local plugin_path=$(get_plugin_path $plugin_name)
+  local legacy_version_script="${plugin_path}/bin/get-version-from-legacy-file"
   check_if_plugin_exists $plugin_path
 
   if [ -f $legacy_tool_version ]; then

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -74,6 +74,13 @@ get_preset_version_for() {
   local asdf_versions_path=$(get_asdf_versions_file_path)
   local matching_tool_version=""
 
+  # If .tool-versions is not in the working directory
+  if [ "$asdf_versions_path" != "$(pwd)/.tool-versions" ]; then
+    # Check for legacy version file
+    matching_tool_version=$(get_tool_version_from_legacy_file $tool_name)
+  fi
+
+  # No legacy file, see if we can use .tool-versions file
   if [ "$asdf_versions_path" != "" ]; then
     matching_tool_version=$(get_tool_version_from_file $asdf_versions_path $tool_name)
   fi
@@ -120,4 +127,18 @@ get_tool_version_from_file() {
   done < $asdf_versions_path
 
   echo $matching_tool_version
+}
+
+get_tool_version_from_legacy_file() {
+  local plugin_name=$1
+  local legacy_tool_version=""
+  local plugin_path=$(get_plugin_path $plugin_name)
+  check_if_plugin_exists $plugin_path
+
+  if [ -f ${plugin_path}/bin/get_version_from_legacy_file ]; then
+    local legacy_tool_version=$(bash ${plugin_path}/bin/get_version_from_legacy_file $(pwd))
+  fi
+
+  # Should return the version/tag/commit/branch/path
+  echo $legacy_tool_version
 }

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -77,12 +77,12 @@ get_preset_version_for() {
   # If .tool-versions is not in the working directory
   if [ "$asdf_versions_path" != "$(pwd)/.tool-versions" ]; then
     # Check for legacy version file
-    matching_tool_version=$(get_tool_version_from_legacy_file $tool_name)
+    matching_tool_version=$(get_tool_version_from_legacy_file $tool_name $(pwd))
+  fi
 
-    # If no legacy version file, see if we can use a .tool-versions file higher in the directory tree
-    if [ "$matching_tool_version" = "" ] && [ "$asdf_versions_path" != "" ]; then
-        matching_tool_version=$(get_tool_version_from_file $asdf_versions_path $tool_name)
-    fi
+  # If no legacy version file, see if we can use a .tool-versions file higher in the directory tree
+  if [ "$matching_tool_version" = "" ] && [ "$asdf_versions_path" != "" ]; then
+    matching_tool_version=$(get_tool_version_from_file $asdf_versions_path $tool_name)
   fi
 
 
@@ -131,12 +131,14 @@ get_tool_version_from_file() {
 
 get_tool_version_from_legacy_file() {
   local plugin_name=$1
+  local directory=$2
+  local legacy_version_script="${plugin_path}/bin/get-version-from-legacy-file"
   local legacy_tool_version=""
   local plugin_path=$(get_plugin_path $plugin_name)
   check_if_plugin_exists $plugin_path
 
-  if [ -f ${plugin_path}/bin/get-version-from-legacy-file ]; then
-    local legacy_tool_version=$(bash ${plugin_path}/bin/get-version-from-legacy-file $(pwd))
+  if [ -f $legacy_tool_version ]; then
+    local legacy_tool_version=$(bash $legacy_version_script $directory)
   fi
 
   # Should return the version/tag/commit/branch/path


### PR DESCRIPTION
Add basic support for legacy version files (e.g. .ruby-version) via an optional `get_version_from_legacy_file` script in each plugin.

Questions:
* Is it safe to equate plugin name with tool name? Or could there be variation in the tool name? (I make this assumption in the `get_tool_version_from_legacy_file` function).
* Should `get_version_from_legacy_file` be named `get-version-from-legacy-file`? It seems the other "callback" scripts use dashes. I'll be happy to change this. I only noticed this after I finished.

I have manually tested this PR with the updated asdf-ruby plugin on Ubuntu 14.04 and OSX 10.10.5.