### PR TITLE
Add support for config file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: c
+script: bats test
+before_script:
+  - git clone https://github.com/sstephenson/bats.git /tmp/bats
+  - export PATH=/tmp/bats/bin:$PATH
+os:
+  - linux
+  - osx

--- a/defaults
+++ b/defaults
@@ -1,0 +1,2 @@
+# enables the use of .ruby-version like files used by other version managers
+legacy_version_file = no

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -121,3 +121,31 @@ get_tool_version_from_file() {
 
   echo $matching_tool_version
 }
+
+get_asdf_config_value_from_file() {
+    local config_path=$1
+    local key=$2
+
+    if [ ! -f $config_path ]; then
+        return 0
+    fi
+
+    local result=$(grep -E "^\s*$key\s*=" $config_path | awk -F '=' '{ gsub(/ /, "", $2); print $2 }')
+    if [ -n "$result" ]; then
+        echo $result
+    fi
+}
+
+get_asdf_config_value() {
+    local key=$1
+    local config_path=${AZDF_CONFIG_FILE:-"$HOME/.asdfrc"}
+    local default_config_path=${AZDF_CONFIG_DEFAULT_FILE:-"$(asdf_dir)/defaults"}
+
+    local result=$(get_asdf_config_value_from_file $config_path $key)
+
+    if [ -n "$result" ]; then
+        echo $result
+    else
+        get_asdf_config_value_from_file $default_config_path $key
+    fi
+}

--- a/test/get_asdf_config_value.bats
+++ b/test/get_asdf_config_value.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+
+. $(dirname $BATS_TEST_DIRNAME)/lib/utils.sh
+
+setup() {
+    AZDF_CONFIG_FILE=$BATS_TMPDIR/asdfrc
+    cat > $AZDF_CONFIG_FILE <<-EOM
+key1 = value1
+legacy_version_file = yes
+EOM
+
+    AZDF_CONFIG_DEFAULT_FILE=$BATS_TMPDIR/asdfrc_defaults
+    cat > $AZDF_CONFIG_DEFAULT_FILE <<-EOM
+# i have  a comment, it's ok
+key2 = value2
+legacy_version_file = no
+EOM
+}
+
+teardown() {
+    rm $AZDF_CONFIG_FILE
+    rm $AZDF_CONFIG_DEFAULT_FILE
+    unset AZDF_CONFIG_DEFAULT_FILE
+    unset AZDF_CONFIG_FILE
+}
+
+@test "get_config returns default when config file does not exist" {
+    result=$(AZDF_CONFIG_FILE="/some/fake/path" get_asdf_config_value "legacy_version_file")
+    [ "$result" = "no" ]
+}
+
+@test "get_config returns default value when the key does not exist" {
+    [ $(get_asdf_config_value "key2") = "value2" ]
+}
+
+@test "get_config returns config file value when key exists" {
+    [ $(get_asdf_config_value "key1") = "value1" ]
+    [ $(get_asdf_config_value "legacy_version_file") = "yes" ]
+}


### PR DESCRIPTION
This closes #41 

The file should be located at `$HOME/.asdfrc` but the path can be overriden using the `ASDF_CONFIG_FILE` environment variable. If it does not exists, the defaults are used.
The default config is expected to be at `asdf_dir/defaults`, does that seem ok?

I am quite lenient on the config file format, but I think it should be ok for this use case.

I also added a few tests and a `.travis.yml` to go with, so it would be nice if you could enable travis :smiley: 