### PR TITLE
Make it possible to use fallback versions.

### DIFF
--- a/bin/private/asdf-exec
+++ b/bin/private/asdf-exec
@@ -15,50 +15,53 @@ if [ "$full_version" == "" ]; then
   exit -1
 fi
 
+IFS=' ' read -a versions <<< "$full_version"
 
-IFS=':' read -a version_info <<< "$full_version"
-if [ "${version_info[0]}" = "ref" ]; then
-  install_type="${version_info[0]}"
-  version="${version_info[1]}"
-  install_path=$(get_install_path $plugin_name $install_type $version)
-elif [ "${version_info[0]}" = "path" ]; then
-  # This is for people who have the local source already compiled
-  # Like those who work on the language, etc
-  # We'll allow specifying path:/foo/bar/project in .tool-versions
-  # And then use the binaries there
-  install_type="path"
-  version="path"
-  install_path="${version_info[1]}"
-else
-  install_type="version"
-  version="${version_info[0]}"
-  install_path=$(get_install_path $plugin_name $install_type $version)
-fi
+for version in "${versions[@]}"; do
+  IFS=':' read -a version_info <<< "$version"
 
-
-if [ ! -d $install_path ]; then
-  echo "$plugin_name $full_version not installed"
-  exit 1
-fi
-
-if [ ! -f ${install_path}/${executable_path} ]; then
-  echo "No such command in $full_version of $plugin_name"
-  exit 1
-fi
+  if [ "${version_info[0]}" = "ref" ]; then
+    install_type="${version_info[0]}"
+    version="${version_info[1]}"
+    install_path=$(get_install_path $plugin_name $install_type $version)
+  elif [ "${version_info[0]}" = "path" ]; then
+    # This is for people who have the local source already compiled
+    # Like those who work on the language, etc
+    # We'll allow specifying path:/foo/bar/project in .tool-versions
+    # And then use the binaries there
+    install_type="path"
+    version="path"
+    install_path="${version_info[1]}"
+  else
+    install_type="version"
+    version="${version_info[0]}"
+    install_path=$(get_install_path $plugin_name $install_type $version)
+  fi
 
 
-if [ -f ${plugin_path}/bin/exec-env ]; then
-  export ASDF_INSTALL_TYPE=$install_type
-  export ASDF_INSTALL_VERSION=$version
-  export ASDF_INSTALL_PATH=$install_path
+  if [ ! -d $install_path ]; then
+    echo "$plugin_name $version not installed"
+    exit 1
+  fi
 
-  source ${plugin_path}/bin/exec-env
+  if [ -f ${install_path}/${executable_path} ]; then
+    if [ -f ${plugin_path}/bin/exec-env ]; then
+      export ASDF_INSTALL_TYPE=$install_type
+      export ASDF_INSTALL_VERSION=$version
+      export ASDF_INSTALL_PATH=$install_path
 
-  # unset everything, we don't want to pollute
-  unset ASDF_INSTALL_TYPE
-  unset ASDF_INSTALL_VERSION
-  unset ASDF_INSTALL_PATH
-  exec ${install_path}/${executable_path} "${@:3}"
-else
-  exec ${install_path}/${executable_path} "${@:3}"
-fi
+      source ${plugin_path}/bin/exec-env
+
+      # unset everything, we don't want to pollute
+      unset ASDF_INSTALL_TYPE
+      unset ASDF_INSTALL_VERSION
+      unset ASDF_INSTALL_PATH
+      exec ${install_path}/${executable_path} "${@:3}"
+    else
+      exec ${install_path}/${executable_path} "${@:3}"
+    fi
+  fi
+done
+
+echo "No such command in $full_version of $plugin_name"
+exit 1

--- a/completions/asdf.fish
+++ b/completions/asdf.fish
@@ -81,12 +81,12 @@ complete -f -c asdf -n '__fish_asdf_using_command reshim; and __fish_asdf_arg_nu
 # local completion
 complete -f -c asdf -n '__fish_asdf_needs_command' -a local -d "Set local version for a plugin"
 complete -f -c asdf -n '__fish_asdf_using_command local; and __fish_asdf_arg_number 2' -a '(asdf plugin-list)'
-complete -f -c asdf -n '__fish_asdf_using_command local; and __fish_asdf_arg_number 3' -a '(asdf list (__fish_asdf_arg_at 3))'
+complete -f -c asdf -n '__fish_asdf_using_command local; and test (count (commandline -opc)) -gt 2' -a '(asdf list (__fish_asdf_arg_at 3))'
 
 # global completion
 complete -f -c asdf -n '__fish_asdf_needs_command' -a global -d "Set global version for a plugin"
 complete -f -c asdf -n '__fish_asdf_using_command global; and __fish_asdf_arg_number 2' -a '(asdf plugin-list)'
-complete -f -c asdf -n '__fish_asdf_using_command global; and __fish_asdf_arg_number 3' -a '(asdf list (__fish_asdf_arg_at 3))'
+complete -f -c asdf -n '__fish_asdf_using_command global; and test (count (commandline -opc)) -gt 2' -a '(asdf list (__fish_asdf_arg_at 3))'
 
 # misc
 complete -f -c asdf -n '__fish_asdf_needs_command' -l "help" -d "Displays help"

--- a/lib/commands/version_commands.sh
+++ b/lib/commands/version_commands.sh
@@ -31,11 +31,6 @@ get_plugin_version() {
 version_command() {
   local cmd=$1
 
-  if [ $# -gt 3 ]; then
-    echo usage: $cmd [PLUGIN] [VERSION]
-    exit 1
-  fi
-
   local file
   if [ $cmd = "global" ]; then
     file=$HOME/.tool-versions
@@ -64,7 +59,7 @@ version_command() {
     get_plugin_version $cmd $file $plugin
   fi
 
-  local version=$3
+  local version=${@:3}
 
   check_if_version_exists $plugin $version
 

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -116,6 +116,7 @@ get_preset_version_for() {
 get_tool_version_from_file() {
   local asdf_versions_path=$1
   local tool_name=$2
+  local get_all_versions=$3
   local matching_tool_version=""
 
   local read_done=false
@@ -128,7 +129,7 @@ get_tool_version_from_file() {
 
     IFS=' ' read -a tool_info <<< $tool_line
     local t_name=$(echo "${tool_info[0]}" | xargs)
-    local t_version=$(echo "${tool_info[1]}" | xargs)
+    local t_version=$(echo "${tool_info[@]:1}" | xargs)
 
     if [ "$t_name" = "$tool_name" ]
     then


### PR DESCRIPTION
I added the possibility to add fallback versions for a plugin.
As discussed in #37, this is a must for Python as (sadly) there are a lot
of scripts which work only with a single version of python, and we therefore
need to be able to call the python2 or python3 command.
A typical usage would be

```
asdf global python 3.5.1 2.7.11
pip2 install ansible
ansible # this uses python 2, but we can use it even though 3.5 is the default
python --version # 3.5.1
```