### PR TITLE
Fix #52: Send any `cd` output to /dev/null

### DIFF
--- a/asdf.sh
+++ b/asdf.sh
@@ -6,7 +6,7 @@ else
   current_script_path=$0
 fi
 
-asdf_dir=$(cd $(dirname $current_script_path) > /dev/null; echo $(pwd))
+asdf_dir=$(cd $(dirname $current_script_path) &> /dev/null; echo $(pwd))
 export PATH="${asdf_dir}/bin:${asdf_dir}/shims:$PATH"
 
 if [ -n "$ZSH_VERSION" ]; then

--- a/asdf.sh
+++ b/asdf.sh
@@ -6,7 +6,7 @@ else
   current_script_path=$0
 fi
 
-asdf_dir=$(cd $(dirname $current_script_path); echo $(pwd))
+asdf_dir=$(cd $(dirname $current_script_path) > /dev/null; echo $(pwd))
 export PATH="${asdf_dir}/bin:${asdf_dir}/shims:$PATH"
 
 if [ -n "$ZSH_VERSION" ]; then


### PR DESCRIPTION
Users of `zsh` can define hook functions that execute when
the current directory changes.  If a user has their `zsh`
configured with a hook function that writes to stdout, the
`asdf` setup script will capture that output in addition to
the output of `pwd`, which causes a misconfiguration of the
`PATH` environment variable.

By redirecting the output, if any, of the `cd` command to
`/dev/null`, this ensures that the path to `bin` in `asdf`
is captured correctly regardless of `zsh` configuration.