### PR TITLE
Install the latest version when running tests

### DIFF
--- a/lib/commands/plugin-test.sh
+++ b/lib/commands/plugin-test.sh
@@ -33,7 +33,8 @@ plugin_test_command() {
         fail_test "list-all did not return any version"
     fi
 
-    (asdf install $plugin_name ${versions[0]})
+    latest_version=${versions[${#versions[@]} - 1]}
+    (asdf install $plugin_name $latest_version)
 
     if [ $? -ne 0 ]; then
         fail_test "install exited with an error"


### PR DESCRIPTION
I had issues installing Python latest version, so I think running the CI on the latest
version will help.
I will eventually ask Travis to enable cron jobs for each language repositories.

https://docs.travis-ci.com/user/cron-jobs/