### PR TITLE
Sort versions in list-all

### DIFF
--- a/lib/commands/list-all.sh
+++ b/lib/commands/list-all.sh
@@ -7,7 +7,9 @@ list_all_command() {
 
   IFS=' ' read -a versions_list <<< "$versions"
 
-  for version in "${versions_list[@]}"
+  sorted_versions=$(for version in ${versions_list[@]}; do echo $version; done | sort -r)
+
+  for version in "${sorted_versions[@]}"
   do
     echo "${version}"
   done

--- a/test/helper.sh
+++ b/test/helper.sh
@@ -1,0 +1,12 @@
+. $(dirname $BATS_TEST_DIRNAME)/lib/utils.sh
+
+prepare() {
+  BASE_DIR=$(mktemp -dt asdf.XXXX)
+  HOME=$BASE_DIR/home
+  ASDF_DIR=$HOME/.asdf
+}
+
+clean() {
+  rm -rf $BASE_DIR
+  unset ASDF_DIR
+}

--- a/test/list-all.bats
+++ b/test/list-all.bats
@@ -1,0 +1,19 @@
+#!/usr/bin/env bats
+
+. $(dirname $BATS_TEST_DIRNAME)/test/helper.sh
+. $(dirname $BATS_TEST_DIRNAME)/lib/commands/list-all.sh
+
+setup() {
+  prepare
+
+  mkdir -p $ASDF_DIR/plugins/foo/bin
+  echo 'echo 0.9 1.0 1.1' > $ASDF_DIR/plugins/foo/bin/list-all
+  chmod +x $ASDF_DIR/plugins/foo/bin/list-all
+}
+
+@test "sort versions from the latest to the oldest" {
+  run list_all_command foo
+  expected=$(echo -e "1.1\n1.0\n0.9\n")
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
+}

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -1,14 +1,13 @@
 #!/usr/bin/env bats
 
-. $(dirname $BATS_TEST_DIRNAME)/lib/utils.sh
+. $(dirname $BATS_TEST_DIRNAME)/test/helper.sh
 
 setup() {
-  ASDF_DIR=$(mktemp -dt asdf.XXXX)
+  prepare
 }
 
 teardown() {
-  rm -rf $ASDF_DIR
-  unset ASDF_DIR
+  clean
 }
 
 @test "check_if_version_exists should exit with 1 if plugin does not exist" {

--- a/test/version_commands.bats
+++ b/test/version_commands.bats
@@ -1,12 +1,10 @@
 #!/usr/bin/env bats
 
-. $(dirname $BATS_TEST_DIRNAME)/lib/utils.sh
+. $(dirname $BATS_TEST_DIRNAME)/test/helper.sh
 . $(dirname $BATS_TEST_DIRNAME)/lib/commands/version_commands.sh
 
 setup() {
-  BASE_DIR=$(mktemp -dt asdf.XXXX)
-  HOME=$BASE_DIR/home
-  ASDF_DIR=$HOME/.asdf
+  prepare
   OTHER_DIR=$BASE_DIR/other
   mkdir -p $ASDF_DIR/plugins/foo $ASDF_DIR/plugins/bar $ASDF_DIR/installs/foo/1.0.0 $ASDF_DIR/installs/foo/1.1.0 $ASDF_DIR/installs/foo/1.2.0 $ASDF_DIR/installs/bar/1.0.0 $OTHER_DIR
 
@@ -16,9 +14,8 @@ setup() {
 }
 
 teardown() {
-  rm -rf $BASE_DIR
+  clean
 }
-
 
 @test "local should emit an error when run in lookup mode and file does not exist" {
   rm .tool-versions


### PR DESCRIPTION
As discussed in #58, I sorted the versions when using list-all from the latest to the oldest.