### PR TITLE
Use bashcompinit instead of compinit for ZSH

### DIFF
--- a/asdf.sh
+++ b/asdf.sh
@@ -11,6 +11,6 @@ export PATH="${asdf_dir}/bin:${asdf_dir}/shims:$PATH"
 
 if [ -n "$ZSH_VERSION" ]; then
   fpath=(${asdf_dir}/completions $fpath)
-  autoload -U compinit
-  compinit
+  autoload -U bashcompinit
+  bashcompinit
 fi


### PR DESCRIPTION
Related to https://github.com/asdf-vm/asdf/issues/68, an improvement for https://github.com/asdf-vm/asdf/pull/25