### PR TITLE
Set ASDF_CONCURRENCY when installing

### DIFF
--- a/lib/commands/install.sh
+++ b/lib/commands/install.sh
@@ -9,6 +9,17 @@ install_command() {
   fi
 }
 
+get_concurrency() {
+  if which nproc > /dev/null 2>&1; then
+    echo $(nproc)
+  elif which nproc > /dev/null 2>&1; then
+    echo $(sysctl -n hw.ncpu)
+  elif [ -f /proc/cpuinfo ]; then
+    echo $(grep -c processor /proc/cpuinfo)
+  else
+    echo "1"
+  fi
+}
 
 install_local_tool_versions() {
   if [ -f $(pwd)/.tool-versions ]; then
@@ -49,6 +60,7 @@ install_tool_version() {
 
 
   local install_path=$(get_install_path $plugin_name $install_type $version)
+  local concurrency=$(get_concurrency)
   if [ -d $install_path ]; then
     echo "$plugin_name $full_version is already installed"
   else
@@ -56,6 +68,7 @@ install_tool_version() {
       export ASDF_INSTALL_TYPE=$install_type
       export ASDF_INSTALL_VERSION=$version
       export ASDF_INSTALL_PATH=$install_path
+      export ASDF_CONCURRENCY=$concurrency
       mkdir $install_path
       bash ${plugin_path}/bin/install
     )

--- a/test/fixtures/dummy_plugin/bin/install
+++ b/test/fixtures/dummy_plugin/bin/install
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+mkdir -p $ASDF_INSTALL_PATH
+env > $ASDF_INSTALL_PATH/env
+echo $ASDF_INSTALL_VERSION > $ASDF_INSTALL_PATH/version

--- a/test/fixtures/dummy_plugin/bin/list-all
+++ b/test/fixtures/dummy_plugin/bin/list-all
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+versions_list=(1.0 1.1 2.0)
+echo ${versions_list[@]}

--- a/test/get_asdf_config_value.bats
+++ b/test/get_asdf_config_value.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-. $(dirname $BATS_TEST_DIRNAME)/lib/utils.sh
+load test_helpers
 
 setup() {
     AZDF_CONFIG_FILE=$BATS_TMPDIR/asdfrc

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+load test_helpers
+
+. $(dirname $BATS_TEST_DIRNAME)/lib/commands/reshim.sh
+. $(dirname $BATS_TEST_DIRNAME)/lib/commands/install.sh
+
+setup() {
+  setup_asdf_dir
+  install_dummy_plugin
+}
+
+teardown() {
+  clean_asdf_dir
+}
+
+@test "install_command installs the correct version" {
+  run install_command dummy 1.1
+  [ "$status" -eq 0 ]
+  [ $(cat $ASDF_DIR/installs/dummy/1.1/version) = "1.1" ]
+}
+
+@test "install_command set ASDF_CONCURRENCY" {
+  run install_command dummy 1.0
+  [ "$status" -eq 0 ]
+  [ -f $ASDF_DIR/installs/dummy/1.0/env ]
+  run grep ASDF_CONCURRENCY $ASDF_DIR/installs/dummy/1.0/env
+  [ "$status" -eq 0 ]
+}

--- a/test/test_helpers.bash
+++ b/test/test_helpers.bash
@@ -1,0 +1,18 @@
+. $(dirname $BATS_TEST_DIRNAME)/lib/utils.sh
+
+setup_asdf_dir() {
+  BASE_DIR=$(mktemp -dt asdf.XXXX)
+  HOME=$BASE_DIR/home
+  ASDF_DIR=$HOME/.asdf
+  mkdir -p $ASDF_DIR/plugins
+  mkdir -p $ASDF_DIR/installs
+}
+
+install_dummy_plugin() {
+  cp -r $BATS_TEST_DIRNAME/fixtures/dummy_plugin $ASDF_DIR/plugins/dummy
+}
+
+clean_asdf_dir() {
+  rm -rf $BASE_DIR
+  unset ASDF_DIR
+}

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -1,14 +1,13 @@
 #!/usr/bin/env bats
 
-. $(dirname $BATS_TEST_DIRNAME)/lib/utils.sh
+load test_helpers
 
 setup() {
-  ASDF_DIR=$(mktemp -dt asdf.XXXX)
+  setup_asdf_dir
 }
 
 teardown() {
-  rm -rf $ASDF_DIR
-  unset ASDF_DIR
+  clean_asdf_dir
 }
 
 @test "check_if_version_exists should exit with 1 if plugin does not exist" {

--- a/test/version_commands.bats
+++ b/test/version_commands.bats
@@ -1,12 +1,12 @@
 #!/usr/bin/env bats
 
-. $(dirname $BATS_TEST_DIRNAME)/lib/utils.sh
+load test_helpers
+
 . $(dirname $BATS_TEST_DIRNAME)/lib/commands/version_commands.sh
 
 setup() {
-  BASE_DIR=$(mktemp -dt asdf.XXXX)
-  HOME=$BASE_DIR/home
-  ASDF_DIR=$HOME/.asdf
+  setup_asdf_dir
+
   OTHER_DIR=$BASE_DIR/other
   mkdir -p $ASDF_DIR/plugins/foo $ASDF_DIR/plugins/bar $ASDF_DIR/installs/foo/1.0.0 $ASDF_DIR/installs/foo/1.1.0 $ASDF_DIR/installs/foo/1.2.0 $ASDF_DIR/installs/bar/1.0.0 $OTHER_DIR
 
@@ -16,7 +16,7 @@ setup() {
 }
 
 teardown() {
-  rm -rf $BASE_DIR
+  clean_asdf_dir
 }
 
 


### PR DESCRIPTION
This set and exports the `ASDF_CONCURRENCY` variable to the install script.
Each plugin should use this variable when appropriate.
I just updated my python plugin to give it a try:

https://github.com/tuvistavie/asdf-python/commit/1538892959436dd32928edba4ed5758e873fd9a2  

This closes #57