### PR TITLE
Check if plugin exists before removing it

### DIFF
--- a/bin/private/asdf-exec
+++ b/bin/private/asdf-exec
@@ -6,7 +6,7 @@ plugin_name=$1
 executable_path=$2
 
 plugin_path=$(get_plugin_path $plugin_name)
-check_if_plugin_exists $plugin_path
+check_if_plugin_exists $plugin_name
 
 full_version=$(get_preset_version_for $plugin_name)
 

--- a/lib/commands/install.sh
+++ b/lib/commands/install.sh
@@ -46,7 +46,7 @@ install_tool_version() {
   local plugin_name=$1
   local full_version=$2
   local plugin_path=$(get_plugin_path $plugin_name)
-  check_if_plugin_exists $plugin_path
+  check_if_plugin_exists $plugin_name
 
 
   IFS=':' read -a version_info <<< "$full_version"

--- a/lib/commands/list-all.sh
+++ b/lib/commands/list-all.sh
@@ -1,7 +1,7 @@
 list_all_command() {
   local plugin_name=$1
   local plugin_path=$(get_plugin_path $plugin_name)
-  check_if_plugin_exists $plugin_path
+  check_if_plugin_exists $plugin_name
 
   local versions=$(bash ${plugin_path}/bin/list-all)
 

--- a/lib/commands/list.sh
+++ b/lib/commands/list.sh
@@ -1,7 +1,7 @@
 list_command() {
   local plugin_name=$1
   local plugin_path=$(get_plugin_path $plugin_name)
-  check_if_plugin_exists $plugin_path
+  check_if_plugin_exists $plugin_name
 
   local plugin_installs_path=$(asdf_dir)/installs/${plugin_name}
 

--- a/lib/commands/plugin-push.sh
+++ b/lib/commands/plugin-push.sh
@@ -7,7 +7,7 @@ plugin_push_command() {
     done
   else
     local plugin_path=$(get_plugin_path $plugin_name)
-    check_if_plugin_exists $plugin_path
+    check_if_plugin_exists $plugin_name
     echo "Pushing $plugin_name..."
     (cd $plugin_path; git push)
   fi

--- a/lib/commands/plugin-remove.sh
+++ b/lib/commands/plugin-remove.sh
@@ -1,5 +1,7 @@
 plugin_remove_command() {
   local plugin_name=$1
+  check_if_plugin_exists $plugin_name
+
   local plugin_path=$(get_plugin_path $plugin_name)
 
   rm -rf $plugin_path

--- a/lib/commands/plugin-update.sh
+++ b/lib/commands/plugin-update.sh
@@ -7,7 +7,7 @@ plugin_update_command() {
     done
   else
     local plugin_path=$(get_plugin_path $plugin_name)
-    check_if_plugin_exists $plugin_path
+    check_if_plugin_exists $plugin_name
     echo "Updating $plugin_name..."
     (cd $plugin_path; git pull)
   fi

--- a/lib/commands/reshim.sh
+++ b/lib/commands/reshim.sh
@@ -2,7 +2,7 @@ shim_command() {
   local plugin_name=$1
   local executable_path=$2
   local plugin_path=$(get_plugin_path $plugin_name)
-  check_if_plugin_exists $plugin_path
+  check_if_plugin_exists $plugin_name
   ensure_shims_dir
 
   generate_shim_for_executable $plugin_name $executable_path
@@ -12,7 +12,7 @@ reshim_command() {
   local plugin_name=$1
   local full_version=$2
   local plugin_path=$(get_plugin_path $plugin_name)
-  check_if_plugin_exists $plugin_path
+  check_if_plugin_exists $plugin_name
   ensure_shims_dir
 
   if [ "$full_version" != "" ]; then
@@ -62,7 +62,7 @@ generate_shim_for_executable() {
   local executable=$2
   local plugin_path=$(get_plugin_path $plugin_name)
 
-  check_if_plugin_exists $plugin_path
+  check_if_plugin_exists $plugin_name
 
   IFS=':' read -a version_info <<< "$full_version"
   if [ "${version_info[0]}" = "ref" ]; then
@@ -81,7 +81,7 @@ generate_shims_for_version() {
   local plugin_name=$1
   local full_version=$2
   local plugin_path=$(get_plugin_path $plugin_name)
-  check_if_plugin_exists $plugin_path
+  check_if_plugin_exists $plugin_name
 
   IFS=':' read -a version_info <<< "$full_version"
   if [ "${version_info[0]}" = "ref" ]; then

--- a/lib/commands/uninstall.sh
+++ b/lib/commands/uninstall.sh
@@ -3,7 +3,7 @@ uninstall_command() {
   local full_version=$2
   local plugin_path=$(get_plugin_path $plugin_name)
 
-  check_if_plugin_exists $plugin_path
+  check_if_plugin_exists $plugin_name
 
   IFS=':' read -a version_info <<< "$full_version"
   if [ "${version_info[0]}" = "ref" ]; then

--- a/lib/commands/version_commands.sh
+++ b/lib/commands/version_commands.sh
@@ -53,7 +53,7 @@ version_command() {
 
   local plugin=$2
 
-  check_if_plugin_exists $(get_plugin_path $plugin)
+  check_if_plugin_exists $plugin
 
   if [ $# -eq 2 ]; then
     get_plugin_version $cmd $file $plugin

--- a/lib/commands/where.sh
+++ b/lib/commands/where.sh
@@ -2,7 +2,7 @@ where_command() {
   local plugin_name=$1
   local full_version=$2
   local plugin_path=$(get_plugin_path $plugin_name)
-  check_if_plugin_exists $plugin_path
+  check_if_plugin_exists $plugin_name
 
   IFS=':' read -a version_info <<< "$full_version"
   if [ "${version_info[0]}" = "ref" ]; then

--- a/lib/commands/which.sh
+++ b/lib/commands/which.sh
@@ -1,7 +1,7 @@
 which_command() {
   local plugin_name=$1
   local plugin_path=$(get_plugin_path $plugin_name)
-  check_if_plugin_exists $plugin_path
+  check_if_plugin_exists $plugin_name
 
   full_version=$(get_preset_version_for $plugin_name)
 

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -153,7 +153,7 @@ get_tool_version_from_legacy_file() {
   local legacy_tool_version=""
   local plugin_path=$(get_plugin_path $plugin_name)
   local legacy_version_script="${plugin_path}/bin/get-version-from-legacy-file"
-  check_if_plugin_exists $plugin_path
+  check_if_plugin_exists $plugin_name
 
   if [ -f $legacy_version_script ]; then
     local legacy_tool_version=$(bash $legacy_version_script $directory)

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -29,8 +29,13 @@ get_install_path() {
 
 
 check_if_plugin_exists() {
-  if [ ! -d $1 ]
-    then
+  # Check if we have a non-empty argument
+  if [ -z "${1+set}" ]; then
+    display_error "No such plugin"
+    exit 1
+  fi
+
+  if [ ! -d $(asdf_dir)/plugins/$1 ]; then
     display_error "No such plugin"
     exit 1
   fi

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -59,7 +59,7 @@ get_plugin_path() {
 
 
 display_error() {
-  echo $1
+  echo >&2 $1
 }
 
 

--- a/test/remove_command.bats
+++ b/test/remove_command.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+
+load test_helpers
+
+. $(dirname $BATS_TEST_DIRNAME)/lib/commands/plugin-remove.sh
+
+setup() {
+  setup_asdf_dir
+}
+
+teardown() {
+  clean_asdf_dir
+}
+
+@test "plugin_remove_command removes a plugin" {
+  install_dummy_plugin
+
+  run plugin_remove_command "dummy"
+  [ "$status" -eq 0 ]
+  [ "$output" = "" ]
+}
+
+@test "plugin_remove_command should exit with 1 when not passed any arguments" {
+  run plugin_remove_command
+  [ "$status" -eq 1 ]
+  [ "$output" = "No such plugin" ]
+}
+
+@test "plugin_remove_command should exit with 1 when passed invalid plugin name" {
+  run plugin_remove_command "does-not-exist"
+  [ "$status" -eq 1 ]
+  [ "$output" = "No such plugin" ]
+}

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -30,3 +30,16 @@ teardown() {
   [ "$status" -eq 0 ]
   [ "$output" = "" ]
 }
+
+@test "check_if_plugin_exists should exit with 1 when plugin is empty string" {
+  run check_if_plugin_exists
+  [ "$status" -eq 1 ]
+  [ "$output" = "No such plugin" ]
+}
+
+@test "check_if_plugin_exists should be noop if plugin exists" {
+  mkdir -p $ASDF_DIR/plugins/foo_bar
+  run check_if_plugin_exists "foo_bar"
+  [ "$status" -eq 0 ]
+  [ "$output" = "" ]
+}


### PR DESCRIPTION
This PR is a fix for issue #76. It takes the following approach:

 1. (Redirect `display_error()` to stdout)
 1. Add failing test cases for `check_if_plugin_exists()`
 1. Change `check_if_plugin_exists()` to expect a plugin name instead of PATH, check if the name is empty and the directory exists -- instead of old potentially buggy behavior.
 1. Update all `check_if_plugin_exists()` call sites (all tests should be green)
 1. Add the failing test cases for issue #76.
 1. Fix the tests by calling `check_if_plugin_exists()` in `plugin_remove_command()`