### PR TITLE
Rename which to current

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ asdf plugin-update <name>
 asdf install <name> <version>
 # asdf install erlang 17.3
 
-asdf which <name>
-# asdf which erlang
+asdf current <name>
+# asdf current erlang
 # 17.3
 
 asdf uninstall <name> <version>

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ asdf install <name> <version>
 
 asdf current <name>
 # asdf current erlang
-# 17.3
+# 17.3 (set by /Users/kim/.tool-versions)
 
 asdf uninstall <name> <version>
 # asdf uninstall erlang 17.3

--- a/bin/asdf
+++ b/bin/asdf
@@ -5,7 +5,7 @@ source $(dirname $(dirname $0))/lib/utils.sh
 source $(dirname $(dirname $0))/lib/commands/help.sh
 source $(dirname $(dirname $0))/lib/commands/install.sh
 source $(dirname $(dirname $0))/lib/commands/uninstall.sh
-source $(dirname $(dirname $0))/lib/commands/which.sh
+source $(dirname $(dirname $0))/lib/commands/current.sh
 source $(dirname $(dirname $0))/lib/commands/where.sh
 source $(dirname $(dirname $0))/lib/commands/version_commands.sh
 source $(dirname $(dirname $0))/lib/commands/list.sh
@@ -36,8 +36,8 @@ case $1 in
 "uninstall")
     uninstall_command $callback_args;;
 
-"which")
-    which_command $callback_args;;
+"current")
+    current_command $callback_args;;
 
 "where")
     where_command $callback_args;;

--- a/completions/asdf.bash
+++ b/completions/asdf.bash
@@ -12,7 +12,7 @@ _asdf () {
     plugin-update)
       COMPREPLY=($(compgen -W "$plugins --all" -- $cur))
       ;;
-    plugin-remove|which|list|list-all)
+    plugin-remove|current|list|list-all)
       COMPREPLY=($(compgen -W "$plugins" -- $cur))
       ;;
     install)
@@ -32,7 +32,7 @@ _asdf () {
       fi
       ;;
     *)
-      local cmds='plugin-add plugin-list plugin-remove plugin-update install uninstall which where list list-all reshim'
+      local cmds='plugin-add plugin-list plugin-remove plugin-update install uninstall current where list list-all reshim'
       COMPREPLY=($(compgen -W "$cmds" -- $cur))
       ;;
   esac

--- a/completions/asdf.fish
+++ b/completions/asdf.fish
@@ -56,9 +56,9 @@ complete -f -c asdf -n '__fish_asdf_needs_command' -a uninstall -d "Remove a spe
 complete -f -c asdf -n '__fish_asdf_using_command uninstall; and __fish_asdf_arg_number 2' -a '(asdf plugin-list)'
 complete -f -c asdf -n '__fish_asdf_using_command uninstall; and __fish_asdf_arg_number 3' -a '(asdf list (__fish_asdf_arg_at 3))'
 
-# which completion
-complete -f -c asdf -n '__fish_asdf_needs_command' -a which -d "Display version set or being used for package"
-complete -f -c asdf -n '__fish_asdf_using_command which; and __fish_asdf_arg_number 2' -a '(asdf plugin-list)'
+# current completion
+complete -f -c asdf -n '__fish_asdf_needs_command' -a current -d "Display version set or being used for package"
+complete -f -c asdf -n '__fish_asdf_using_command current; and __fish_asdf_arg_number 2' -a '(asdf plugin-list)'
 
 # where completion
 complete -f -c asdf -n '__fish_asdf_needs_command' -a where -d "Display install path for an installed version"

--- a/help.txt
+++ b/help.txt
@@ -11,7 +11,7 @@ MANAGE PACKAGES
                                        with no arguments, install all the package
                                        versions listed in the .tool-versions file
   asdf uninstall <name> <version>      Remove a specific version of a package
-  asdf which <name>                    Display version set or being used for package
+  asdf current <name>                  Display current version set or being used for package
   asdf where <name> <version>          Display install path for an installed version
   asdf local [name]                    Display a package local version
   asdf local <name> <version>          Set the package local version

--- a/lib/commands/current.sh
+++ b/lib/commands/current.sh
@@ -1,15 +1,16 @@
 current_command() {
   local plugin_name=$1
   local plugin_path=$(get_plugin_path $plugin_name)
+  local tool_versions_path=$(get_asdf_versions_file_path)
   check_if_plugin_exists $plugin_name
 
   full_version=$(get_preset_version_for $plugin_name)
 
   if [ "$full_version" == "" ]; then
-      echo "No version set for ${plugin_name}"
-      exit -1
+    echo "No version set for $plugin_name"
+    exit 1
   else
-      echo "$full_version"
-      exit 0
+    echo "$full_version (set by $tool_versions_path)"
+    exit 0
   fi
 }

--- a/lib/commands/current.sh
+++ b/lib/commands/current.sh
@@ -1,16 +1,20 @@
 current_command() {
   local plugin_name=$1
-  local plugin_path=$(get_plugin_path $plugin_name)
-  local tool_versions_path=$(get_asdf_versions_file_path)
+  local version=$(get_preset_version_for $plugin_name)
+
   check_if_plugin_exists $plugin_name
 
-  full_version=$(get_preset_version_for $plugin_name)
-
-  if [ "$full_version" == "" ]; then
+  if [ "$version" == "" ]; then
     echo "No version set for $plugin_name"
     exit 1
   else
-    echo "$full_version (set by $tool_versions_path)"
+    local version_file_path=$(get_version_file_path_for $plugin_name)
+    if [ "$version_file_path" == "" ]; then
+      echo "$version"
+    else
+      echo "$version (set by $version_file_path)"
+    fi
+
     exit 0
   fi
 }

--- a/lib/commands/current.sh
+++ b/lib/commands/current.sh
@@ -1,4 +1,4 @@
-which_command() {
+current_command() {
   local plugin_name=$1
   local plugin_path=$(get_plugin_path $plugin_name)
   check_if_plugin_exists $plugin_name

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -67,6 +67,21 @@ display_error() {
   echo >&2 $1
 }
 
+get_version_file_path_for() {
+  local tool_name=$1
+  local legacy_version_file_support=$(get_asdf_config_value "legacy_version_file")
+
+  if [ ! -f "$(pwd)/.tool-versions" ] && [ "$legacy_version_file_support" = "yes" ]; then
+    # Check for legacy version and return "" if it exists
+    local legacy_version=$(get_tool_version_from_legacy_file $tool_name $(pwd))
+    if [ "$legacy_version" != "" ]; then
+      echo ""
+      return 1
+    fi
+  fi
+
+  echo $(get_asdf_versions_file_path)
+}
 
 get_asdf_versions_file_path() {
   local asdf_tool_versions_path=""

--- a/test/current_command.bats
+++ b/test/current_command.bats
@@ -6,45 +6,47 @@ load test_helpers
 
 setup() {
   setup_asdf_dir
+  install_dummy_plugin
 
   PROJECT_DIR=$HOME/project
   OTHER_DIR=$HOME/other
-  mkdir -p $ASDF_DIR/plugins/foo $ASDF_DIR/installs/foo/1.0.0 $ASDF_DIR/installs/foo/1.1.0 $PROJECT_DIR $OTHER_DIR
+  mkdir -p $ASDF_DIR/installs/dummy/1.0.0 $ASDF_DIR/installs/dummy/1.1.0 $PROJECT_DIR $OTHER_DIR
 
-  echo 'foo 1.0.0' >> $HOME/.tool-versions
-  echo 'foo 1.1.0' >> $PROJECT_DIR/.tool-versions
+  echo 'dummy 1.0.0' >> $HOME/.tool-versions
+  echo 'dummy 1.1.0' >> $PROJECT_DIR/.tool-versions
+  echo '1.2.0' >> $OTHER_DIR/.dummy-version
 }
 
 teardown() {
   clean_asdf_dir
 }
 
-@test "current should output the version the local .tool_versions path" {
+@test "current should derive from the local .tool_versions when it exists" {
   cd $PROJECT_DIR
 
-  run current_command "foo"
+  run current_command "dummy"
   [ "$status" -eq 0 ]
   [ "$output" = "1.1.0 (set by $PROJECT_DIR/.tool-versions)" ]
 }
 
-@test "current should output the version the global .tool_versions path" {
+@test "current should derive from the global .tool_versions when local doesn't exist" {
   cd $OTHER_DIR
 
-  run current_command "foo"
+  run current_command "dummy"
   [ "$status" -eq 0 ]
   [ "$output" = "1.0.0 (set by $HOME/.tool-versions)" ]
 }
 
 @test "current should error when the plugin doesn't exist" {
-  run current_command "bar"
+  run current_command "foobar"
   [ "$status" -eq 1 ]
 }
 
 @test "current should error when no version is set" {
-    cd $OTHER_DIR
-    rm $HOME/.tool-versions
+  cd $OTHER_DIR
+  rm $HOME/.tool-versions
 
-    run current_command "foo"
-    [ "$status" -eq 1 ]
-    [ "$output" = "No version set for foo" ]
+  run current_command "dummy"
+  [ "$status" -eq 1 ]
+  [ "$output" = "No version set for dummy" ]
 }

--- a/test/current_command.bats
+++ b/test/current_command.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+
+load test_helpers
+
+. $(dirname $BATS_TEST_DIRNAME)/lib/commands/current.sh
+
+setup() {
+  setup_asdf_dir
+
+  PROJECT_DIR=$HOME/project
+  OTHER_DIR=$HOME/other
+  mkdir -p $ASDF_DIR/plugins/foo $ASDF_DIR/installs/foo/1.0.0 $ASDF_DIR/installs/foo/1.1.0 $PROJECT_DIR $OTHER_DIR
+
+  echo 'foo 1.0.0' >> $HOME/.tool-versions
+  echo 'foo 1.1.0' >> $PROJECT_DIR/.tool-versions
+}
+
+teardown() {
+  clean_asdf_dir
+}
+
+@test "current should output the version the local .tool_versions path" {
+  cd $PROJECT_DIR
+
+  run current_command "foo"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1.1.0 (set by $PROJECT_DIR/.tool-versions)" ]
+}
+
+@test "current should output the version the global .tool_versions path" {
+  cd $OTHER_DIR
+
+  run current_command "foo"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1.0.0 (set by $HOME/.tool-versions)" ]
+}
+
+@test "current should error when the plugin doesn't exist" {
+  run current_command "bar"
+  [ "$status" -eq 1 ]
+}
+
+@test "current should error when no version is set" {
+    cd $OTHER_DIR
+    rm $HOME/.tool-versions
+
+    run current_command "foo"
+    [ "$status" -eq 1 ]
+    [ "$output" = "No version set for foo" ]
+}

--- a/test/current_command.bats
+++ b/test/current_command.bats
@@ -37,6 +37,15 @@ teardown() {
   [ "$output" = "1.0.0 (set by $HOME/.tool-versions)" ]
 }
 
+@test "current should derive from the legacy file if enabled and hide the file path" {
+  echo 'legacy_version_file = yes' > $HOME/.asdfrc
+  cd $OTHER_DIR
+
+  run current_command "dummy"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1.2.0" ]
+}
+
 @test "current should error when the plugin doesn't exist" {
   run current_command "foobar"
   [ "$status" -eq 1 ]

--- a/test/fixtures/dummy_plugin/bin/get-version-from-legacy-file
+++ b/test/fixtures/dummy_plugin/bin/get-version-from-legacy-file
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+get_legacy_version() {
+  current_directory=$1
+  version_file="$current_directory/.dummy-version"
+
+  if [ -f $version_file ]; then
+    cat $version_file
+  fi
+}
+
+get_legacy_version $1


### PR DESCRIPTION
Renames `asdf which` to `asdf current` and adds `(set by TOOL_VERSIONS_PATH)`

This is the first step of issue #72. 

Example:

    > asdf current erlang
    > 17.3 (set by /Users/kim/.tool-versions)

I'm by no means a qualified shell scripter, so I would appreciate some feedback on this.