### PR TITLE
Setup command in README should use most recent tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Supported languages include Ruby, Node.js, Elixir and more. Supporting a new lan
 Copy-paste the following into command line:
 
 ```bash
-git clone https://github.com/asdf-vm/asdf.git ~/.asdf
+git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.1.0
 
 ```
 

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -1,5 +1,5 @@
 asdf_version() {
-  echo "0.1"
+  echo "0.2.0"
 }
 
 

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -1,5 +1,5 @@
 asdf_version() {
-  echo "0.2.0"
+  echo "0.2.0-dev"
 }
 
 


### PR DESCRIPTION
I also went ahead and incremented the version number to 0.2.0. Of course we can wait to tag if there other things that need to make it into 0.2.0.