### PR TITLE
Add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+#Changelog
+
+##0.2.0-dev
+
+Features
+
+* Unify `asdf local` and `asdf global` version getters as `asdf current` (#83)
+* Rename `asdf which` to `asdf current` (#78)
+
+##0.1.0
+
+* First tagged release


### PR DESCRIPTION
I'm a fan of flat files for this sort of thing, but this may be overkill. @HashNuke @tuvistavie what do you guys thing? Version 0.2.0 hasn't been tagged yet, but I went ahead and added a section for it, so that when tagging happens no changes will need to be made to CHANGELOG.md.