### PR TITLE
Legacy File Redux

### DIFF
--- a/docs/creating-plugins.md
+++ b/docs/creating-plugins.md
@@ -50,9 +50,19 @@ Setup the env to run the binaries in the package.
 
 Uninstalls a specific version of a tool.
 
-#### bin/get_version_from_legacy_file
+#### bin/list-legacy-filenames
 
-Prints the version of the tool to use if a legacy version file is found in the current directory (e.g. rbenv's `.ruby-version`). Current directory is passed as the only argument to this script.
+Register additional setter files for this plugin. Must print a string with a space-seperated list of filenames.
+
+```
+.ruby-version .rvmrc
+```
+
+Note: This will only apply for users who have enabled the `legacy_version_file` option in their `~/.asdfrc`.
+
+#### bin/parse-legacy-file
+
+This can be used to further parse the legacy file found by asdf. If `parse-legacy-file` isn't implemented, asdf will simply cat the file to determine the version.
 
 ### Custom shim templates
 

--- a/docs/creating-plugins.md
+++ b/docs/creating-plugins.md
@@ -62,7 +62,7 @@ Note: This will only apply for users who have enabled the `legacy_version_file` 
 
 #### bin/parse-legacy-file
 
-This can be used to further parse the legacy file found by asdf. If `parse-legacy-file` isn't implemented, asdf will simply cat the file to determine the version.
+This can be used to further parse the legacy file found by asdf. If `parse-legacy-file` isn't implemented, asdf will simply cat the file to determine the version. The script will be passed the file path as its first argument.
 
 ### Custom shim templates
 

--- a/lib/commands/current.sh
+++ b/lib/commands/current.sh
@@ -2,10 +2,13 @@ current_command() {
   local plugin_name=$1
 
   check_if_plugin_exists $plugin_name
-  local version_file_path=$(find_version_file_for $plugin_name)
-  local version=$(parse_version_file $version_file_path $plugin_name)
-  check_if_version_exists $plugin_name $version
 
+  local search_path=$(pwd)
+  local version_and_path=$(find_version "$plugin_name" "$search_path")
+  local version=$(cut -d ':' -f 1 <<< "$version_and_path");
+  local version_file_path=$(cut -d ':' -f 2  <<< "$version_and_path");
+
+  check_if_version_exists $plugin_name $version
   check_for_deprecated_plugin $plugin_name
 
   if [ -z "$version" ]; then

--- a/lib/commands/current.sh
+++ b/lib/commands/current.sh
@@ -6,10 +6,29 @@ current_command() {
   local version=$(parse_version_file $version_file_path $plugin_name)
   check_if_version_exists $plugin_name $version
 
+  check_for_deprecated_plugin $plugin_name
+
   if [ -z "$version" ]; then
     echo "No version set for $plugin_name"
     exit 1
   else
     echo "$version (set by $version_file_path)"
+  fi
+}
+
+# Warn if the plugin isn't using the updated legacy file api.
+check_for_deprecated_plugin() {
+  local plugin_name=$1
+
+  local plugin_path=$(get_plugin_path "$plugin_name")
+  local legacy_config=$(get_asdf_config_value "legacy_version_file")
+  local deprecated_script="${plugin_path}/bin/get-version-from-legacy-file"
+  local new_script="${plugin_path}/bin/list-legacy-filenames"
+
+  if [ "$legacy_config" = "yes" ] && [ -f $deprecated_script ] && [ ! -f $new_script ]; then
+    echo "Heads up! It looks like your $plugin_name plugin is out of date. You can update it with:"
+    echo ""
+    echo "  asdf plugin-update $plugin_name"
+    echo ""
   fi
 }

--- a/lib/commands/current.sh
+++ b/lib/commands/current.sh
@@ -1,20 +1,15 @@
 current_command() {
   local plugin_name=$1
-  local version=$(get_preset_version_for $plugin_name)
 
   check_if_plugin_exists $plugin_name
+  local version_file_path=$(find_version_file_for $plugin_name)
+  local version=$(parse_version_file $version_file_path $plugin_name)
+  check_if_version_exists $plugin_name $version
 
-  if [ "$version" == "" ]; then
+  if [ -z "$version" ]; then
     echo "No version set for $plugin_name"
     exit 1
   else
-    local version_file_path=$(get_version_file_path_for $plugin_name)
-    if [ "$version_file_path" == "" ]; then
-      echo "$version"
-    else
-      echo "$version (set by $version_file_path)"
-    fi
-
-    exit 0
+    echo "$version (set by $version_file_path)"
   fi
 }

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -56,7 +56,7 @@ display_error() {
   echo >&2 $1
 }
 
-find_version_for() {
+find_version() {
   local plugin_name=$1
   local search_path=$2
 
@@ -73,7 +73,7 @@ find_version_for() {
     local asdf_version=$(parse_asdf_version_file "$search_path/.tool-versions" $plugin_name)
 
     if [ -n "$asdf_version" ]; then
-      echo "$asdf_version"
+      echo "$asdf_version:$search_path/.tool-versions"
       return 0
     fi
 
@@ -81,7 +81,7 @@ find_version_for() {
       local legacy_version=$(parse_legacy_version_file "$search_path/$filename" $plugin_name)
 
       if [ -n "$legacy_version" ]; then
-        echo "$legacy_version"
+        echo "$legacy_version:$search_path/$filename"
         return 0
       fi
     done
@@ -124,8 +124,11 @@ parse_legacy_version_file() {
 
 get_preset_version_for() {
   local plugin_name=$1
+  local search_path=$(pwd)
+  local version_and_path=$(find_version "$plugin_name" "$search_path")
+  local version=$(cut -d ':' -f 1 <<< "$version_and_path");
 
-  echo "$(find_version "$plugin_name" "$search_path")"
+  echo "$version"
 }
 
 get_asdf_config_value_from_file() {

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -2,7 +2,6 @@ asdf_version() {
   echo "0.2.0-dev"
 }
 
-
 asdf_dir() {
   if [ -z $ASDF_DIR ]; then
     local current_script_path=${BASH_SOURCE[0]}
@@ -11,7 +10,6 @@ asdf_dir() {
 
   echo $ASDF_DIR
 }
-
 
 get_install_path() {
   local plugin=$1
@@ -26,7 +24,6 @@ get_install_path() {
     echo $(asdf_dir)/installs/${plugin}/${install_type}-${version}
   fi
 }
-
 
 check_if_plugin_exists() {
   # Check if we have a non-empty argument
@@ -51,17 +48,9 @@ check_if_version_exists() {
   fi
 }
 
-
-get_version_part() {
-  IFS='@' read -a version_info <<< "$1"
-  echo ${version_info[$2]}
-}
-
-
 get_plugin_path() {
   echo $(asdf_dir)/plugins/$1
 }
-
 
 display_error() {
   echo >&2 $1

--- a/test/fixtures/dummy_plugin/bin/list-legacy-filenames
+++ b/test/fixtures/dummy_plugin/bin/list-legacy-filenames
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo ".dummy-version .dummyrc"

--- a/test/fixtures/dummy_plugin/bin/parse-legacy-file
+++ b/test/fixtures/dummy_plugin/bin/parse-legacy-file
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo $(cat $1 | tr -d "dummy-")

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -8,7 +8,7 @@ setup() {
   install_dummy_version "0.1.0"
   install_dummy_version "0.2.0"
 
-  PROJECT_DIR=$BASE_DIR/project
+  PROJECT_DIR=$HOME/project
   mkdir -p $PROJECT_DIR
 }
 
@@ -44,4 +44,91 @@ teardown() {
   run check_if_plugin_exists "dummy"
   [ "$status" -eq 0 ]
   [ "$output" = "" ]
+}
+
+@test "find_version_file_for should return .tool-versions if legacy is disabled" {
+  cd $PROJECT_DIR
+  touch ".tool-versions"
+  touch ".dummy-version"
+
+  run find_version_file_for "dummy"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$PROJECT_DIR/.tool-versions" ]
+}
+
+@test "find_version_file_for should return .tool-versions ++ plugin filenames if supported" {
+  cd $PROJECT_DIR
+  touch "$HOME/.tool-versions"
+  touch ".dummy-version"
+  echo 'legacy_version_file = yes' > $HOME/.asdfrc
+
+  run find_version_file_for "dummy"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$PROJECT_DIR/.dummy-version" ]
+}
+
+@test "find_version_file_for should return .tool-versions if unsupported" {
+  cd $PROJECT_DIR
+  touch "$HOME/.tool-versions"
+  touch ".dummy-version"
+  echo 'legacy_version_file = yes' > $HOME/.asdfrc
+  rm $ASDF_DIR/plugins/dummy/bin/list-legacy-filenames
+
+  run find_version_file_for "dummy"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$HOME/.tool-versions" ]
+}
+
+@test "search_filenames should return the path to the first filename found" {
+  touch "$PROJECT_DIR/.dummy-version"
+  touch "$PROJECT_DIR/.tool-versions"
+
+  run search_filenames ".tool-versions .dummy-version" $PROJECT_DIR
+  [ "$status" -eq 0 ]
+  [ "$output" = "$PROJECT_DIR/.tool-versions" ]
+}
+
+@test "search_filenames should walk parent directories" {
+  touch "$PROJECT_DIR/.dummy-version"
+  touch "$HOME/.tool-versions"
+
+  run search_filenames ".tool-versions" $PROJECT_DIR
+  [ "$status" -eq 0 ]
+  [ "$output" = "$HOME/.tool-versions" ]
+}
+
+@test "search_filenames should return nothing if not found" {
+  run search_filenames ".does-not-exist" $PROJECT_DIR
+  [ "$status" -eq 0 ]
+  [ "$output" = "" ]
+}
+
+@test "parse_version_file parses the version from a .tool-version file" {
+  echo "dummy 0.2.0" > $HOME/.tool-versions
+  run parse_version_file $HOME/.tool-versions "dummy"
+  [ "$status" -eq 0 ]
+  [ "$output" = "0.2.0" ]
+}
+
+@test "parse_version_file calls the plugin's parse-legacy-file if implemented" {
+  echo "dummy-0.2.0" > $HOME/.dummy-version
+  run parse_version_file $HOME/.dummy-version "dummy"
+  [ "$status" -eq 0 ]
+  [ "$output" = "0.2.0" ]
+}
+
+@test "parse_version_file cats the legacy file if parse-legacy-file isn't implemented" {
+  echo "0.2.0" > $HOME/.dummy-version
+  rm $ASDF_DIR/plugins/dummy/bin/parse-legacy-file
+  run parse_version_file $HOME/.dummy-version "dummy"
+  [ "$status" -eq 0 ]
+  [ "$output" = "0.2.0" ]
+}
+
+@test "get_preset_version_for returns the current version" {
+  cd $PROJECT_DIR
+  echo "dummy 0.2.0" > .tool-versions
+  run get_preset_version_for "dummy"
+  [ "$status" -eq 0 ]
+  [ "$output" = "0.2.0" ]
 }

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -4,6 +4,12 @@ load test_helpers
 
 setup() {
   setup_asdf_dir
+  install_dummy_plugin
+  install_dummy_version "0.1.0"
+  install_dummy_version "0.2.0"
+
+  PROJECT_DIR=$BASE_DIR/project
+  mkdir -p $PROJECT_DIR
 }
 
 teardown() {
@@ -11,22 +17,19 @@ teardown() {
 }
 
 @test "check_if_version_exists should exit with 1 if plugin does not exist" {
-  mkdir -p $ASDF_DIR/installs
-  run check_if_version_exists "foo" "1.0.0"
+  run check_if_version_exists "inexistent" "1.0.0"
   [ "$status" -eq 1 ]
-  [ "$output" = "version 1.0.0 is not installed for foo" ]
+  [ "$output" = "version 1.0.0 is not installed for inexistent" ]
 }
 
 @test "check_if_version_exists should exit with 1 if version does not exist" {
-  mkdir -p $ASDF_DIR/installs/foo
-  run check_if_version_exists "foo" "1.0.0"
+  run check_if_version_exists "dummy" "1.0.0"
   [ "$status" -eq 1 ]
-  [ "$output" = "version 1.0.0 is not installed for foo" ]
+  [ "$output" = "version 1.0.0 is not installed for dummy" ]
 }
 
 @test "check_if_version_exists should be noop if version exists" {
-  mkdir -p $ASDF_DIR/installs/foo/1.0.0
-  run check_if_version_exists "foo" "1.0.0"
+  run check_if_version_exists "dummy" "0.1.0"
   [ "$status" -eq 0 ]
   [ "$output" = "" ]
 }
@@ -38,8 +41,7 @@ teardown() {
 }
 
 @test "check_if_plugin_exists should be noop if plugin exists" {
-  mkdir -p $ASDF_DIR/plugins/foo_bar
-  run check_if_plugin_exists "foo_bar"
+  run check_if_plugin_exists "dummy"
   [ "$status" -eq 0 ]
   [ "$output" = "" ]
 }

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -52,7 +52,7 @@ teardown() {
 
   run find_version "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
-  [ "$output" = "0.1.0" ]
+  [ "$output" = "0.1.0:$PROJECT_DIR/.tool-versions" ]
 }
 
 @test "find_version should return the legacy file if supported" {
@@ -62,7 +62,7 @@ teardown() {
 
   run find_version "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
-  [ "$output" = "0.2.0" ]
+  [ "$output" = "0.2.0:$PROJECT_DIR/.dummy-version" ]
 }
 
 @test "find_version skips .tool-version file that don't list the plugin" {
@@ -71,7 +71,7 @@ teardown() {
 
   run find_version "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
-  [ "$output" = "0.1.0" ]
+  [ "$output" = "0.1.0:$HOME/.tool-versions" ]
 }
 
 @test "find_version should return .tool-versions if unsupported" {
@@ -82,7 +82,7 @@ teardown() {
 
   run find_version "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
-  [ "$output" = "0.1.0" ]
+  [ "$output" = "0.1.0:$HOME/.tool-versions" ]
 }
 
 @test "get_preset_version_for returns the current version" {


### PR DESCRIPTION
This implements the proposal in #81.

Now, plugins register the legacy filenames they support. ASDF searches for both legacy and .tool-version files simultaneously.

Users with plugins that only support the old legacy file api will see a warning message with instructions to update their plugin.