### PR TITLE
Versions prefixed with "path:" no longer seem to work

### DIFF
--- a/lib/commands/current.sh
+++ b/lib/commands/current.sh
@@ -4,9 +4,12 @@ current_command() {
   check_if_plugin_exists $plugin_name
 
   local search_path=$(pwd)
-  local version_and_path=$(find_version "$plugin_name" "$search_path")
-  local version=$(cut -d ':' -f 1 <<< "$version_and_path");
-  local version_file_path=$(cut -d ':' -f 2  <<< "$version_and_path");
+
+  local version_and_path
+  IFS=' ' read -a version_and_path <<< "$(find_version "$plugin_name" "$search_path")"
+
+  local version="${version_and_path[0]}"
+  local version_file_path="${version_and_path[1]}"
 
   check_if_version_exists $plugin_name $version
   check_for_deprecated_plugin $plugin_name

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -73,7 +73,7 @@ find_version() {
     local asdf_version=$(parse_asdf_version_file "$search_path/.tool-versions" $plugin_name)
 
     if [ -n "$asdf_version" ]; then
-      echo "$asdf_version:$search_path/.tool-versions"
+      echo "$asdf_version $search_path/.tool-versions"
       return 0
     fi
 
@@ -81,7 +81,7 @@ find_version() {
       local legacy_version=$(parse_legacy_version_file "$search_path/$filename" $plugin_name)
 
       if [ -n "$legacy_version" ]; then
-        echo "$legacy_version:$search_path/$filename"
+        echo "$legacy_version $search_path/$filename"
         return 0
       fi
     done
@@ -126,7 +126,7 @@ get_preset_version_for() {
   local plugin_name=$1
   local search_path=$(pwd)
   local version_and_path=$(find_version "$plugin_name" "$search_path")
-  local version=$(cut -d ':' -f 1 <<< "$version_and_path");
+  local version=$(cut -d ' ' -f 1 <<< "$version_and_path");
 
   echo "$version"
 }

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -92,3 +92,11 @@ teardown() {
   [ "$status" -eq 0 ]
   [ "$output" = "0.2.0" ]
 }
+
+@test "get_preset_version_for returns the current version when using path" {
+  cd $PROJECT_DIR
+  echo "dummy path:/usr" > .tool-versions
+  run get_preset_version_for "dummy"
+  [ "$status" -eq 0 ]
+  [ "$output" = "path:/usr" ]
+}

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -52,7 +52,7 @@ teardown() {
 
   run find_version "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
-  [ "$output" = "0.1.0:$PROJECT_DIR/.tool-versions" ]
+  [ "$output" = "0.1.0 $PROJECT_DIR/.tool-versions" ]
 }
 
 @test "find_version should return the legacy file if supported" {
@@ -62,7 +62,7 @@ teardown() {
 
   run find_version "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
-  [ "$output" = "0.2.0:$PROJECT_DIR/.dummy-version" ]
+  [ "$output" = "0.2.0 $PROJECT_DIR/.dummy-version" ]
 }
 
 @test "find_version skips .tool-version file that don't list the plugin" {
@@ -71,7 +71,7 @@ teardown() {
 
   run find_version "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
-  [ "$output" = "0.1.0:$HOME/.tool-versions" ]
+  [ "$output" = "0.1.0 $HOME/.tool-versions" ]
 }
 
 @test "find_version should return .tool-versions if unsupported" {
@@ -82,7 +82,7 @@ teardown() {
 
   run find_version "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
-  [ "$output" = "0.1.0:$HOME/.tool-versions" ]
+  [ "$output" = "0.1.0 $HOME/.tool-versions" ]
 }
 
 @test "get_preset_version_for returns the current version" {


### PR DESCRIPTION
"path:" prefixed versions no longer seem to work and instead error with "No such command in path of $plugin_name". This new behavior seems related to d505c0ee7127ae4a9516f6f3f8046e5e4865700e.

The first commit adds a failing test case for `get_preset_version_for` that shows it losing information when parsing a version prefixed with "path:". I made an attempt at fixing this behavior  in the second commit by switching the return value of `get_preset_version_for` to be space-delimited and then parsing that for `current_command`.

I'm happy to take suggestions for other ways to fix this (my bash is pretty rudimentary), or feel free to edit my branch if you have other ideas.
