### PR TITLE
Prepare for 0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,18 @@
 
 ##0.2.0-dev
 
+##0.2.0
+
 Features
 
+* Improve plugin API for legacy file support (#87)
 * Unify `asdf local` and `asdf global` version getters as `asdf current` (#83)
 * Rename `asdf which` to `asdf current` (#78)
+
+Fixed Bugs
+
+* Fix bug that caused the `local` command to crash when the directory contains whitespace (#90)
+* Misc typo corrections (#93, #99)
 
 ##0.1.0
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Supported languages include Ruby, Node.js, Elixir and more. Supporting a new lan
 Copy-paste the following into command line:
 
 ```bash
-git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.1.0
+git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.2.0
 
 ```
 


### PR DESCRIPTION
* Add everything that was merged for 0.2.0 to the changelog.
* Update install command in the readme with 0.2.0 tag.

I will tag 0.2.0 when I merge this.

Let me know there are any issues with merging this.