### PR TITLE
Determine version from global file when project is outside home.

### DIFF
--- a/test/utils.bats
+++ b/test/utils.bats
@@ -92,3 +92,12 @@ teardown() {
   [ "$status" -eq 0 ]
   [ "$output" = "0.2.0" ]
 }
+
+@test "get_preset_version_for returns the global version from home when project is outside of home" {
+  echo "dummy 0.1.0" > $HOME/.tool-versions
+  PROJECT_DIR=$BASE_DIR/project
+  mkdir -p $PROJECT_DIR
+  run get_preset_version_for "dummy"
+  [ "$status" -eq 0 ]
+  [ "$output" = "0.1.0" ]
+}


### PR DESCRIPTION
Without this patch, asdf was not able to determine the tool version
for a project located outside the user's HOME directory.

```
/work/project/
/home/me/.tool-versions
```

This changeset lets asdf find the global version stored at
$HOME/.tool-versions when the directory traversal from
the project dir was not able to find a suitable version.
