### PR TITLE
add link to asdf-terraform in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Plugins are how asdf understands how to handle different packages. Below is a li
 | Redis     | [smashedtoatoms/asdf-redis](https://github.com/smashedtoatoms/asdf-redis) | [![Build Status](https://travis-ci.org/smashedtoatoms/asdf-redis.svg?branch=master)](https://travis-ci.org/smashedtoatoms/asdf-redis)
 | Riak      | [smashedtoatoms/asdf-riak](https://github.com/smashedtoatoms/asdf-riak) | [![Build Status](https://travis-ci.org/smashedtoatoms/asdf-riak.svg?branch=master)](https://travis-ci.org/smashedtoatoms/asdf-riak)
 | Ruby      | [asdf-vm/asdf-ruby](https://github.com/asdf-vm/asdf-ruby) | [![Build Status](https://travis-ci.org/asdf-vm/asdf-ruby.svg?branch=master)](https://travis-ci.org/asdf-vm/asdf-ruby)
+| Terraform | [neerfri/asdf-terraform](https://github.com/neerfri/asdf-terraform) | [![Build Status](https://travis-ci.org/neerfri/asdf-terraform.svg?branch=master)](https://travis-ci.org/neerfri/asdf-terraform)
 
 
 ##### Add a plugin


### PR DESCRIPTION
Hello,

I've added `asdf-terraform` link to the README.
The plugin is covered by tests in Travis as you suggest (with some additions)

See https://github.com/neerfri/asdf-terraform
and https://travis-ci.org/neerfri/asdf-terraform

Thanks!