### PR TITLE
Get version from env if ASDF_${TOOL}_VERSION is defined.

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -82,6 +82,12 @@ find_version() {
   local plugin_name=$1
   local search_path=$2
 
+  local version=$(get_version_from_env "$plugin_name")
+  if [ -n "$version" ]; then
+      echo "$version"
+      return 0
+  fi
+
   local plugin_path=$(get_plugin_path "$plugin_name")
   local legacy_config=$(get_asdf_config_value "legacy_version_file")
   local legacy_list_filenames_script="${plugin_path}/bin/list-legacy-filenames"
@@ -92,7 +98,7 @@ find_version() {
   fi
 
   while [ "$search_path" != "/" ]; do
-    local version=$(get_version_in_dir "$plugin_name" "$search_path" "$legacy_filenames")
+    version=$(get_version_in_dir "$plugin_name" "$search_path" "$legacy_filenames")
     if [ -n "$version" ]; then
       echo "$version"
       return 0
@@ -101,6 +107,14 @@ find_version() {
   done
 
   get_version_in_dir "$plugin_name" "$HOME" "$legacy_filenames"
+}
+
+get_version_from_env () {
+  local plugin_name=$1
+  local upcase_name=$(echo $plugin_name | tr '[a-z]' '[A-Z]')
+  local version_env_var="ASDF_${upcase_name}_VERSION"
+  local version=${!version_env_var}
+  echo "$version"
 }
 
 parse_asdf_version_file() {

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -101,3 +101,11 @@ teardown() {
   [ "$status" -eq 0 ]
   [ "$output" = "0.1.0" ]
 }
+
+@test "get_preset_version_for returns the tool version from env if ASDF_{TOOL}_VERSION is defined" {
+  cd $PROJECT_DIR
+  echo "dummy 0.2.0" > .tool-versions
+  ASDF_DUMMY_VERSION=3.0.0 run get_preset_version_for "dummy"
+  [ "$status" -eq 0 ]
+  [ "$output" = "3.0.0" ]
+}


### PR DESCRIPTION
For example if asdf finds that the `ASDF_FOO_VERSION` is
defined in the current environment it will override the
version of `foo` from the `.tool-version` file.

Closes #49