### PR TITLE
Bugfix: `ref:` and `path:` versions are not read correctly.

### DIFF
--- a/lib/commands/current.sh
+++ b/lib/commands/current.sh
@@ -5,8 +5,8 @@ current_command() {
 
   local search_path=$(pwd)
   local version_and_path=$(find_version "$plugin_name" "$search_path")
-  local version=$(cut -d ':' -f 1 <<< "$version_and_path");
-  local version_file_path=$(cut -d ':' -f 2  <<< "$version_and_path");
+  local version=$(cut -d '|' -f 1 <<< "$version_and_path");
+  local version_file_path=$(cut -d '|' -f 2  <<< "$version_and_path");
 
   check_if_version_exists $plugin_name $version
   check_for_deprecated_plugin $plugin_name

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -64,7 +64,7 @@ get_version_in_dir() {
   local asdf_version=$(parse_asdf_version_file "$search_path/.tool-versions" $plugin_name)
 
   if [ -n "$asdf_version" ]; then
-    echo "$asdf_version:$search_path/.tool-versions"
+    echo "$asdf_version|$search_path/.tool-versions"
     return 0
   fi
 
@@ -72,7 +72,7 @@ get_version_in_dir() {
     local legacy_version=$(parse_legacy_version_file "$search_path/$filename" $plugin_name)
 
     if [ -n "$legacy_version" ]; then
-      echo "$legacy_version:$search_path/$filename"
+      echo "$legacy_version|$search_path/$filename"
       return 0
     fi
   done
@@ -108,14 +108,11 @@ parse_asdf_version_file() {
   local plugin_name=$2
 
   if [ -f "$file_path" ]; then
-    cat $file_path | while read -r line || [[ -n "$line" ]]; do
-      local line_parts=($line)
-
-      if [ "${line_parts[0]}" = "$plugin_name" ]; then
-        echo ${line_parts[1]}
-        return 0
-      fi
-    done
+    local version=$(grep "${plugin_name} " $file_path | sed -e "s/^${plugin_name} //")
+    if [ -n "$version" ]; then
+      echo $version
+      return 0
+    fi
   fi
 }
 
@@ -139,7 +136,7 @@ get_preset_version_for() {
   local plugin_name=$1
   local search_path=$(pwd)
   local version_and_path=$(find_version "$plugin_name" "$search_path")
-  local version=$(cut -d ':' -f 1 <<< "$version_and_path");
+  local version=$(cut -d '|' -f 1 <<< "$version_and_path");
 
   echo "$version"
 }

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -52,7 +52,7 @@ teardown() {
 
   run find_version "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
-  [ "$output" = "0.1.0:$PROJECT_DIR/.tool-versions" ]
+  [ "$output" = "0.1.0|$PROJECT_DIR/.tool-versions" ]
 }
 
 @test "find_version should return the legacy file if supported" {
@@ -62,7 +62,7 @@ teardown() {
 
   run find_version "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
-  [ "$output" = "0.2.0:$PROJECT_DIR/.dummy-version" ]
+  [ "$output" = "0.2.0|$PROJECT_DIR/.dummy-version" ]
 }
 
 @test "find_version skips .tool-version file that don't list the plugin" {
@@ -71,7 +71,7 @@ teardown() {
 
   run find_version "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
-  [ "$output" = "0.1.0:$HOME/.tool-versions" ]
+  [ "$output" = "0.1.0|$HOME/.tool-versions" ]
 }
 
 @test "find_version should return .tool-versions if unsupported" {
@@ -82,7 +82,7 @@ teardown() {
 
   run find_version "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
-  [ "$output" = "0.1.0:$HOME/.tool-versions" ]
+  [ "$output" = "0.1.0|$HOME/.tool-versions" ]
 }
 
 @test "get_preset_version_for returns the current version" {
@@ -100,4 +100,20 @@ teardown() {
   run get_preset_version_for "dummy"
   [ "$status" -eq 0 ]
   [ "$output" = "0.1.0" ]
+}
+
+@test "get_preset_version_for should return branch reference version" {
+  cd $PROJECT_DIR
+  echo "dummy ref:master" > $PROJECT_DIR/.tool-versions
+  run get_preset_version_for "dummy"
+  [ "$status" -eq 0 ]
+  [ "$output" = "ref:master" ]
+}
+
+@test "get_preset_version_for should return path version" {
+  cd $PROJECT_DIR
+  echo "dummy path:/some/place with spaces" > $PROJECT_DIR/.tool-versions
+  run get_preset_version_for "dummy"
+  [ "$status" -eq 0 ]
+  [ "$output" = "path:/some/place with spaces" ]
 }


### PR DESCRIPTION
Before this patch, with a `.tool-versions` file like:

```
lfe ref:master
```

`get_preset_version_for` would return `ref` instead of `ref:master`.

Same was happening for `path:` versions. Actually there was PR #94 
on which I based my changes but instead of using space as delimiter
I went for using `|` which would be a lot more weird if present as
part of a file path, this also allows to specify paths which have
spaces which are much more frequent.

Closes #94 #95