### PR TITLE
Use -e flag when calling echo so newlines are used.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.2.0
 Depending on your OS, run the following
 ```bash
 # For Ubuntu or other linux distros
-echo '\n. $HOME/.asdf/asdf.sh' >> ~/.bashrc
-echo '\n. $HOME/.asdf/completions/asdf.bash' >> ~/.bashrc
+echo -e '\n. $HOME/.asdf/asdf.sh' >> ~/.bashrc
+echo -e '\n. $HOME/.asdf/completions/asdf.bash' >> ~/.bashrc
 
 # OR for Mac OSX
-echo '\n. $HOME/.asdf/asdf.sh' >> ~/.bash_profile
-echo '\n. $HOME/.asdf/completions/asdf.bash' >> ~/.bash_profile
+echo -e '\n. $HOME/.asdf/asdf.sh' >> ~/.bash_profile
+echo -e '\n. $HOME/.asdf/completions/asdf.bash' >> ~/.bash_profile
 ```
 
 If you use zsh or any other shell, replace `.bashrc` with the config file for the respective shell.


### PR DESCRIPTION
Corrects a bug I introduced in PR #117. The -e flag enables interpretation of backslash escapes on CentOS and doesn't break OSX (OSX automatically interprets backslash escapes).