### PR TITLE
Add metadata to shims

### DIFF
--- a/docs/creating-plugins.md
+++ b/docs/creating-plugins.md
@@ -72,6 +72,16 @@ asdf allows custom shim templates. For an executable called `foo`, if there's a 
 
 This must be used wisely. For now AFAIK, it's only being used in the Elixir plugin, because an executable is also read as an Elixir file apart from just being an executable. Which makes it not possible to use the standard bash shim.
 
+**Important: Shim metadata **
+
+If you create a custom shim, be sure to include a comment like the following (replacing your plugin name) in it:
+
+```
+# asdf-plugin: plugin_name
+```
+
+asdf uses this `asdf-plugin` metadata to remove unused shims when uninstalling.
+
 ## Testing plugins
 
 `asdf` contains the `plugin-test` command to test your plugin.

--- a/lib/commands/reshim.sh
+++ b/lib/commands/reshim.sh
@@ -48,9 +48,11 @@ write_shim_script() {
   if [ -f $plugin_shims_path/$executable_name ]; then
     cp $plugin_shims_path/$executable_name $shim_path
   else
-    echo """#!/usr/bin/env bash
+    cat <<EOF > $shim_path
+#!/usr/bin/env bash
+# asdf-plugin: ${plugin_name}
 exec $(asdf_dir)/bin/private/asdf-exec ${plugin_name} ${executable_path} \"\$@\"
-""" > $shim_path
+EOF
   fi
 
   chmod +x $shim_path

--- a/test/fixtures/dummy_plugin/bin/install
+++ b/test/fixtures/dummy_plugin/bin/install
@@ -3,3 +3,10 @@
 mkdir -p $ASDF_INSTALL_PATH
 env > $ASDF_INSTALL_PATH/env
 echo $ASDF_INSTALL_VERSION > $ASDF_INSTALL_PATH/version
+
+# create the dummy executable
+mkdir -p $ASDF_INSTALL_PATH/bin
+cat <<EOF > $ASDF_INSTALL_PATH/bin/dummy
+exec echo dummy
+EOF
+chmod 755 $ASDF_INSTALL_PATH/bin/dummy

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -42,3 +42,11 @@ teardown() {
   [ "$status" -eq 0 ]
   [ $(cat $ASDF_DIR/installs/dummy/1.2/version) = "1.2" ]
 }
+
+@test "install_command should create a shim with metadada" {
+  run install_command dummy 1.0
+  [ "$status" -eq 0 ]
+  [ -f $ASDF_DIR/installs/dummy/1.0/env ]
+  run grep "# asdf-plugin: dummy" $ASDF_DIR/shims/dummy
+  [ "$status" -eq 0 ]
+}

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -47,7 +47,7 @@ teardown() {
   run install_command dummy 1.0
   [ "$status" -eq 0 ]
   [ -f $ASDF_DIR/installs/dummy/1.0/env ]
-  run grep "# asdf-plugin: dummy" $ASDF_DIR/shims/dummy
+  run grep "asdf-plugin: dummy" $ASDF_DIR/shims/dummy
   [ "$status" -eq 0 ]
 }
 

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -50,3 +50,11 @@ teardown() {
   run grep "# asdf-plugin: dummy" $ASDF_DIR/shims/dummy
   [ "$status" -eq 0 ]
 }
+
+
+@test "install_command running a shim should call the plugin executable" {
+  run install_command dummy 1.0
+  [ "$status" -eq 0 ]
+  # run the shim which should be on path and expect the plugin's output
+  [ "dummy" $(dummy) ]
+}


### PR DESCRIPTION
When a shim is created, add plugin metadata so we can later know which shims belong to which plugins, this will help aid with removing unused shims on uninstall. See #67

```
# asdf-plugin: ${plugin_name}”
```

Thanks to @duijf for the metadata proposal.