### PR TITLE
Shims remove on latest version uninstall (depends on #122)

### DIFF
--- a/lib/commands/list.sh
+++ b/lib/commands/list.sh
@@ -1,16 +1,15 @@
 list_command() {
   local plugin_name=$1
-  local plugin_path=$(get_plugin_path $plugin_name)
   check_if_plugin_exists $plugin_name
 
-  local plugin_installs_path=$(asdf_dir)/installs/${plugin_name}
+  local versions=$(list_installed_versions $plugin_name)
 
-  if [ -d $plugin_installs_path ]; then
-    #TODO check if dir is empty and show no-installed-versions msg
-    for install in ${plugin_installs_path}/*/; do
-      echo "$(basename $install)"
+  if [ -n "${versions}" ]; then
+    for version in $versions; do
+      echo $version
     done
   else
-    echo 'Oohes nooes ~! No versions installed'
+    display_error 'No versions installed'
+    exit 1
   fi
 }

--- a/lib/commands/plugin-remove.sh
+++ b/lib/commands/plugin-remove.sh
@@ -6,4 +6,6 @@ plugin_remove_command() {
 
   rm -rf $plugin_path
   rm -rf $(asdf_dir)/installs/${plugin_name}
+
+  grep -l "asdf-plugin: ${plugin_name}" $(asdf_dir)/shims/* 2>/dev/null | xargs rm -f
 }

--- a/lib/commands/uninstall.sh
+++ b/lib/commands/uninstall.sh
@@ -31,4 +31,11 @@ uninstall_command() {
   else
     rm -rf $install_path
   fi
+
+  # remove plugin shims if no other version of this plugin is installed
+  local count_installed=$(list_installed_versions $plugin_name | wc -l)
+  if [ 0 -eq $count_installed ]; then
+    grep -l "asdf-plugin: ${plugin_name}" $(asdf_dir)/shims/* 2>/dev/null | xargs rm -f
+  fi
+
 }

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -25,6 +25,19 @@ get_install_path() {
   fi
 }
 
+list_installed_versions() {
+  local plugin_name=$1
+  local plugin_path=$(get_plugin_path $plugin_name)
+
+  local plugin_installs_path=$(asdf_dir)/installs/${plugin_name}
+
+  if [ -d $plugin_installs_path ]; then
+    for install in $(ls -d ${plugin_installs_path}/*/ 2>/dev/null); do
+      echo "$(basename $install)"
+    done
+  fi
+}
+
 check_if_plugin_exists() {
   # Check if we have a non-empty argument
   if [ -z "${1+set}" ]; then

--- a/test/list_command.bats
+++ b/test/list_command.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+load test_helpers
+
+. $(dirname $BATS_TEST_DIRNAME)/lib/commands/install.sh
+. $(dirname $BATS_TEST_DIRNAME)/lib/commands/list.sh
+
+setup() {
+  setup_asdf_dir
+  install_dummy_plugin
+}
+
+teardown() {
+  clean_asdf_dir
+}
+
+@test "list_command should output error when plugin is not installed" {
+  run list_command dummy
+  [ "No versions installed" == "$output" ]
+  [ "$status" -eq 1 ]
+}
+
+@test "list_command should list installed versions" {
+  run install_command dummy 1.0
+  run install_command dummy 1.1
+  run list_command dummy
+  [ "$(echo -e "1.0\n1.1")" == "$output" ]
+  [ "$status" -eq 0 ]
+}

--- a/test/remove_command.bats
+++ b/test/remove_command.bats
@@ -2,6 +2,8 @@
 
 load test_helpers
 
+. $(dirname $BATS_TEST_DIRNAME)/lib/commands/reshim.sh
+. $(dirname $BATS_TEST_DIRNAME)/lib/commands/install.sh
 . $(dirname $BATS_TEST_DIRNAME)/lib/commands/plugin-remove.sh
 
 setup() {
@@ -30,4 +32,41 @@ teardown() {
   run plugin_remove_command "does-not-exist"
   [ "$status" -eq 1 ]
   [ "$output" = "No such plugin" ]
+}
+
+@test "plugin_remove_command should remove installed versions" {
+  install_dummy_plugin
+  run install_command dummy 1.0
+  [ "$status" -eq 0 ]
+  [ -d $ASDF_DIR/installs/dummy ]
+
+  run plugin_remove_command dummy
+  [ "$status" -eq 0 ]
+  [ ! -d $ASDF_DIR/installs/dummy ]
+}
+
+@test "plugin_remove_command should also remove shims for that plugin" {
+  install_dummy_plugin
+  run install_command dummy 1.0
+  [ "$status" -eq 0 ]
+  [ -f $ASDF_DIR/shims/dummy ]
+
+  run plugin_remove_command dummy
+  [ "$status" -eq 0 ]
+  [ ! -f $ASDF_DIR/shims/dummy ]
+}
+
+
+@test "plugin_remove_command should not remove unrelated shims" {
+  install_dummy_plugin
+  run install_command dummy 1.0
+
+  # make an unrelated shim
+  echo "# asdf-plugin: gummy" > $ASDF_DIR/shims/gummy
+
+  run plugin_remove_command dummy
+  [ "$status" -eq 0 ]
+
+  # unrelated shim should exist
+  [ -f $ASDF_DIR/shims/gummy ]
 }

--- a/test/uninstall_command.bats
+++ b/test/uninstall_command.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+
+load test_helpers
+
+. $(dirname $BATS_TEST_DIRNAME)/lib/commands/reshim.sh
+. $(dirname $BATS_TEST_DIRNAME)/lib/commands/install.sh
+. $(dirname $BATS_TEST_DIRNAME)/lib/commands/uninstall.sh
+
+setup() {
+  setup_asdf_dir
+  install_dummy_plugin
+
+  PROJECT_DIR=$HOME/project
+  mkdir $PROJECT_DIR
+}
+
+teardown() {
+  clean_asdf_dir
+}
+
+@test "uninstall_command should fail when no such version is installed" {
+  run uninstall_command dummy 3.14
+  [ "$output" == "No such version" ]
+  [ "$status" -eq 1 ]
+}
+
+@test "uninstall_command should remove the plugin with that version from asdf" {
+  run install_command dummy 1.1
+  [ "$status" -eq 0 ]
+  [ $(cat $ASDF_DIR/installs/dummy/1.1/version) = "1.1" ]
+  run uninstall_command dummy 1.1
+  [ ! -f  $ASDF_DIR/installs/dummy/1.1/version ]
+}
+
+@test "uninstall_command should invoke the plugin bin/uninstall if available" {
+  run install_command dummy 1.1
+  [ "$status" -eq 0 ]
+  mkdir -p $ASDF_DIR/plugins/dummy/bin
+  echo "echo custom uninstall" > $ASDF_DIR/plugins/dummy/bin/uninstall
+  chmod 755 $ASDF_DIR/plugins/dummy/bin/uninstall
+  run uninstall_command dummy 1.1
+  [ "$output" == "custom uninstall" ]
+  [ "$status" -eq 0 ]
+}
+
+@test "uninstall_command should remove the plugin shims if no other version is installed" {
+  run install_command dummy 1.1
+  [ -f $ASDF_DIR/shims/dummy ]
+  run uninstall_command dummy 1.1
+  [ ! -f $ASDF_DIR/shims/dummy ]
+}
+
+@test "uninstall_command should leave the plugin shims if other version is installed" {
+  run install_command dummy 1.0
+  [ -f $ASDF_DIR/installs/dummy/1.0/bin/dummy ]
+
+  run install_command dummy 1.1
+  [ -f $ASDF_DIR/installs/dummy/1.1/bin/dummy ]
+
+  [ -f $ASDF_DIR/shims/dummy ]
+  run uninstall_command dummy 1.0
+  [ -f $ASDF_DIR/shims/dummy ]
+}
+
+@test "uninstall_command should not remove other unrelated shims" {
+  run install_command dummy 1.0
+  [ -f $ASDF_DIR/shims/dummy ]
+
+  touch $ASDF_DIR/shims/gummy
+  [ -f $ASDF_DIR/shims/gummy ]
+
+  run uninstall_command dummy 1.0
+  [ -f $ASDF_DIR/shims/gummy ]
+}


### PR DESCRIPTION
When the latest version of a tool is uninstalled,
Remove the plugin shims (marked with metadata at #122)

Also found lots of missing tests and added them.

Closes #67