### PR TITLE
Add a couple lines to the creating-plugins guide on version ordering.

### DIFF
--- a/docs/creating-plugins.md
+++ b/docs/creating-plugins.md
@@ -23,6 +23,10 @@ Must print a string with a space-seperated list of versions. Example output woul
 1.0.1 1.0.2 1.3.0 1.4
 ```
 
+Note that the newest version should be listed last so it appears closer to the user's prompt. This is helpful since the `list-all` command prints each version on it's own line. If there are many versions it's possible the early versions will be off screen.
+
+If versions are being pulled from releases page on a website it's recommended to not sort the versions if at all possible. Often the versions are already in the correct order or, in reverse order, in which case something like `tac` should suffice.
+
 #### bin/install
 
 This script should install the version, in the path mentioned in `ASDF_INSTALL_PATH`


### PR DESCRIPTION
This was something we talked about on #33 but never added to the plugin guide.