### PR TITLE
Add a helpful error message to the install command

### DIFF
--- a/lib/commands/install.sh
+++ b/lib/commands/install.sh
@@ -4,6 +4,9 @@ install_command() {
 
   if [ "$plugin_name" = "" ] && [ "$full_version" = "" ]; then
     install_local_tool_versions
+  elif [[ $# -eq 1 ]]; then
+    display_error "You must specify a name and a version to install"
+    exit 1
   else
     install_tool_version $plugin_name $full_version
   fi

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -64,3 +64,15 @@ teardown() {
   [ "$($ASDF_DIR/shims/dummy world hello)" == "This is Dummy 1.0! hello world" ]
   [ "$status" -eq 0 ]
 }
+
+@test "install_command fails when the name or version are not specified" {
+  run install_command dummy
+  [ "$status" -eq 1 ]
+  [ "$output" = "You must specify a name and a version to install" ]
+  [ ! -f $ASDF_DIR/installs/dummy/1.1/version ]
+
+  run install_command 1.1
+  [ "$status" -eq 1 ]
+  [ "$output" = "You must specify a name and a version to install" ]
+  [ ! -f $ASDF_DIR/installs/dummy/1.1/version ]
+}


### PR DESCRIPTION
Add a helpful error message to the install command to warn users when they don't specify a version to install. I came across this a couple days ago, and was surprised when asdf behaved as if nothing had gone wrong. Adding a simple arity check fixes this.

This fixes #132.