### PR TITLE
Prepare for 0.2.1 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,18 @@
 #Changelog
 
-##0.2.0-dev
+##0.2.1-dev
+
+##0.2.1
 
 Features
 
 * Determine global tool version even when used outside of home directory (#106)
+
+Fixed Bugs
+
+* Correct reading of `ref:` and `path:` versions (#112)
+* Remove shims when uninstalling a version or removing a plugin (#122, #123, #125, #128, #131)
+* Add a helpful error message to the install command (#135)
 
 ##0.2.0
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Supported languages include Ruby, Node.js, Elixir and more. Supporting a new lan
 Copy-paste the following into command line:
 
 ```bash
-git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.2.0
+git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.2.1
 
 ```
 

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -1,5 +1,5 @@
 asdf_version() {
-  echo "0.2.0-dev"
+  echo "0.2.1"
 }
 
 asdf_dir() {


### PR DESCRIPTION
We've had a lot of bugfixes over the last month, so I figured it's about time to tag another patch version. I don't see anything here that would break the existing 0.2.0 API, so I think it's safe to just increment the patch version. With some of the upcoming changes there will likely be some API differences, so the next release after this one will probably be 0.3.0.

I'm going to wait until #135 is merged before merging this. Once this is merge I'll tag v0.2.1.