### PR TITLE
Allow `asdf local` and `asdf global` to take path: versions

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -55,6 +55,12 @@ check_if_version_exists() {
   local plugin=$1
   local version=$2
   local version_dir=$(asdf_dir)/installs/$plugin/$version
+
+  # if version starts with path: use that directory
+  if [ "${version/path:}" != "$version" ]; then
+      version_dir=$(echo $version | cut -d: -f 2)
+  fi
+
   if [ ! -d $version_dir ]; then
     display_error "version $version is not installed for $plugin"
     exit 1

--- a/test/version_commands.bats
+++ b/test/version_commands.bats
@@ -70,6 +70,19 @@ teardown() {
   [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0" ]
 }
 
+@test "local should fail to set a path:dir if dir does not exists " {
+    run local_command "dummy" "path:$PROJECT_DIR/local"
+    [ "$output" = "version path:$PROJECT_DIR/local is not installed for dummy" ]
+    [ "$status" -eq 1 ]
+}
+
+@test "local should set a path:dir if dir exists " {
+    mkdir -p $PROJECT_DIR/local
+    run local_command "dummy" "path:$PROJECT_DIR/local"
+    [ "$status" -eq 0 ]
+    [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy path:$PROJECT_DIR/local" ]
+}
+
 @test "global should create a global .tool-versions file if it doesn't exist" {
   run global_command "dummy" "1.1.0"
   [ "$status" -eq 0 ]
@@ -87,4 +100,17 @@ teardown() {
   run global_command "dummy" "1.1.0"
   [ "$status" -eq 0 ]
   [ "$(cat $HOME/.tool-versions)" = "dummy 1.1.0" ]
+}
+
+@test "global should fail to set a path:dir if dir does not exists " {
+    run global_command "dummy" "path:$PROJECT_DIR/local"
+    [ "$output" = "version path:$PROJECT_DIR/local is not installed for dummy" ]
+    [ "$status" -eq 1 ]
+}
+
+@test "global should set a path:dir if dir exists " {
+    mkdir -p $PROJECT_DIR/local
+    run global_command "dummy" "path:$PROJECT_DIR/local"
+    [ "$status" -eq 0 ]
+    [ "$(cat $HOME/.tool-versions)" = "dummy path:$PROJECT_DIR/local" ]
 }


### PR DESCRIPTION
When given a path: version, just check that the directory
actually exists.

Closes #95 