### PR TITLE
Check permissions on scripts in plugins' bin directories when testing

### DIFF
--- a/lib/commands/plugin-test.sh
+++ b/lib/commands/plugin-test.sh
@@ -62,5 +62,13 @@ plugin_test_command() {
         fi
     fi
 
+    # Assert the scripts in bin are executable by asdf
+    for filename in $ASDF_DIR/plugins/$plugin_name/bin/*
+    do
+        if [ ! -x "$filename" ]; then
+            fail_test "Incorrect permissions on $filename. Must be executable by asdf"
+        fi
+    done
+
     rm -rf $ASDF_DIR
 }


### PR DESCRIPTION
This is the first in a series of steps to address issue #124.

Plugins will now fail the test if the scripts in `bin/` are not executable.