### PR TITLE
Fix fish shell's deprecation warnings when using the `complete` command

### DIFF
--- a/completions/asdf.fish
+++ b/completions/asdf.fish
@@ -39,12 +39,12 @@ complete -f -c asdf -n '__fish_asdf_needs_command' -a plugin-list -d "List insta
 
 # plugin-remove completion
 complete -f -c asdf -n '__fish_asdf_needs_command' -a plugin-remove -d "Remove plugin and package versions"
-complete -f -c asdf -n '__fish_asdf_using_command plugin-remove; and __fish_asdf_arg_number 2' -a '(asdf plugin-list)' -A
+complete -f -c asdf -n '__fish_asdf_using_command plugin-remove; and __fish_asdf_arg_number 2' -a '(asdf plugin-list)'
 
 # plugin-update completion
 complete -f -c asdf -n '__fish_asdf_needs_command' -a plugin-update -d "Update plugin"
-complete -f -c asdf -n '__fish_asdf_using_command plugin-update; and __fish_asdf_arg_number 2' -a '(asdf plugin-list)' -A
-complete -f -c asdf -n '__fish_asdf_using_command plugin-update; and __fish_asdf_arg_number 2' -a --all -A
+complete -f -c asdf -n '__fish_asdf_using_command plugin-update; and __fish_asdf_arg_number 2' -a '(asdf plugin-list)'
+complete -f -c asdf -n '__fish_asdf_using_command plugin-update; and __fish_asdf_arg_number 2' -a --all
 
 # install completion
 complete -f -c asdf -n '__fish_asdf_needs_command' -a install -d "Install a specific version of a package"


### PR DESCRIPTION
Attempting to tab-complete an asdf command would result in a deprecation warning being printed.

The --authoritative/-A and --unauthoritative/-u flags have been removed from the `complete` command.

Context: https://github.com/fish-shell/fish-shell/pull/3660