### PR TITLE
export ASDF_DIR so that plugins can use it to refer to the ASDF DIR

### DIFF
--- a/asdf.sh
+++ b/asdf.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 
 if [ "${BASH_SOURCE[0]}" != "" ]; then
-  current_script_path=${BASH_SOURCE[0]}
+  current_script_path="${BASH_SOURCE[0]}"
 else
-  current_script_path=$0
+  current_script_path="$0"
 fi
 
-asdf_dir=$(cd $(dirname $current_script_path) &> /dev/null; echo $(pwd))
-export PATH="${asdf_dir}/bin:${asdf_dir}/shims:$PATH"
+# shellcheck disable=SC2155,SC2164
+export ASDF_DIR="$(cd "$(dirname "$current_script_path")" &> /dev/null; pwd)"
+export PATH="${ASDF_DIR}/bin:${ASDF_DIR}/shims:$PATH"
 
 if [ -n "$ZSH_VERSION" ]; then
   autoload -U bashcompinit


### PR DESCRIPTION
Also fixed `shellcheck` warnings in the file.

Ref: https://github.com/robbyrussell/oh-my-zsh/blob/master/plugins/asdf/asdf.plugin.zsh