### PR TITLE
Add OpenPGP keyring support by ignoring the keyring in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ installs
 plugins
 shims
 .vagrant
-
+keyrings


### PR DESCRIPTION
As the proposal for asdf-nodejs to [validate OpenPGP signatures](https://github.com/asdf-vm/asdf-nodejs/pull/25) has been approved and merged I guess the design is sound and other plugins can follow.

Related to: #159