### PR TITLE
Make sure grep uses the correct settings when invoked by asdf.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 Fixed Bugs
 
-* Export `ASDF_DIR` variable so the Zsh plugin can locate asdf if it's in a custom location
+* Set `GREP_OPTIONS` and `GREP_COLORS` variables in util.sh so grep is always invoked with the correct settings (#170)
+* Export `ASDF_DIR` variable so the Zsh plugin can locate asdf if it's in a custom location (#156)
 
 ##0.2.1
 

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -1,3 +1,8 @@
+# We shouldn't rely on the user's grep settings to be correct. If we set these
+# here anytime asdf invokes grep it will be invoked with these options
+GREP_OPTIONS="--color=never"
+GREP_COLORS=
+
 asdf_version() {
   echo "0.2.1"
 }


### PR DESCRIPTION
This should fix #168. Tests were failing on my Mac due to my own custom `GREP_OPTIONS` (`--color=always`). Making this change fixed the issue.

@StevenXL you can checkout this branch if you want to make sure this actually fixes the issue you found.