### PR TITLE
Avoid error when sysctl is missing hw.ncpu key

### DIFF
--- a/lib/commands/install.sh
+++ b/lib/commands/install.sh
@@ -15,7 +15,7 @@ install_command() {
 get_concurrency() {
   if which nproc > /dev/null 2>&1; then
     echo $(nproc)
-  elif which sysctl > /dev/null 2>&1; then
+  elif which sysctl > /dev/null 2>&1 && sysctl hw.ncpu > /dev/null 2>&1; then
     echo $(sysctl -n hw.ncpu)
   elif [ -f /proc/cpuinfo ]; then
     echo $(grep -c processor /proc/cpuinfo)


### PR DESCRIPTION
When trying to use `asdf` in Alpine Linux in Docker, I got an error when trying to determine the number of CPUs, since Alpine has `sysctl` but the key `hw.ncpu` doesn't exist.

This adds an additional check for that case.