### PR TITLE
Support system version

### DIFF
--- a/bin/private/asdf-exec
+++ b/bin/private/asdf-exec
@@ -18,33 +18,16 @@ fi
 IFS=' ' read -a versions <<< "$full_version"
 
 for version in "${versions[@]}"; do
-  IFS=':' read -a version_info <<< "$version"
+  install_path=$(find_install_path $plugin_name $version)
 
-  if [ "${version_info[0]}" = "ref" ]; then
-    install_type="${version_info[0]}"
-    version="${version_info[1]}"
-    install_path=$(get_install_path $plugin_name $install_type $version)
-  elif [ "${version_info[0]}" = "path" ]; then
-    # This is for people who have the local source already compiled
-    # Like those who work on the language, etc
-    # We'll allow specifying path:/foo/bar/project in .tool-versions
-    # And then use the binaries there
-    install_type="path"
-    version="path"
-    install_path="${version_info[1]}"
-  else
-    install_type="version"
-    version="${version_info[0]}"
-    install_path=$(get_install_path $plugin_name $install_type $version)
-  fi
-
-
-  if [ ! -d $install_path ]; then
+  if [ $version != "system" -a ! -d "$install_path" ]; then
     echo "$plugin_name $version not installed"
     exit 1
   fi
 
-  if [ -f ${install_path}/${executable_path} ]; then
+  full_executable_path=$(get_executable_path $plugin_name $version $executable_path)
+
+  if [ $? -eq 0 -a -f "$full_executable_path" ]; then
     if [ -f ${plugin_path}/bin/exec-env ]; then
       export ASDF_INSTALL_TYPE=$install_type
       export ASDF_INSTALL_VERSION=$version
@@ -56,10 +39,9 @@ for version in "${versions[@]}"; do
       unset ASDF_INSTALL_TYPE
       unset ASDF_INSTALL_VERSION
       unset ASDF_INSTALL_PATH
-      exec ${install_path}/${executable_path} "${@:3}"
-    else
-      exec ${install_path}/${executable_path} "${@:3}"
     fi
+
+    exec $full_executable_path "${@:3}"
   fi
 done
 

--- a/bin/private/asdf-exec
+++ b/bin/private/asdf-exec
@@ -20,7 +20,7 @@ IFS=' ' read -a versions <<< "$full_version"
 for version in "${versions[@]}"; do
   install_path=$(find_install_path $plugin_name $version)
 
-  if [ $version != "system" -a ! -d "$install_path" ]; then
+  if [ $version != "system" ] && [ ! -d "$install_path" ]; then
     echo "$plugin_name $version not installed"
     exit 1
   fi

--- a/completions/asdf.fish
+++ b/completions/asdf.fish
@@ -81,12 +81,12 @@ complete -f -c asdf -n '__fish_asdf_using_command reshim; and __fish_asdf_arg_nu
 # local completion
 complete -f -c asdf -n '__fish_asdf_needs_command' -a local -d "Set local version for a plugin"
 complete -f -c asdf -n '__fish_asdf_using_command local; and __fish_asdf_arg_number 2' -a '(asdf plugin-list)'
-complete -f -c asdf -n '__fish_asdf_using_command local; and test (count (commandline -opc)) -gt 2' -a '(asdf list (__fish_asdf_arg_at 3))'
+complete -f -c asdf -n '__fish_asdf_using_command local; and test (count (commandline -opc)) -gt 2' -a '(asdf list (__fish_asdf_arg_at 3)) system'
 
 # global completion
 complete -f -c asdf -n '__fish_asdf_needs_command' -a global -d "Set global version for a plugin"
 complete -f -c asdf -n '__fish_asdf_using_command global; and __fish_asdf_arg_number 2' -a '(asdf plugin-list)'
-complete -f -c asdf -n '__fish_asdf_using_command global; and test (count (commandline -opc)) -gt 2' -a '(asdf list (__fish_asdf_arg_at 3))'
+complete -f -c asdf -n '__fish_asdf_using_command global; and test (count (commandline -opc)) -gt 2' -a '(asdf list (__fish_asdf_arg_at 3)) system'
 
 # misc
 complete -f -c asdf -n '__fish_asdf_needs_command' -l "help" -d "Displays help"

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -178,7 +178,7 @@ get_executable_path() {
   check_if_version_exists $plugin_name $version
 
   if [ $version = "system" ]; then
-    path=$(echo $PATH | sed -e "s|$(asdf_dir)/shims:\?||g")
+    path=$(echo $PATH | sed -e "s|$ASDF_DIR/shims||g; s|::|:|g")
     cmd=$(basename $executable_path)
     cmd_path=$(PATH=$path which $cmd 2>&1)
     if [ $? -ne 0 ]; then

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -46,7 +46,7 @@ list_installed_versions() {
 check_if_plugin_exists() {
   # Check if we have a non-empty argument
   if [ -z "${1+set}" ]; then
-    display_error "No such plugin"
+    display_error "No plugin given"
     exit 1
   fi
 
@@ -57,7 +57,7 @@ check_if_plugin_exists() {
 }
 
 check_if_version_exists() {
-  local plugin=$1
+  local plugin_name=$1
   local version=$2
   local version_dir=$(asdf_dir)/installs/$plugin/$version
 
@@ -66,8 +66,10 @@ check_if_version_exists() {
       version_dir=$(echo $version | cut -d: -f 2)
   fi
 
+  check_if_plugin_exists $plugin_name
+
   if [ $version != "system" -a ! -d $version_dir ]; then
-    display_error "version $version is not installed for $plugin"
+    display_error "version $version is not installed for $plugin_name"
     exit 1
   fi
 }
@@ -173,6 +175,8 @@ get_executable_path() {
   local version=$2
   local executable_path=$3
 
+  check_if_version_exists $plugin_name $version
+
   if [ $version = "system" ]; then
     path=$(echo $PATH | sed -e "s|$(asdf_dir)/shims:\?||g")
     cmd=$(basename $executable_path)
@@ -226,29 +230,29 @@ get_preset_version_for() {
 }
 
 get_asdf_config_value_from_file() {
-    local config_path=$1
-    local key=$2
+  local config_path=$1
+  local key=$2
 
-    if [ ! -f $config_path ]; then
-        return 0
-    fi
+  if [ ! -f $config_path ]; then
+    return 0
+  fi
 
-    local result=$(grep -E "^\s*$key\s*=" $config_path | awk -F '=' '{ gsub(/ /, "", $2); print $2 }')
-    if [ -n "$result" ]; then
-        echo $result
-    fi
+  local result=$(grep -E "^\s*$key\s*=" $config_path | awk -F '=' '{ gsub(/ /, "", $2); print $2 }')
+  if [ -n "$result" ]; then
+    echo $result
+  fi
 }
 
 get_asdf_config_value() {
-    local key=$1
-    local config_path=${AZDF_CONFIG_FILE:-"$HOME/.asdfrc"}
-    local default_config_path=${AZDF_CONFIG_DEFAULT_FILE:-"$(asdf_dir)/defaults"}
+  local key=$1
+  local config_path=${AZDF_CONFIG_FILE:-"$HOME/.asdfrc"}
+  local default_config_path=${AZDF_CONFIG_DEFAULT_FILE:-"$(asdf_dir)/defaults"}
 
-    local result=$(get_asdf_config_value_from_file $config_path $key)
+  local result=$(get_asdf_config_value_from_file $config_path $key)
 
-    if [ -n "$result" ]; then
-        echo $result
-    else
-        get_asdf_config_value_from_file $default_config_path $key
-    fi
+  if [ -n "$result" ]; then
+    echo $result
+  else
+    get_asdf_config_value_from_file $default_config_path $key
+  fi
 }

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -59,7 +59,7 @@ check_if_plugin_exists() {
 check_if_version_exists() {
   local plugin_name=$1
   local version=$2
-  local version_dir=$(asdf_dir)/installs/$plugin/$version
+  local version_dir=$(asdf_dir)/installs/$plugin_name/$version
 
   # if version starts with path: use that directory
   if [ "${version/path:}" != "$version" ]; then
@@ -68,7 +68,7 @@ check_if_version_exists() {
 
   check_if_plugin_exists $plugin_name
 
-  if [ $version != "system" -a ! -d $version_dir ]; then
+  if [ $version != "system" ] && [ ! -d $version_dir ]; then
     display_error "version $version is not installed for $plugin_name"
     exit 1
   fi

--- a/test/remove_command.bats
+++ b/test/remove_command.bats
@@ -25,7 +25,7 @@ teardown() {
 @test "plugin_remove_command should exit with 1 when not passed any arguments" {
   run plugin_remove_command
   [ "$status" -eq 1 ]
-  [ "$output" = "No such plugin" ]
+  [ "$output" = "No plugin given" ]
 }
 
 @test "plugin_remove_command should exit with 1 when passed invalid plugin name" {

--- a/test/test_helpers.bash
+++ b/test/test_helpers.bash
@@ -6,6 +6,8 @@ setup_asdf_dir() {
   ASDF_DIR=$HOME/.asdf
   mkdir -p $ASDF_DIR/plugins
   mkdir -p $ASDF_DIR/installs
+  mkdir -p $ASDF_DIR/shims
+  PATH=$ASDF_DIR/shims:$PATH
 }
 
 install_dummy_plugin() {

--- a/test/update_command.bats
+++ b/test/update_command.bats
@@ -12,7 +12,7 @@ setup() {
   install_dummy_plugin
 
   # Copy over git repo so we have something to test with
-  cp -r . $ASDF_DIR
+  cp -r .git $ASDF_DIR
   (
   cd $ASDF_DIR
   git remote remove origin

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -19,7 +19,7 @@ teardown() {
 @test "check_if_version_exists should exit with 1 if plugin does not exist" {
   run check_if_version_exists "inexistent" "1.0.0"
   [ "$status" -eq 1 ]
-  [ "$output" = "version 1.0.0 is not installed for inexistent" ]
+  [ "$output" = "No such plugin" ]
 }
 
 @test "check_if_version_exists should exit with 1 if version does not exist" {

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -34,10 +34,17 @@ teardown() {
   [ "$output" = "" ]
 }
 
+@test "check_if_version_exists should be noop if version is system" {
+  mkdir -p $ASDF_DIR/plugins/foo
+  run check_if_version_exists "foo" "system"
+  [ "$status" -eq 0 ]
+  [ "$output" = "" ]
+}
+
 @test "check_if_plugin_exists should exit with 1 when plugin is empty string" {
   run check_if_plugin_exists
   [ "$status" -eq 1 ]
-  [ "$output" = "No such plugin" ]
+  [ "$output" = "No plugin given" ]
 }
 
 @test "check_if_plugin_exists should be noop if plugin exists" {
@@ -138,4 +145,35 @@ teardown() {
   run get_preset_version_for "dummy"
   [ "$status" -eq 0 ]
   [ "$output" = "path:/some/place with spaces" ]
+}
+
+@test "get_executable_path for system version should return system path" {
+  mkdir -p $ASDF_DIR/plugins/foo
+  run get_executable_path "foo" "system" "ls"
+  [ "$status" -eq 0 ]
+  [ "$output" = $(which ls) ]
+}
+
+@test "get_executable_path for system version should not use asdf shims" {
+  mkdir -p $ASDF_DIR/plugins/foo
+  touch $ASDF_DIR/shims/dummy_executable
+  chmod +x $ASDF_DIR/shims/dummy_executable
+
+  run which dummy_executable
+  [ "$status" -eq 0 ]
+
+  run get_executable_path "foo" "system" "dummy_executable"
+  [ "$status" -eq 1 ]
+}
+
+@test "get_executable_path for non system version should return relative path from plugin" {
+  mkdir -p $ASDF_DIR/plugins/foo
+  mkdir -p $ASDF_DIR/installs/foo/1.0.0/bin
+  executable_path=$ASDF_DIR/installs/foo/1.0.0/bin/dummy
+  touch $executable_path
+  chmod +x $executable_path
+
+  run get_executable_path "foo" "1.0.0" "bin/dummy"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$executable_path" ]
 }


### PR DESCRIPTION
This allows asdf to pass through to the system version of a give tool if it's version is set to `system` in the `.tool-versions` file. For example `ruby system` would result in `ruby` executing the version of Ruby on the path that is not managed by asdf. Or in the case of `ruby` not being present on the path, an error.

@tuvistavie did all the work for the feature, I just added the tests for it.

This should close #55