### PR TITLE
Avoid bash error when no version is set

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -68,7 +68,7 @@ check_if_version_exists() {
 
   check_if_plugin_exists $plugin_name
 
-  if [ $version != "system" ] && [ ! -d $version_dir ]; then
+  if [ "$version" != "system" ] && [ ! -d $version_dir ]; then
     display_error "version $version is not installed for $plugin_name"
     exit 1
   fi


### PR DESCRIPTION
Running "asdf current ruby" before installing any Rubies gave me:

    /Users/henrik/.asdf/lib/utils.sh: line 73: [: !=: unary operator expected
    No version set for ruby