### PR TITLE
Query git for the current version tag (Fixes #189)

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -4,7 +4,11 @@ GREP_OPTIONS="--color=never"
 GREP_COLORS=
 
 asdf_version() {
-  echo "0.2.1"
+  # Move to the asdf repo, then report the current tag
+  (
+  cd $(asdf_dir)
+  git describe --tags
+  )
 }
 
 asdf_dir() {


### PR DESCRIPTION
Previously the version number was hard coded into `utils.sh`. This can be easy to miss when bumping version numbers elsewhere. This pull request asks git what the most recent tag in the tree is, reporting that answer instead of a static version number. The version number also contains what I suspect are

1. the number of commits since that version tag and
2. the mini-hash for the current commit.

```bash
$ asdf --version
v0.3.0-5-gbaad7dd
```