### PR TITLE
Add asdf-plugin-version metadata to shims

### DIFF
--- a/lib/commands/reshim.sh
+++ b/lib/commands/reshim.sh
@@ -51,7 +51,7 @@ write_shim_script() {
     cp "$plugin_shims_path/$executable_name" "$shim_path"
   elif [ -f "$shim_path" ]; then
     if ! grep "# asdf-plugin-version: $version" "$shim_path" > /dev/null; then
-      sed "$shim_path" -i'' -e "s/\(asdf-plugin: $plugin_name\)/\1\n# asdf-plugin-version: $version/"
+     sed -i'' -e "s/\(asdf-plugin: $plugin_name\)/\1\\"$'\n'"# asdf-plugin-version: $version/" "$shim_path"
     fi
   else
     cat <<EOF > "$shim_path"
@@ -191,7 +191,7 @@ remove_shim_for_version() {
     return 0
   fi
 
-  sed "$shim_path" -i'' -e "/# asdf-plugin-version: $version/d"
+  sed -i'' -e "/# asdf-plugin-version: $version/d" "$shim_path"
 
   if [ ! -f "$plugin_shims_path/$executable_name" ] && \
         ! grep "# asdf-plugin-version" "$shim_path" > /dev/null || \

--- a/lib/commands/reshim.sh
+++ b/lib/commands/reshim.sh
@@ -25,6 +25,7 @@ reshim_command() {
     for install in ${plugin_installs_path}/*/; do
       local full_version_name=$(echo $(basename $install) | sed 's/ref\-/ref\:/')
       generate_shims_for_version $plugin_name $full_version_name
+      remove_obsolete_shims $plugin_name $full_version_name
     done
   fi
 }
@@ -40,22 +41,28 @@ ensure_shims_dir() {
 
 write_shim_script() {
   local plugin_name=$1
-  local executable_path=$2
+  local version=$2
+  local executable_path=$3
   local executable_name=$(basename $executable_path)
   local plugin_shims_path=$(get_plugin_path $plugin_name)/shims
   local shim_path=$(asdf_dir)/shims/$executable_name
 
-  if [ -f $plugin_shims_path/$executable_name ]; then
-    cp $plugin_shims_path/$executable_name $shim_path
+  if [ -f "$plugin_shims_path/$executable_name" ]; then
+    cp "$plugin_shims_path/$executable_name" "$shim_path"
+  elif [ -f "$shim_path" ]; then
+    if ! grep "# asdf-plugin-version: $version" "$shim_path" > /dev/null; then
+      sed "$shim_path" -i'' -e "s/\(asdf-plugin: $plugin_name\)/\1\n# asdf-plugin-version: $version/"
+    fi
   else
-    cat <<EOF > $shim_path
+    cat <<EOF > "$shim_path"
 #!/usr/bin/env bash
 # asdf-plugin: ${plugin_name}
+# asdf-plugin-version: ${version}
 exec $(asdf_dir)/bin/private/asdf-exec ${plugin_name} ${executable_path} "\$@"
 EOF
   fi
 
-  chmod +x $shim_path
+  chmod +x "$shim_path"
 }
 
 
@@ -75,15 +82,79 @@ generate_shim_for_executable() {
     local version="${version_info[0]}"
   fi
 
-  write_shim_script $plugin_name $executable
+  write_shim_script "$plugin_name" "$version" "$executable"
+}
+
+list_plugin_bin_paths() {
+  local plugin_name=$1
+  local version=$2
+  local install_type=$3
+  local plugin_path=$(get_plugin_path "$plugin_name")
+  local install_path=$(get_install_path "$plugin_name" "$install_type" "$version")
+
+  if [ -f "${plugin_path}/bin/list-bin-paths" ]; then
+    local space_separated_list_of_bin_paths=$(
+      export ASDF_INSTALL_TYPE=$install_type
+      export ASDF_INSTALL_VERSION=$version
+      export ASDF_INSTALL_PATH=$install_path
+      bash "${plugin_path}/bin/list-bin-paths"
+    )
+  else
+    local space_separated_list_of_bin_paths="bin"
+  fi
+  echo "$space_separated_list_of_bin_paths"
 }
 
 
 generate_shims_for_version() {
   local plugin_name=$1
   local full_version=$2
-  local plugin_path=$(get_plugin_path $plugin_name)
-  check_if_plugin_exists $plugin_name
+  check_if_plugin_exists "$plugin_name"
+
+
+  IFS=':' read -a version_info <<< "$full_version"
+  if [ "${version_info[0]}" = "ref" ]; then
+    local install_type="${version_info[0]}"
+    local version="${version_info[1]}"
+  else
+    local install_type="version"
+    local version="${version_info[0]}"
+  fi
+  space_separated_list_of_bin_paths="$(list_plugin_bin_paths "$plugin_name" "$version" "$install_type")"
+  IFS=' ' read -a all_bin_paths <<< "$space_separated_list_of_bin_paths"
+
+  local install_path=$(get_install_path "$plugin_name" "$install_type" "$version")
+
+  for bin_path in "${all_bin_paths[@]}"; do
+    for executable_file in $install_path/$bin_path/*; do
+      # because just $executable_file gives absolute path; We don't want version hardcoded in shim
+      local executable_path_relative_to_install_path=$bin_path/$(basename "$executable_file")
+      if [ -x "$executable_file" ]; then
+          write_shim_script "$plugin_name" "$version" "$executable_path_relative_to_install_path"
+      fi
+    done
+  done
+}
+
+shim_still_exists() {
+  local shim_name=$1
+  local install_path=$2
+  local space_separated_list_of_bin_paths=$3
+  IFS=' ' read -a all_bin_paths <<< "$space_separated_list_of_bin_paths"
+
+
+  for bin_path in "${all_bin_paths[@]}"; do
+    if [ -x "$install_path/$bin_path/$shim_name" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+remove_obsolete_shims() {
+  local plugin_name=$1
+  local full_version=$2
+  local shims_path="$(asdf_dir)/shims"
 
   IFS=':' read -a version_info <<< "$full_version"
   if [ "${version_info[0]}" = "ref" ]; then
@@ -94,28 +165,61 @@ generate_shims_for_version() {
     local version="${version_info[0]}"
   fi
 
-  local install_path=$(get_install_path $plugin_name $install_type $version)
+  space_separated_list_of_bin_paths="$(list_plugin_bin_paths "$plugin_name" "$version" "$install_type")"
 
-  if [ -f ${plugin_path}/bin/list-bin-paths ]; then
-    local space_separated_list_of_bin_paths=$(
-      export ASDF_INSTALL_TYPE=$install_type
-      export ASDF_INSTALL_VERSION=$version
-      export ASDF_INSTALL_PATH=$install_path
-      bash ${plugin_path}/bin/list-bin-paths
-    )
-  else
-    local space_separated_list_of_bin_paths="bin"
+  local install_path=$(get_install_path "$plugin_name" "$install_type" "$version")
+
+  for shim_path in "$shims_path"/*; do
+    local shim_name="$(basename "$shim_path")"
+    if grep "# asdf-plugin: $plugin_name" "$shim_path" > /dev/null && \
+        grep "# asdf-plugin-version: $version" "$shim_path" > /dev/null && \
+        ! shim_still_exists "$shim_name" "$install_path" "$space_separated_list_of_bin_paths"; then
+      remove_shim_for_version "$plugin_name" "$shim_name" "$version"
+    fi
+  done
+}
+
+remove_shim_for_version() {
+  local plugin_name=$1
+  local executable_name=$2
+  local version=$3
+  local plugin_shims_path=$(get_plugin_path "$plugin_name")/shims
+  local shim_path="$(asdf_dir)/shims/$executable_name"
+  local count_installed=$(list_installed_versions "$plugin_name" | wc -l)
+
+  if ! grep "# asdf-plugin: $plugin_name" "$shim_path" > /dev/null 2>&1; then
+    return 0
   fi
 
+  sed "$shim_path" -i'' -e "/# asdf-plugin-version: $version/d"
+
+  if [ ! -f "$plugin_shims_path/$executable_name" ] && \
+        ! grep "# asdf-plugin-version" "$shim_path" > /dev/null || \
+      [ "$count_installed" -eq 0 ]; then
+    rm "$shim_path"
+  fi
+}
+
+remove_shims_for_version() {
+  local plugin_name=$1
+  local full_version=$2
+  check_if_plugin_exists "$plugin_name"
+
+  IFS=':' read -a version_info <<< "$full_version"
+  if [ "${version_info[0]}" = "ref" ]; then
+    local install_type="${version_info[0]}"
+    local version="${version_info[1]}"
+  else
+    local install_type="version"
+    local version="${version_info[0]}"
+  fi
+  space_separated_list_of_bin_paths="$(list_plugin_bin_paths "$plugin_name" "$version" "$install_type")"
   IFS=' ' read -a all_bin_paths <<< "$space_separated_list_of_bin_paths"
 
   for bin_path in "${all_bin_paths[@]}"; do
     for executable_file in $install_path/$bin_path/*; do
-      # because just $executable_file gives absolute path; We don't want version hardcoded in shim
-      local executable_path_relative_to_install_path=$bin_path/$(basename $executable_file)
-      if [ -x "$executable_file" ]; then
-          write_shim_script $plugin_name $executable_path_relative_to_install_path
-      fi
+      local executable_name="$(basename "$executable_file")"
+      remove_shim_for_version "$plugin_name" "$executable_name" "$version"
     done
   done
 }

--- a/lib/commands/uninstall.sh
+++ b/lib/commands/uninstall.sh
@@ -21,6 +21,8 @@ uninstall_command() {
     exit 1
   fi
 
+  remove_shims_for_version "$plugin_name" "$full_version"
+
   if [ -f ${plugin_path}/bin/uninstall ]; then
     (
       export ASDF_INSTALL_TYPE=$install_type
@@ -31,11 +33,4 @@ uninstall_command() {
   else
     rm -rf $install_path
   fi
-
-  # remove plugin shims if no other version of this plugin is installed
-  local count_installed=$(list_installed_versions $plugin_name | wc -l)
-  if [ 0 -eq $count_installed ]; then
-    grep -l "asdf-plugin: ${plugin_name}" $(asdf_dir)/shims/* 2>/dev/null | xargs rm -f
-  fi
-
 }

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -69,7 +69,7 @@ teardown() {
   [ "$status" -eq 0 ]
 
   lines_count=$(grep "asdf-plugin-version: 1.1" $ASDF_DIR/shims/dummy | wc -l)
-  [ "$lines_count" = "1" ]
+  [ "$lines_count" -eq "1" ]
 }
 
 

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -43,12 +43,33 @@ teardown() {
   [ $(cat $ASDF_DIR/installs/dummy/1.2/version) = "1.2" ]
 }
 
-@test "install_command should create a shim with metadada" {
+@test "install_command should create a shim with asdf-plugin metadata" {
   run install_command dummy 1.0
   [ "$status" -eq 0 ]
   [ -f $ASDF_DIR/installs/dummy/1.0/env ]
   run grep "asdf-plugin: dummy" $ASDF_DIR/shims/dummy
   [ "$status" -eq 0 ]
+
+  run grep "asdf-plugin-version: 1.0" $ASDF_DIR/shims/dummy
+  [ "$status" -eq 0 ]
+}
+
+@test "install_command should create a shim with asdf-plugin-version metadata" {
+  run install_command dummy 1.1
+  [ "$status" -eq 0 ]
+  run grep "asdf-plugin-version: 1.1" $ASDF_DIR/shims/dummy
+  [ "$status" -eq 0 ]
+
+  run grep "asdf-plugin-version: 1.0" $ASDF_DIR/shims/dummy
+  [ "$status" -eq 1 ]
+
+  run install_command dummy 1.0
+  [ "$status" -eq 0 ]
+  run grep "asdf-plugin-version: 1.0" $ASDF_DIR/shims/dummy
+  [ "$status" -eq 0 ]
+
+  lines_count=$(grep "asdf-plugin-version: 1.1" $ASDF_DIR/shims/dummy | wc -l)
+  [ "$lines_count" = "1" ]
 }
 
 

--- a/test/reshim_command.bats
+++ b/test/reshim_command.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+
+load test_helpers
+
+. $(dirname $BATS_TEST_DIRNAME)/lib/commands/reshim.sh
+. $(dirname $BATS_TEST_DIRNAME)/lib/commands/install.sh
+
+setup() {
+  setup_asdf_dir
+  install_dummy_plugin
+
+  PROJECT_DIR=$HOME/project
+  mkdir $PROJECT_DIR
+}
+
+teardown() {
+  clean_asdf_dir
+}
+
+
+@test "reshim command should remove shims of removed binaries" {
+  run install_command dummy 1.0
+  [ "$status" -eq 0 ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
+
+  run reshim_command dummy
+  [ "$status" -eq 0 ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
+
+  run rm "$ASDF_DIR/installs/dummy/1.0/bin/dummy"
+  run reshim_command dummy
+  [ "$status" -eq 0 ]
+  [ ! -f "$ASDF_DIR/shims/dummy" ]
+}
+
+@test "reshim should remove metadata of removed binaries" {
+  run install_command dummy 1.0
+  run install_command dummy 1.1
+
+  run rm "$ASDF_DIR/installs/dummy/1.0/bin/dummy"
+  run reshim_command dummy
+  [ "$status" -eq 0 ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
+  run grep "asdf-plugin-version: 1.0" "$ASDF_DIR/shims/dummy"
+  [ "$status" -eq 1 ]
+  run grep "asdf-plugin-version: 1.1" "$ASDF_DIR/shims/dummy"
+  [ "$status" -eq 0 ]
+}

--- a/test/uninstall_command.bats
+++ b/test/uninstall_command.bats
@@ -62,6 +62,20 @@ teardown() {
   [ -f $ASDF_DIR/shims/dummy ]
 }
 
+@test "uninstall_command should remove relevant asdf-plugin-version metadata" {
+  run install_command dummy 1.0
+  [ -f $ASDF_DIR/installs/dummy/1.0/bin/dummy ]
+
+  run install_command dummy 1.1
+  [ -f $ASDF_DIR/installs/dummy/1.1/bin/dummy ]
+
+  run uninstall_command dummy 1.0
+  run grep "asdf-plugin-version: 1.1" $ASDF_DIR/shims/dummy
+  [ "$status" -eq 0 ]
+  run grep "asdf-plugin-version: 1.0" $ASDF_DIR/shims/dummy
+  [ "$status" -eq 1 ]
+}
+
 @test "uninstall_command should not remove other unrelated shims" {
   run install_command dummy 1.0
   [ -f $ASDF_DIR/shims/dummy ]


### PR DESCRIPTION
This adds `asdf-plugin-version` to all generated shims.
This metadata is used to remove the shim when necessary.

I think this should handle most cases we need:

* Remove a shim when removing a version using `asdf uninstall`
* Remove a shim which has been uninstalled using the language package manager when calling `asdf reshim $PLUGIN`

Of course this will only remove a shim in the case the binary exists in no other versions of the plugin, so for example if we install a binary `dummy` using versions `1.0` and `1.1`
of a plugin, and then remove version `1.0`, the shim will
correctly stay. However, if the shim was only installed
in version `1.0` and we remove this version, the shim
will be removed.

Please take a look and let me know if I missed something.

This should fix #200 