### PR TITLE
Add more details on the proper behavior of install scripts to the plugin guide

### DIFF
--- a/docs/creating-plugins.md
+++ b/docs/creating-plugins.md
@@ -29,8 +29,11 @@ If versions are being pulled from releases page on a website it's recommended to
 
 #### bin/install
 
-This script should install the version, in the path mentioned in `ASDF_INSTALL_PATH`
+This script should install the version, in the path mentioned in `ASDF_INSTALL_PATH`.
 
+The install script should exit with a status of `0` when the installation is successful. If the installation fails the script should exit with any non-zero exit status.
+
+If possible the script should only place files in the `ASDF_INSTALL_PATH` directory once the build and installation of the tool is deemed successful by the install script. asdf [checks for the existence](https://github.com/asdf-vm/asdf/blob/242d132afbf710fe3c7ec23c68cec7bdd2c78ab5/lib/utils.sh#L44) of the `ASDF_INSTALL_PATH` directory in order to determine if that version of the tool is installed. If the `ASDF_INSTALL_PATH` directory is populated at the beginning of the installation process other asdf commands run in other terminals during the installation may consider that version of the tool installed, even when it is not fully installed.
 
 ### Optional scripts
 


### PR DESCRIPTION
# Summary

Added one key detail about the install script (exit codes) to the plugin guide. Also suggested only populating the target directory once the installation is complete or deemed successful  to prevent incorrect asdf behavior. This is something I noticed earlier this week with the Python plugin.