### PR TITLE
List all installed plugins when no argument is passed to current

### DIFF
--- a/lib/commands/current.sh
+++ b/lib/commands/current.sh
@@ -1,4 +1,4 @@
-current_command() {
+plugin_current_command() {
   local plugin_name=$1
 
   check_if_plugin_exists $plugin_name
@@ -16,6 +16,17 @@ current_command() {
     exit 1
   else
     echo "$version (set by $version_file_path)"
+  fi
+}
+
+current_command() {
+  if [ $# -eq 0 ]; then
+    for plugin in $(plugin_list_command); do
+      echo "$plugin $(plugin_current_command $plugin)"
+    done
+  else
+    local plugin=$1
+    plugin_current_command $plugin
   fi
 }
 

--- a/test/current_command.bats
+++ b/test/current_command.bats
@@ -3,6 +3,7 @@
 load test_helpers
 
 . $(dirname $BATS_TEST_DIRNAME)/lib/commands/current.sh
+. $(dirname $BATS_TEST_DIRNAME)/lib/commands/plugin-list.sh
 
 setup() {
   setup_asdf_dir
@@ -57,4 +58,23 @@ teardown() {
   run current_command "dummy"
   [ "$status" -eq 1 ]
   [ "$output" = "version 9.9.9 is not installed for dummy" ]
+}
+
+@test "should output all plugins when no plugin passed" {
+
+  install_dummy_plugin
+  install_dummy_version "1.1.0"
+
+  install_mock_plugin "foobar"
+  install_mock_plugin_version "foobar" "1.0.0"
+
+  cd $PROJECT_DIR
+  echo 'dummy 1.1.0' >> $PROJECT_DIR/.tool-versions
+  echo 'foobar 1.0.0' >> $PROJECT_DIR/.tool-versions
+
+  run current_command
+  expected="dummy 1.1.0 (set by $PROJECT_DIR/.tool-versions)
+foobar 1.0.0 (set by $PROJECT_DIR/.tool-versions)"
+
+  [ "$expected" = "$output" ]
 }

--- a/test/test_helpers.bash
+++ b/test/test_helpers.bash
@@ -10,13 +10,23 @@ setup_asdf_dir() {
   PATH=$ASDF_DIR/shims:$PATH
 }
 
+install_mock_plugin() {
+  local plugin_name=$1
+  cp -r "$BATS_TEST_DIRNAME/fixtures/dummy_plugin" "$ASDF_DIR/plugins/$plugin_name"
+}
+
+install_mock_plugin_version() {
+  local plugin_name=$1
+  local plugin_version=$2
+  mkdir -p "$ASDF_DIR/installs/$plugin_name/$plugin_version"
+}
+
 install_dummy_plugin() {
-  cp -r $BATS_TEST_DIRNAME/fixtures/dummy_plugin $ASDF_DIR/plugins/dummy
+  install_mock_plugin "dummy"
 }
 
 install_dummy_version() {
-  dummy_version=$1
-  mkdir -p $ASDF_DIR/installs/dummy/$dummy_version
+  install_mock_plugin_version "dummy" "$1"
 }
 
 clean_asdf_dir() {


### PR DESCRIPTION
`asdf current` currently needs the plugin name to show the version.
With the increasing number of plugins, I think it would be nice to have
a list of all the version currently in use, so I added this functionality to
`current`. For example, here is the output I now get on my machine:

```
elixir 1.5.1 (set by /home/daniel/.tool-versions)
erlang 20.0 (set by /home/daniel/.tool-versions)
golang 1.8 (set by /home/daniel/.tool-versions)
nodejs 6.10.2 (set by /home/daniel/.tool-versions)
python 3.6.1 2.7.13 system (set by /home/daniel/.tool-versions)
ruby 2.4.1 (set by /home/daniel/.tool-versions)
```