### PR TITLE
Release script

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+# Unoffical Bash "strict mode"
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euo pipefail
+#ORIGINAL_IFS=$IFS
+IFS=$'\t\n' # Stricter IFS settings
+
+usage() {
+    cat <<EOF
+
+Usage: release.sh [new version]
+
+This script is only intended for use by asdf maintainers when releasing new
+versions of asdf. Plugin developers and asdf users do not need this script.
+
+This script updates the hardcoded versions in the source code and README and
+then commits them on the current branch. It then tags that commit with the
+specified version.
+
+EOF
+}
+
+error_exit() {
+    usage
+    exit 1
+}
+
+new_version="${1:-}"
+new_tag_name="v$new_version"
+
+# Make sure the user provides a version
+if [[ -z "$new_version" ]]
+then
+    echo "ERROR: no new version specified"
+    error_exit
+fi
+
+# Make sure version passed in is a plain semantic version to guard against
+# leading 'v'.
+if ! [[ "${new_version:0:1}" =~ ^[0-9]+$ ]]; then
+    echo >&2 "ERROR: semantic version should not start with a letter"
+    error_exit
+fi
+
+# Make sure the version the user provided hasn't already been tagged
+if git tag | grep "$new_tag_name" > /dev/null; then
+    echo >&2 "ERROR: git tag with that version already exists"
+    exit 1
+fi
+
+echo "INFO: Checking that all changes are commited and pushed"
+git pull
+
+# Disallow unstaged changes in the working tree
+if ! git diff-files --check --exit-code --ignore-submodules -- >&2; then
+    echo >&2 "ERROR: You have unstaged changes."
+    exit 1
+fi
+
+# Disallow uncommitted changes in the index
+if ! git diff-index --cached --exit-code -r --ignore-submodules HEAD -- >&2; then
+    echo >&2 "ERROR: Your index contains uncommitted changes."
+    exit 1
+fi
+
+# Update version in README
+sed -i.bak "s|^\(git clone.*--branch \).*$|\1$new_tag_name|" README.md
+
+# Update version in utils.sh
+# TODO: Hardcode version until.sh since not all asdf will include the Git repo
+
+# Commit the changed files before tagging the new release
+git add README.md
+git add lib/utils.sh
+git commit -m "Update version to $new_version"
+
+#git tag -fa ${VERSION} -m "Version ${VERSION}"
+#git tag -fa -a RELEASE -m "Current RELEASE"
+#
+#NEW_VERSION="${VERSION%.*}.$((${VERSION##*.}+1))"
+#set -ex
+#sed -i.bak "s/${VERSION}/${NEW_VERSION}/" setup.py
+#
+#git commit -m "Auto-increasing the version number after a release."
+
+#git push --force origin --tags
+
+echo "INFO: done."

--- a/release.sh
+++ b/release.sh
@@ -70,20 +70,14 @@ sed -i.bak "s|^\(git clone.*--branch \).*$|\1$new_tag_name|" README.md
 # Update version in utils.sh
 # TODO: Hardcode version until.sh since not all asdf will include the Git repo
 
+echo "INFO: Committing and tagging new version"
+
 # Commit the changed files before tagging the new release
 git add README.md
 git add lib/utils.sh
 git commit -m "Update version to $new_version"
 
-#git tag -fa ${VERSION} -m "Version ${VERSION}"
-#git tag -fa -a RELEASE -m "Current RELEASE"
-#
-#NEW_VERSION="${VERSION%.*}.$((${VERSION##*.}+1))"
-#set -ex
-#sed -i.bak "s/${VERSION}/${NEW_VERSION}/" setup.py
-#
-#git commit -m "Auto-increasing the version number after a release."
-
-#git push --force origin --tags
+git tag -a "$new_tag_name" -m "Version ${new_version}"
 
 echo "INFO: done."
+echo "INFO: Now you can push this local branch to the GitHub repository."


### PR DESCRIPTION
# Summary

Add a release.sh that automates the work needed to release a new version of asdf. The script ensures the version doesn't already exist and also makes sure there aren't any uncommitted changes in the working directory. The script updates the files that contain the version, then commits the changes, and then tags a new version. 

All the maintainer needs to do to release a new version is:

1.  Run the script on the master branch - `./release.sh v0.3.1`
2. Then push the branch to GitHub - `git push origin master`

This will address part of #198 

There is one TODO comment in the script. That will be addressed in another PR that will resolve the rest of #198.
