### PR TITLE
Use origin when updating tags

### DIFF
--- a/lib/commands/update.sh
+++ b/lib/commands/update.sh
@@ -13,7 +13,7 @@ update_command() {
     echo "Updated asdf to latest on the master branch"
   else
     # Update to latest release
-    git fetch --tags || exit 1
+    git fetch origin --tags || exit 1
     tag=$(git tag | sort_versions | sed '$!d') || exit 1
 
     # Update


### PR DESCRIPTION
# Summary

`update_command` is using `git pull origin master`, when updating with `--head`,
but using `git fetch --tags` when updating to a tag, without specifying the remote.

This PR makes it use `git fetch origin --tags` instead.

This was preventing me from successfully running tests locally, as it was defaulting to another remote to which I currently don't have access.