### PR TITLE
Add installing from a parent directory's .tool-versions

### DIFF
--- a/lib/commands/install.sh
+++ b/lib/commands/install.sh
@@ -37,10 +37,9 @@ get_concurrency() {
 }
 
 install_local_tool_versions() {
-  if [ -f "$(pwd)/.tool-versions" ]; then
-    local asdf_versions_path
-    asdf_versions_path="$(pwd)/.tool-versions"
-
+  local asdf_versions_path
+  asdf_versions_path=$(find_tool_versions)
+  if [ -f "${asdf_versions_path}" ]; then
     while read -r tool_line; do
       IFS=' ' read -r -a tool_info <<< "$tool_line"
       local tool_name
@@ -55,6 +54,7 @@ install_local_tool_versions() {
   else
     echo "Either specify a tool & version in the command"
     echo "OR add .tool-versions file in this directory"
+    echo "or in a parent directory"
     exit 1
   fi
 }

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -325,7 +325,8 @@ get_plugin_source_url() {
 }
 
 find_tool_versions() {
-    local search_path=$(pwd)
+    local search_path
+    search_path=$(pwd)
     while [ "$search_path" != "/" ]; do
         if [ -f "$search_path/.tool-versions" ]; then
             echo "${search_path}/.tool-versions"

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -323,3 +323,14 @@ get_plugin_source_url() {
     grep "repository" "$plugin_config" | awk -F'=' '{print $2}' | sed 's/ //'
   fi
 }
+
+find_tool_versions() {
+    local search_path=$(pwd)
+    while [ "$search_path" != "/" ]; do
+        if [ -f "$search_path/.tool-versions" ]; then
+            echo "${search_path}/.tool-versions"
+            return 0
+        fi
+        search_path=$(dirname "$search_path")
+    done
+}

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -97,3 +97,19 @@ teardown() {
   [ "$output" = "You must specify a name and a version to install" ]
   [ ! -f $ASDF_DIR/installs/dummy/1.1/version ]
 }
+
+@test "install_command uses a parent directory .tool-versions file if present" {
+  # asdf lib needed to run generated shims
+  cp -rf $BATS_TEST_DIRNAME/../{bin,lib} $ASDF_DIR/
+
+  echo 'dummy 1.0' > $PROJECT_DIR/.tool-versions
+  mkdir -p $PROJECT_DIR/child
+
+  cd $PROJECT_DIR/child
+
+  run install_command
+
+  # execute the generated shim
+  [ "$($ASDF_DIR/shims/dummy world hello)" == "This is Dummy 1.0! hello world" ]
+  [ "$status" -eq 0 ]
+}

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -207,3 +207,22 @@ teardown() {
   [ "$status" -eq 0 ]
   [ "$output" = "$executable_path" ]
 }
+
+@test "find_tool_versions will find a .tool-versions path if it exists in current directory" {
+  echo "dummy 0.1.0" > $PROJECT_DIR/.tool-versions
+  cd $PROJECT_DIR
+
+  run find_tool_versions
+  [ "$status" -eq 0 ]
+  [ "$output" = "$PROJECT_DIR/.tool-versions" ]
+}
+
+@test "find_tool_versions will find a .tool-versions path if it exists in parent directory" {
+  echo "dummy 0.1.0" > $PROJECT_DIR/.tool-versions
+  mkdir -p $PROJECT_DIR/child
+  cd $PROJECT_DIR/child
+
+  run find_tool_versions
+  [ "$status" -eq 0 ]
+  [ "$output" = "$PROJECT_DIR/.tool-versions" ]
+}


### PR DESCRIPTION
# Summary

Adds installing from a parent directory's `.tool-versions` file if found.

Fixes: #236 

## Other Information

I looked quickly to see if there was anything like this in the `utils.sh` but did not see anything. The `while` loops is almost a copy of the one in `find_version` but wanted to keep the addition without refactoring too much. If there is a better way to go about doing this I am open to suggestions.