### PR TITLE
Replace `ref-` prefix in output of list command with `ref:`

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -48,7 +48,7 @@ list_installed_versions() {
   if [ -d "$plugin_installs_path" ]; then
 	# shellcheck disable=SC2045
     for install in $(ls -d "${plugin_installs_path}"/*/ 2>/dev/null); do
-		basename "$install"
+		basename "$install" | sed 's/^ref-/ref:/'
     done
   fi
 }


### PR DESCRIPTION
I've installed an Erlang version with `ref:` as follows:
```
$ asdf install erlang ref:OTP-20.1.2
```

Then `$ asdf list erlang` gives me the following output:
```
$ asdf list erlang
ref-OTP-20.1.2
```

Based on the output (and shell completion), I added the following line in my `.tool-versions`:
```
erlang ref-OTP-20.1.2
```

Then, although I was able to run the specified version of erlang in that machine, I cannot install the specified version using the same `.tool-versions` file in another machine.
[As written in README.md](https://github.com/asdf-vm/asdf#the-tool-versions-file), I should use `ref:` prefix, not `ref-`.
Simply replacing `ref-` with `ref:` resolved the issue.

I think all user-facing version strings should be prefixed with `ref:` instead of `ref-`; `ref-` should only be used as the on-disk representation.
(Please correct me if I misunderstand something!)

This PR simply replaces the prefix parts in output of `$ asdf list` command (and also shell completion).
Thank you!