### PR TITLE
Rename OS X to macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Depending on your OS, run the following
 echo -e '\n. $HOME/.asdf/asdf.sh' >> ~/.bashrc
 echo -e '\n. $HOME/.asdf/completions/asdf.bash' >> ~/.bashrc
 
-# OR for Mac OSX
+# OR for macOS
 echo -e '\n. $HOME/.asdf/asdf.sh' >> ~/.bash_profile
 echo -e '\n. $HOME/.asdf/completions/asdf.bash' >> ~/.bash_profile
 ```
@@ -33,7 +33,7 @@ mkdir -p ~/.config/fish/completions; and cp ~/.asdf/completions/asdf.fish ~/.con
 
 > For most plugins, it is good if you have installed the following packages OR their equivalent on your OS
 
-> * **OS X**: Install these via homebrew `coreutils automake autoconf openssl libyaml readline libxslt libtool unixodbc`
+> * **macOS**: Install these via homebrew `coreutils automake autoconf openssl libyaml readline libxslt libtool unixodbc`
 > * **Ubuntu**: `automake autoconf libreadline-dev libncurses-dev libssl-dev libyaml-dev libxslt-dev libffi-dev libtool unixodbc-dev`
 > * **Fedora**: `automake autoconf readline-devel ncurses-devel openssl-devel libyaml-devel libxslt-devel libffi-devel libtool unixODBC-devel`
 


### PR DESCRIPTION
`macOS` is the new [official name](https://www.apple.com/macos/).