### PR TITLE
Duplicate shims

### DIFF
--- a/lib/commands/reshim.sh
+++ b/lib/commands/reshim.sh
@@ -58,7 +58,7 @@ write_shim_script() {
     cp "$plugin_shims_path/$executable_name" "$shim_path"
   elif [ -f "$shim_path" ]; then
     if ! grep "# asdf-plugin-version: $version" "$shim_path" > /dev/null; then
-     sed -i'' -e "s/\(asdf-plugin: $plugin_name\)/\1\\"$'\n'"# asdf-plugin-version: $version/" "$shim_path"
+     sed -i '' -e "s/\(asdf-plugin: $plugin_name\)/\1\\"$'\n'"# asdf-plugin-version: $version/" "$shim_path"
     fi
   else
     cat <<EOF > "$shim_path"
@@ -210,7 +210,7 @@ remove_shim_for_version() {
     return 0
   fi
 
-  sed -i'' -e "/# asdf-plugin-version: $version/d" "$shim_path"
+  sed -i '' -e "/# asdf-plugin-version: $version/d" "$shim_path"
 
   if [ ! -f "$plugin_shims_path/$executable_name" ] && \
         ! grep "# asdf-plugin-version" "$shim_path" > /dev/null || \

--- a/lib/commands/reshim.sh
+++ b/lib/commands/reshim.sh
@@ -58,7 +58,8 @@ write_shim_script() {
     cp "$plugin_shims_path/$executable_name" "$shim_path"
   elif [ -f "$shim_path" ]; then
     if ! grep "# asdf-plugin-version: $version" "$shim_path" > /dev/null; then
-     sed -i '' -e "s/\(asdf-plugin: $plugin_name\)/\1\\"$'\n'"# asdf-plugin-version: $version/" "$shim_path"
+     sed -i.bak -e "s/\(asdf-plugin: $plugin_name\)/\1\\"$'\n'"# asdf-plugin-version: $version/" "$shim_path"
+     rm "$shim_path".bak
     fi
   else
     cat <<EOF > "$shim_path"
@@ -210,7 +211,8 @@ remove_shim_for_version() {
     return 0
   fi
 
-  sed -i '' -e "/# asdf-plugin-version: $version/d" "$shim_path"
+  sed -i.bak -e "/# asdf-plugin-version: $version/d" "$shim_path"
+  rm "$shim_path".bak
 
   if [ ! -f "$plugin_shims_path/$executable_name" ] && \
         ! grep "# asdf-plugin-version" "$shim_path" > /dev/null || \

--- a/lib/commands/version_commands.sh
+++ b/lib/commands/version_commands.sh
@@ -25,7 +25,8 @@ version_command() {
   done
 
   if [ -f "$file" ] && grep "$plugin" "$file" > /dev/null; then
-    sed -i '' -e "s/$plugin .*/$plugin ${versions[*]}/" "$file"
+    sed -i.bak -e "s/$plugin .*/$plugin ${versions[*]}/" "$file"
+    rm "$file".bak
   else
     echo "$plugin ${versions[*]}" >> "$file"
   fi

--- a/lib/commands/version_commands.sh
+++ b/lib/commands/version_commands.sh
@@ -25,7 +25,7 @@ version_command() {
   done
 
   if [ -f "$file" ] && grep "$plugin" "$file" > /dev/null; then
-    sed -i -e "s/$plugin .*/$plugin ${versions[*]}/" "$file"
+    sed -i '' -e "s/$plugin .*/$plugin ${versions[*]}/" "$file"
   else
     echo "$plugin ${versions[*]}" >> "$file"
   fi

--- a/test/reshim_command.bats
+++ b/test/reshim_command.bats
@@ -48,7 +48,10 @@ teardown() {
 }
 
 @test "reshim should not duplicate shims" {
-  run install_command dummy 1.0
+  cd $PROJECT_DIR
+  echo "dummy 1.0" > .tool-versions
+
+  run install_command
   [ "$status" -eq 0 ]
   [ -f "$ASDF_DIR/shims/dummy" ]
 

--- a/test/reshim_command.bats
+++ b/test/reshim_command.bats
@@ -49,9 +49,9 @@ teardown() {
 
 @test "reshim should not duplicate shims" {
   cd $PROJECT_DIR
-  echo "dummy 1.0" > .tool-versions
 
-  run install_command
+  run install_command dummy 1.0
+  run install_command dummy 1.1
   [ "$status" -eq 0 ]
   [ -f "$ASDF_DIR/shims/dummy" ]
 

--- a/test/reshim_command.bats
+++ b/test/reshim_command.bats
@@ -59,4 +59,8 @@ teardown() {
   run reshim_command dummy
   [ "$status" -eq 0 ]
   [ "1" -eq "$(ls $ASDF_DIR/shims/dummy* | wc -l)" ]
+
+  run reshim_command dummy
+  [ "$status" -eq 0 ]
+  [ "1" -eq "$(ls $ASDF_DIR/shims/dummy* | wc -l)" ]
 }

--- a/test/reshim_command.bats
+++ b/test/reshim_command.bats
@@ -46,3 +46,17 @@ teardown() {
   run grep "asdf-plugin-version: 1.1" "$ASDF_DIR/shims/dummy"
   [ "$status" -eq 0 ]
 }
+
+@test "reshim should not duplicate shims" {
+  run install_command dummy 1.0
+  [ "$status" -eq 0 ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
+
+  run rm $ASDF_DIR/shims/*
+  [ "$status" -eq 0 ]
+  [ "0" -eq "$(ls $ASDF_DIR/shims/dummy* | wc -l)" ]
+
+  run reshim_command dummy
+  [ "$status" -eq 0 ]
+  [ "1" -eq "$(ls $ASDF_DIR/shims/dummy* | wc -l)" ]
+}

--- a/test/version_commands.bats
+++ b/test/version_commands.bats
@@ -63,6 +63,14 @@ teardown() {
   [ "$tool_version_contents" = "dummy 1.1.0" ]
 }
 
+@test "local should not create a duplicate .tool-versions file if such file exists" {
+  echo 'dummy 1.0.0' >> $PROJECT_DIR/.tool-versions
+
+  run local_command "dummy" "1.1.0"
+  [ "$status" -eq 0 ]
+  [ "$(ls $PROJECT_DIR/.tool-versions* | wc -l)" -eq 1 ]
+}
+
 @test "local should overwrite the existing version if it's set" {
   echo 'dummy 1.0.0' >> $PROJECT_DIR/.tool-versions
   run local_command "dummy" "1.1.0"


### PR DESCRIPTION
# Summary

The MacOS version of `sed` requires you to provide a backup extension if you use the `-i` flag. Due to some weirdness in the implementation `-i'' -e` ignores the `''` and uses `-e` as the backup extension. This caused duplicate shims and `.tool-versions` files to show up with `-e` on the end of the filename.

Fixes: #242 

## Other Information

This problem only seems to show up if you don't provide a version to the reshim command. `asdf reshim elixir` would trigger it, but `asdf reshim elixir 1.5.2` would not. This inspired me to add a second dummy version to the reshim test, which does make it consistently fail on my machine without these fixes. However, by the time we reach the problematic sed command I don't see any difference in inputs or execution between user-provided versions or auto-discovered versions, so the exact reasoning there remains a mystery.