### PR TITLE
Add test that greps source code for banned commands.

### DIFF
--- a/test/banned_commands.bats
+++ b/test/banned_commands.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+load test_helpers
+
+banned_commands=(realpath)
+
+setup() {
+  setup_asdf_dir
+}
+
+teardown() {
+  clean_asdf_dir
+}
+
+@test "banned commands are not found in source code" {
+  for cmd in "${banned_commands[@]}"; do
+      # Assert command is not used in the lib and bin dirs
+      run grep -nHR "$cmd" lib bin
+      [ "$status" -eq 1 ]
+      [ "$output" = "" ]
+  done
+}


### PR DESCRIPTION
# Summary

Add test that greps source code for banned commands. Currently I'm only looking for the realpath command, but there are likely many other commands we shouldn't be using if we want to ensure cross platform compatibility.

This should prevent issues like #248 from occurring in the future.

## Other Information

We can add to this test by adding commands to the array of banned commands defined at the top of the file.