### PR TITLE
Fix issue when having Elixir and R plugins installed

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -214,7 +214,7 @@ parse_asdf_version_file() {
 
   if [ -f "$file_path" ]; then
     local version
-	version=$(grep "${plugin_name} " "$file_path" | sed -e "s/^${plugin_name} //")
+	version=$(grep "^${plugin_name} " "$file_path" | sed -e "s/^${plugin_name} //")
     if [ -n "$version" ]; then
       echo "$version"
       return 0


### PR DESCRIPTION
# Summary

When having both Elixir and R plugins installed, and an Elixir version set in `~/.tool-versions`, trying to fetch the current version of R would fail with:

```bash
$ asdf current r
version elixir is not installed for r
```

This happens because `exlixir 1.0` would be a match for `grep "r " ~/.tool-versions`. Adding `^` to the `grep` command to search from the begining of the line line fixes this issue.