### PR TITLE
Add zsh compinit info to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,21 @@ Depending on your OS and shell, run the following:
   
 * Zsh:
 
+    If you are using a framework, such as oh-my-zsh, use these lines. (Be sure that if
+    you make future changes to .zshrc these lines remain *below* the line where you source
+    your framework.)
+    
   ```bash
   echo -e '\n. $HOME/.asdf/asdf.sh' >> ~/.zshrc
   echo -e '\n. $HOME/.asdf/completions/asdf.bash' >> ~/.zshrc
   ```
-
+  If you are not using a framework, or if on starting your shell you get an error message
+  like 'command not found: compinit', then add this line before the ones above.
+  
+  ```bash
+  autoload -Uz compinit && compinit
+  ```
+  
 * Fish:
 
   ```bash


### PR DESCRIPTION
# Summary
Updates README.md to give more detailed installation information to zsh users.

Fixes: #266 