### PR TITLE
add to PATH once. Fixes #261

### DIFF
--- a/asdf.sh
+++ b/asdf.sh
@@ -8,7 +8,9 @@ fi
 
 export ASDF_DIR
 ASDF_DIR="$(cd "$(dirname "$current_script_path")" &> /dev/null || exit 1; pwd)"
-export PATH="${ASDF_DIR}/bin:${ASDF_DIR}/shims:$PATH"
+
+[[ ":$PATH:" != *":${ASDF_DIR}/bin:"* ]] && PATH="${ASDF_DIR}/bin:$PATH"
+[[ ":$PATH:" != *":${ASDF_DIR}/shims:"* ]] && PATH="${ASDF_DIR}/shims:$PATH"
 
 if [ -n "$ZSH_VERSION" ]; then
   autoload -U bashcompinit


### PR DESCRIPTION
# Summary

asdf currently adds itself to PATH even if it's already present. This fix checks whether asdf is within PATH before adding if not found.

Fixes: #261 