### PR TITLE
Add print repo URLs with `asdf plugin-list` and `adsf plugin-list-all`

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ asdf plugin-add <name> <git-url>
 ```bash
 asdf plugin-list
 # asdf plugin-list
+# java            https://github.com/skotchpine/asdf-java.git
+# nodejs          https://github.com/asdf-vm/asdf-nodejs.git
 ```
 
 ##### Remove a plugin

--- a/help.txt
+++ b/help.txt
@@ -1,8 +1,8 @@
 MANAGE PLUGINS
   asdf plugin-add <name> [<git-url>]   Add a plugin from the plugin repo OR, add a Git repo 
                                        as a plugin by specifying the name and repo url
-  asdf plugin-list                     List installed plugins
-  asdf plugin-list-all                 List plugins registered on asdf-plugins repository
+  asdf plugin-list                     List installed plugins with repository URLs
+  asdf plugin-list-all                 List plugins registered on asdf-plugins repository with URLs
   asdf plugin-remove <name>            Remove plugin and package versions
   asdf plugin-update <name>            Update plugin
   asdf plugin-update --all             Update all plugins

--- a/lib/commands/plugin-list-all.sh
+++ b/lib/commands/plugin-list-all.sh
@@ -3,7 +3,14 @@ plugin_list_all_command() {
 
   local plugins_path
   plugins_path="$(asdf_dir)/repository/plugins"
+
+if ls "$plugins_path" &> /dev/null; then
   for plugin in $plugins_path/*; do
-    basename "$plugin"
+    plugin_name=$(basename "$plugin")
+    source_url=$(get_plugin_source_url "$plugin_name")
+    printf "%-15s %s\n" "$plugin_name" "$source_url"
   done
+else
+  printf "%s%s\n" "error: index of plugins not found at " "$plugins_path"
+fi
 }

--- a/lib/commands/plugin-list.sh
+++ b/lib/commands/plugin-list.sh
@@ -4,9 +4,11 @@ plugin_list_command() {
 
   if ls "$plugins_path" &> /dev/null; then
     for plugin_path in $plugins_path/* ; do
-      basename "$plugin_path"
+      plugin_name=$(basename "$plugin_path")
+      source_url=$(get_plugin_source_url "$plugin_name")
+      printf "%-15s %s\n" "$plugin_name" "$source_url"
     done
   else
-    echo 'Oohes nooes ~! No plugins installed'
+    printf "%s\n" "Oohes nooes ~! No plugins installed"
   fi
 }


### PR DESCRIPTION
# Summary
Add print repo URLs with `asdf plugin-list` and `adsf plugin-list-all`.
Fixes #268 

## Other Information

I decided not to use a flag as the raw output is itself not too useful and the terminal can afford the space to always print the URL. I'm happy to update to require a flag, but personally, I think it just adds more cruft to `-h` and README and is ultimately distracting for newcomers.

* Use printf for formatting
* Add error when plugin index at `/asdf_dir/repository/plugins` is not found
* add example of output to README