### PR TITLE
fix Macos nuance with bash sessions messing $PATH

### DIFF
--- a/asdf.sh
+++ b/asdf.sh
@@ -7,7 +7,7 @@ else
 fi
 
 export ASDF_DIR
-ASDF_DIR="$(cd "$(dirname "$current_script_path")" &> /dev/null || exit 1; pwd)"
+ASDF_DIR="$(dirname "$(readlink -f "$current_script_path" 2>/dev/null || greadlink -f "$current_script_path" 2> /dev/null)")"
 
 [[ ":$PATH:" != *":${ASDF_DIR}/bin:"* ]] && PATH="${ASDF_DIR}/bin:$PATH"
 [[ ":$PATH:" != *":${ASDF_DIR}/shims:"* ]] && PATH="${ASDF_DIR}/shims:$PATH"


### PR DESCRIPTION
# Summary
On MacOs there is a known problem with bash sessions which brake env vars.
Changing method of getting script dir fixes this problem

Method for retrieving current script dir in PR works with symlinks and "sourcing script".

On MacOs there is no `readlink`(MacOs is so MacOs) so we have to use `greadlink`

`2>/dev/null` - suppressing command not found for `readlink` under MacOs

Fixes: #279 
