### PR TITLE
Adds curl(1) as a dependency in Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Depending on your OS and shell, run the following:
 > For most plugins, it is good if you have installed the following packages OR their equivalent on your OS
 
 > * **macOS**: Install these via homebrew `coreutils automake autoconf openssl libyaml readline libxslt libtool unixodbc`
-> * **Ubuntu**: `automake autoconf libreadline-dev libncurses-dev libssl-dev libyaml-dev libxslt-dev libffi-dev libtool unixodbc-dev`
+> * **Ubuntu**: `automake autoconf libreadline-dev libncurses-dev libssl-dev libyaml-dev libxslt-dev libffi-dev libtool unixodbc-dev curl`
 > * **Fedora**: `automake autoconf readline-devel ncurses-devel openssl-devel libyaml-devel libxslt-devel libffi-devel libtool unixODBC-devel`
 
 **That's all ~! You are ready to use asdf**


### PR DESCRIPTION
Ubuntu does not ship with `curl(1)` pre-installed.
