### PR TITLE
Suggest action when no version is set

### DIFF
--- a/bin/private/asdf-exec
+++ b/bin/private/asdf-exec
@@ -12,7 +12,7 @@ check_if_plugin_exists "$plugin_name"
 full_version=$(get_preset_version_for "$plugin_name")
 
 if [ "$full_version" == "" ]; then
-  echo "No version set for ${plugin_name}"
+  echo "No version set for ${plugin_name}: please run `asdf <global|local> ${plugin_name} <version>`"
   exit -1
 fi
 

--- a/bin/private/asdf-exec
+++ b/bin/private/asdf-exec
@@ -12,7 +12,7 @@ check_if_plugin_exists "$plugin_name"
 full_version=$(get_preset_version_for "$plugin_name")
 
 if [ "$full_version" == "" ]; then
-  echo "No version set for ${plugin_name}: please run `asdf <global|local> ${plugin_name} <version>`"
+  echo "No version set for ${plugin_name}: please run \`asdf <global|local> ${plugin_name} <version>\`"
   exit -1
 fi
 

--- a/lib/commands/current.sh
+++ b/lib/commands/current.sh
@@ -16,7 +16,7 @@ plugin_current_command() {
   check_for_deprecated_plugin "$plugin_name"
 
   if [ -z "$version" ]; then
-    printf "%s\\n" "No version set for $plugin_name: please run `asdf <global|local> ${plugin_name} <version>`"
+    printf "%s\\n" "No version set for $plugin_name: please run \`asdf <global|local> ${plugin_name} <version>\`"
     exit 1
   else
     printf "%-8s%s\\n" "$version" "(set by $version_file_path)"

--- a/lib/commands/current.sh
+++ b/lib/commands/current.sh
@@ -16,7 +16,7 @@ plugin_current_command() {
   check_for_deprecated_plugin "$plugin_name"
 
   if [ -z "$version" ]; then
-    printf "%s\\n" "No version set for $plugin_name"
+    printf "%s\\n" "No version set for $plugin_name: please run `asdf <global|local> ${plugin_name} <version>`"
     exit 1
   else
     printf "%-8s%s\\n" "$version" "(set by $version_file_path)"

--- a/lib/commands/which.sh
+++ b/lib/commands/which.sh
@@ -14,7 +14,7 @@ current_version() {
   check_for_deprecated_plugin "$plugin_name"
 
   if [ -z "$version" ]; then
-    echo "No version set for $plugin_name: please run `asdf <global|local> ${plugin_name} <version>`"
+    echo "No version set for $plugin_name: please run \`asdf <global|local> ${plugin_name} <version>\`"
     exit 1
   else
     echo "$version"

--- a/lib/commands/which.sh
+++ b/lib/commands/which.sh
@@ -14,7 +14,7 @@ current_version() {
   check_for_deprecated_plugin "$plugin_name"
 
   if [ -z "$version" ]; then
-    echo "No version set for $plugin_name"
+    echo "No version set for $plugin_name: please run `asdf <global|local> ${plugin_name} <version>`"
     exit 1
   else
     echo "$version"

--- a/test/current_command.bats
+++ b/test/current_command.bats
@@ -75,7 +75,7 @@ teardown() {
   echo 'foobar 1.0.0' >> $PROJECT_DIR/.tool-versions
 
   run current_command
-  expected="baz            No version set for baz
+  expected="baz            No version set for baz: please run `asdf <global|local> baz <version>`
 dummy          1.1.0   (set by $PROJECT_DIR/.tool-versions)
 foobar         1.0.0   (set by $PROJECT_DIR/.tool-versions)"
 

--- a/test/current_command.bats
+++ b/test/current_command.bats
@@ -75,7 +75,7 @@ teardown() {
   echo 'foobar 1.0.0' >> $PROJECT_DIR/.tool-versions
 
   run current_command
-  expected="baz            No version set for baz: please run `asdf <global|local> baz <version>`
+  expected="baz            No version set for baz: please run \`asdf <global|local> baz <version>\`
 dummy          1.1.0   (set by $PROJECT_DIR/.tool-versions)
 foobar         1.0.0   (set by $PROJECT_DIR/.tool-versions)"
 


### PR DESCRIPTION
# Summary

These changes give additional information when no version of a plugin is currently set. Using the suggested text from `@pikeas`, it recommends the `asdf` command a user should run.

Fixes: #291
