### PR TITLE
Specify when a version is set via environment variable

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -120,7 +120,11 @@ find_version() {
   local version
   version=$(get_version_from_env "$plugin_name")
   if [ -n "$version" ]; then
-      echo "$version"
+      local upcase_name
+      upcase_name=$(echo "$plugin_name" | tr '[:lower:]' '[:upper:]')
+      local version_env_var="ASDF_${upcase_name}_VERSION"
+
+      echo "$version|$version_env_var environment variable"
       return 0
   fi
 


### PR DESCRIPTION
# Summary

This change creates the following output when a version is set using an environment variable:

```
$ ASDF_ERLANG_VERSION=19.2 asdf current
erlang         19.2    (set by ASDF_ERLANG_VERSION environment variable)
...
```

Fixes: #292 
