### PR TITLE
Refactor "no version set" messages

### DIFF
--- a/bin/private/asdf-exec
+++ b/bin/private/asdf-exec
@@ -12,7 +12,7 @@ check_if_plugin_exists "$plugin_name"
 full_version=$(get_preset_version_for "$plugin_name")
 
 if [ "$full_version" == "" ]; then
-  echo "No version set for ${plugin_name}: please run \`asdf <global|local> ${plugin_name} <version>\`"
+  display_no_version_set "$plugin_name"
   exit -1
 fi
 

--- a/lib/commands/current.sh
+++ b/lib/commands/current.sh
@@ -16,7 +16,7 @@ plugin_current_command() {
   check_for_deprecated_plugin "$plugin_name"
 
   if [ -z "$version" ]; then
-    printf "%s\\n" "No version set for $plugin_name: please run \`asdf <global|local> ${plugin_name} <version>\`"
+    printf "%s\\n" "$(display_no_version_set "$plugin_name")"
     exit 1
   else
     printf "%-8s%s\\n" "$version" "(set by $version_file_path)"

--- a/lib/commands/which.sh
+++ b/lib/commands/which.sh
@@ -14,7 +14,7 @@ current_version() {
   check_for_deprecated_plugin "$plugin_name"
 
   if [ -z "$version" ]; then
-    echo "No version set for $plugin_name: please run \`asdf <global|local> ${plugin_name} <version>\`"
+    display_no_version_set "$plugin_name"
     exit 1
   else
     echo "$version"

--- a/lib/commands/which.sh
+++ b/lib/commands/which.sh
@@ -1,4 +1,4 @@
-current_version() {
+which_command() {
   local plugin_name=$1
 
   check_if_plugin_exists "$plugin_name"
@@ -9,6 +9,7 @@ current_version() {
   version_and_path=$(find_version "$plugin_name" "$search_path")
   local version
   version=$(cut -d '|' -f 1 <<< "$version_and_path");
+  local install_type="version"
 
   check_if_version_exists "$plugin_name" "$version"
   check_for_deprecated_plugin "$plugin_name"
@@ -16,21 +17,10 @@ current_version() {
   if [ -z "$version" ]; then
     display_no_version_set "$plugin_name"
     exit 1
-  else
-    echo "$version"
-    exit 0
   fi
-}
-
-which_command() {
-  local plugin_name=$1
-  local plugin_path
-  plugin_path=$(get_plugin_path "$plugin_name")
-  check_if_plugin_exists "$plugin_name"
-  local install_type="version"
 
   local install_path
-  install_path=$(get_install_path "$plugin_name" "$install_type" "$(current_version "$plugin_name")")
+  install_path=$(get_install_path "$plugin_name" "$install_type" "$version")
 
   if [ -d "$install_path" ]; then
     echo "$install_path/bin/$plugin_name"

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -160,6 +160,11 @@ find_version() {
   fi
 }
 
+display_no_version_set() {
+  local plugin_name=$1
+  echo "No version set for ${plugin_name}; please run \`asdf <global | local> ${plugin_name} <version>\`"
+}
+
 get_version_from_env () {
   local plugin_name=$1
   local upcase_name

--- a/test/current_command.bats
+++ b/test/current_command.bats
@@ -75,7 +75,7 @@ teardown() {
   echo 'foobar 1.0.0' >> $PROJECT_DIR/.tool-versions
 
   run current_command
-  expected="baz            No version set for baz: please run \`asdf <global|local> baz <version>\`
+  expected="baz            No version set for baz; please run \`asdf <global | local> baz <version>\`
 dummy          1.1.0   (set by $PROJECT_DIR/.tool-versions)
 foobar         1.0.0   (set by $PROJECT_DIR/.tool-versions)"
 

--- a/test/which_command.bats
+++ b/test/which_command.bats
@@ -8,6 +8,7 @@ load test_helpers
 setup() {
   setup_asdf_dir
   install_dummy_plugin
+  install_mock_plugin "bazbat"
   run install_command dummy 1.0
 
   PROJECT_DIR=$HOME/project
@@ -23,12 +24,20 @@ teardown() {
 
   echo 'dummy 1.0' >> $PROJECT_DIR/.tool-versions
 
-  run current_version "dummy"
-  [ "$output" = "1.0" ]
-
   run which_command "dummy"
   [ "$status" -eq 0 ]
   [ "$output" = "$ASDF_DIR/installs/dummy/1.0/bin/dummy" ]
+}
+
+@test "which should inform when no version is set" {
+  cd $PROJECT_DIR
+
+  local expected
+  expected="No version set for bazbat; please run \`asdf <global | local> bazbat <version>\`"
+
+  run which_command "bazbat"
+  [ "$status" -eq 1 ]
+  [ "$output" = "$expected" ]
 }
 
 @test "which should error when the plugin doesn't exist" {


### PR DESCRIPTION
# Summary

This PR refactors my previous changes by drawing the "no version set" messages into a utility. It also addresses the odd output from `asdf which` that was caused by running a version check in a subshell. A new test reflects this desired behavior.

Refer: #296

## Other Information

Further refactoring is deserved in `which_command`. Such was likely attempted previously with the unintended consequence of hiding the version check from the user. Also, given how `check_if_version_exists` works currently, the final `else` clause of `which_command` will never run.

/cc @Stratus3D 