### PR TITLE
Fix `plugin-list-all` test

### DIFF
--- a/test/plugin_list_all_command.bats
+++ b/test/plugin_list_all_command.bats
@@ -15,8 +15,8 @@ teardown() {
 
 @test "plugin_list_all list all plugins in the repository" {
   run plugin_list_all_command
-  local expected="bar
-foo"
+  local expected="bar              http://example.com/bar
+foo              http://example.com/foo"
   [ "$status" -eq 0 ]
   [ "$output" = "$expected" ]
 }


### PR DESCRIPTION
# Summary

The `plugin-list-all` test file was not run by `bats` due to the name of the file (`.sh` instead of `.bats`). This has been fixed, and the contents of the expected output now reflect the actual output (including the repository).
