### PR TITLE
AZDF_CONFIG_FILE -> ASDF_CONFIG_FILE typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ legacy_version_file = yes
 
 ## Environment Variables
 
-* `AZDF_CONFIG_FILE` - Defaults to `~/.asdfrc` as described above. Can be set to any location.
+* `ASDF_CONFIG_FILE` - Defaults to `~/.asdfrc` as described above. Can be set to any location.
 * `ASDF_DEFAULT_TOOL_VERSIONS_FILENAME` - The name of the file storing the tool names and versions. Defaults to `.tool-versions`. Can be any valid file name.
 
 ## Uninstall

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -286,8 +286,8 @@ get_asdf_config_value_from_file() {
 
 get_asdf_config_value() {
   local key=$1
-  local config_path=${AZDF_CONFIG_FILE:-"$HOME/.asdfrc"}
-  local default_config_path=${AZDF_CONFIG_DEFAULT_FILE:-"$(asdf_dir)/defaults"}
+  local config_path=${ASDF_CONFIG_FILE:-"$HOME/.asdfrc"}
+  local default_config_path=${ASDF_CONFIG_DEFAULT_FILE:-"$(asdf_dir)/defaults"}
 
   local result
   result=$(get_asdf_config_value_from_file "$config_path" "$key")

--- a/test/get_asdf_config_value.bats
+++ b/test/get_asdf_config_value.bats
@@ -3,14 +3,14 @@
 load test_helpers
 
 setup() {
-    AZDF_CONFIG_FILE=$BATS_TMPDIR/asdfrc
-    cat > $AZDF_CONFIG_FILE <<-EOM
+    ASDF_CONFIG_FILE=$BATS_TMPDIR/asdfrc
+    cat > $ASDF_CONFIG_FILE <<-EOM
 key1 = value1
 legacy_version_file = yes
 EOM
 
-    AZDF_CONFIG_DEFAULT_FILE=$BATS_TMPDIR/asdfrc_defaults
-    cat > $AZDF_CONFIG_DEFAULT_FILE <<-EOM
+    ASDF_CONFIG_DEFAULT_FILE=$BATS_TMPDIR/asdfrc_defaults
+    cat > $ASDF_CONFIG_DEFAULT_FILE <<-EOM
 # i have  a comment, it's ok
 key2 = value2
 legacy_version_file = no
@@ -18,14 +18,14 @@ EOM
 }
 
 teardown() {
-    rm $AZDF_CONFIG_FILE
-    rm $AZDF_CONFIG_DEFAULT_FILE
-    unset AZDF_CONFIG_DEFAULT_FILE
-    unset AZDF_CONFIG_FILE
+    rm $ASDF_CONFIG_FILE
+    rm $ASDF_CONFIG_DEFAULT_FILE
+    unset ASDF_CONFIG_DEFAULT_FILE
+    unset ASDF_CONFIG_FILE
 }
 
 @test "get_config returns default when config file does not exist" {
-    result=$(AZDF_CONFIG_FILE="/some/fake/path" get_asdf_config_value "legacy_version_file")
+    result=$(ASDF_CONFIG_FILE="/some/fake/path" get_asdf_config_value "legacy_version_file")
     [ "$result" = "no" ]
 }
 


### PR DESCRIPTION
update the README so that the `ASDF_CONFIG_FILE` environment variable is
spelled correctly
