### PR TITLE
add or move asdf to front of PATH

### DIFF
--- a/asdf.sh
+++ b/asdf.sh
@@ -9,8 +9,17 @@ fi
 export ASDF_DIR
 ASDF_DIR="$(cd "$(dirname "$current_script_path")" &> /dev/null || exit 1; pwd)"
 
-[[ ":$PATH:" != *":${ASDF_DIR}/bin:"* ]] && PATH="${ASDF_DIR}/bin:$PATH"
-[[ ":$PATH:" != *":${ASDF_DIR}/shims:"* ]] && PATH="${ASDF_DIR}/shims:$PATH"
+# Add asdf to PATH
+#
+# if in $PATH, remove, regardless of if it is in the right place (at the front) or not.
+# replace all occurrences - ${parameter//pattern/string}
+ASDF_BIN="${ASDF_DIR}/bin:"
+ASDF_SHIMS="${ASDF_DIR}/shims:"
+[[ ":$PATH:" == *"${ASDF_BIN}"* ]] && PATH="${PATH//$ASDF_BIN/}"
+[[ ":$PATH:" == *"${ASDF_SHIMS}"* ]] && PATH="${PATH//$ASDF_SHIMS/}"
+# add to front of $PATH
+PATH="${ASDF_DIR}/bin:$PATH"
+PATH="${ASDF_DIR}/shims:$PATH"
 
 if [ -n "$ZSH_VERSION" ]; then
   autoload -U bashcompinit

--- a/asdf.sh
+++ b/asdf.sh
@@ -18,8 +18,8 @@ ASDF_SHIMS="${ASDF_DIR}/shims:"
 [[ ":$PATH:" == *"${ASDF_BIN}"* ]] && PATH="${PATH//$ASDF_BIN/}"
 [[ ":$PATH:" == *"${ASDF_SHIMS}"* ]] && PATH="${PATH//$ASDF_SHIMS/}"
 # add to front of $PATH
-PATH="${ASDF_DIR}/bin:$PATH"
-PATH="${ASDF_DIR}/shims:$PATH"
+PATH="${ASDF_BIN}$PATH"
+PATH="${ASDF_SHIMS}$PATH"
 
 if [ -n "$ZSH_VERSION" ]; then
   autoload -U bashcompinit

--- a/asdf.sh
+++ b/asdf.sh
@@ -15,8 +15,8 @@ ASDF_DIR="$(cd "$(dirname "$current_script_path")" &> /dev/null || exit 1; pwd)"
 # replace all occurrences - ${parameter//pattern/string}
 ASDF_BIN="${ASDF_DIR}/bin:"
 ASDF_SHIMS="${ASDF_DIR}/shims:"
-[[ ":$PATH:" == *"${ASDF_BIN}"* ]] && PATH="${PATH//$ASDF_BIN/}"
-[[ ":$PATH:" == *"${ASDF_SHIMS}"* ]] && PATH="${PATH//$ASDF_SHIMS/}"
+[[ "$PATH:" == *"${ASDF_BIN}"* ]] && PATH="${PATH//$ASDF_BIN/}"
+[[ "$PATH:" == *"${ASDF_SHIMS}"* ]] && PATH="${PATH//$ASDF_SHIMS/}"
 # add to front of $PATH
 PATH="${ASDF_BIN}$PATH"
 PATH="${ASDF_SHIMS}$PATH"


### PR DESCRIPTION
# Summary

Some OSs and shells reorder items within PATH, this can result in the `asdf` entries being moved to the wrong place. This seems to occur on macOS and possibly due to the Tmux login shell option, see here for a discussion: https://github.com/thoughtbot/dotfiles/issues/587#issuecomment-369335238 .

`asdf` detects there are entries already in PATH and so does not prepend them to PATH, but due to the reordering by other tools, it stops functioning as intended.

## Proposed fix
1. Remove any `asdf` entries within PATH, regardless of their position.
2. Prepend the entries to PATH.

For PATHs without `asdf` nothing will be removed. Then the entries will be prepended.
For PATHs with `asdf` entries, they will be removed, even if in the correct position. Then the entries will be prepended.

Fixes: #288 

## Other Information

I noted in https://github.com/asdf-vm/asdf/pull/271 that PATH reordering happens but it didn't occur to me to fix it this way at the time :man_shrugging: sorry?
