### PR TITLE
begin stabalising asdf prepending to PATH logic

### DIFF
--- a/asdf.sh
+++ b/asdf.sh
@@ -15,8 +15,8 @@ ASDF_DIR="$(cd "$(dirname "$current_script_path")" &> /dev/null || exit 1; pwd)"
 # replace all occurrences - ${parameter//pattern/string}
 ASDF_BIN="${ASDF_DIR}/bin:"
 ASDF_SHIMS="${ASDF_DIR}/shims:"
-[[ "$PATH:" == *"${ASDF_BIN}"* ]] && PATH="${PATH//$ASDF_BIN/}"
-[[ "$PATH:" == *"${ASDF_SHIMS}"* ]] && PATH="${PATH//$ASDF_SHIMS/}"
+[[ ":$PATH:" == *"${ASDF_BIN}"* ]] && PATH="${PATH//$ASDF_BIN/}"
+[[ ":$PATH:" == *"${ASDF_SHIMS}"* ]] && PATH="${PATH//$ASDF_SHIMS/}"
 # add to front of $PATH
 PATH="${ASDF_BIN}$PATH"
 PATH="${ASDF_SHIMS}$PATH"

--- a/asdf.sh
+++ b/asdf.sh
@@ -18,8 +18,8 @@ ASDF_SHIMS="${ASDF_DIR}/shims"
 [[ ":$PATH:" == *":${ASDF_BIN}:"* ]] && PATH="${PATH//$ASDF_BIN:/}"
 [[ ":$PATH:" == *":${ASDF_SHIMS}:"* ]] && PATH="${PATH//$ASDF_SHIMS:/}"
 # add to front of $PATH
-PATH="${ASDF_BIN}$PATH"
-PATH="${ASDF_SHIMS}$PATH"
+PATH="${ASDF_BIN}:$PATH"
+PATH="${ASDF_SHIMS}:$PATH"
 
 if [ -n "$ZSH_VERSION" ]; then
   autoload -U bashcompinit

--- a/asdf.sh
+++ b/asdf.sh
@@ -13,10 +13,10 @@ ASDF_DIR="$(cd "$(dirname "$current_script_path")" &> /dev/null || exit 1; pwd)"
 #
 # if in $PATH, remove, regardless of if it is in the right place (at the front) or not.
 # replace all occurrences - ${parameter//pattern/string}
-ASDF_BIN="${ASDF_DIR}/bin:"
-ASDF_SHIMS="${ASDF_DIR}/shims:"
-[[ ":$PATH:" == *"${ASDF_BIN}"* ]] && PATH="${PATH//$ASDF_BIN/}"
-[[ ":$PATH:" == *"${ASDF_SHIMS}"* ]] && PATH="${PATH//$ASDF_SHIMS/}"
+ASDF_BIN="${ASDF_DIR}/bin"
+ASDF_SHIMS="${ASDF_DIR}/shims"
+[[ ":$PATH:" == *":${ASDF_BIN}:"* ]] && PATH="${PATH//$ASDF_BIN:/}"
+[[ ":$PATH:" == *":${ASDF_SHIMS}:"* ]] && PATH="${PATH//$ASDF_SHIMS:/}"
 # add to front of $PATH
 PATH="${ASDF_BIN}$PATH"
 PATH="${ASDF_SHIMS}$PATH"


### PR DESCRIPTION
# Summary

as per suggestion from here - https://github.com/asdf-vm/asdf/pull/303#issuecomment-371231967 :
* remove colon from `ASDF_` variables
* use `:` to normalize PATH
* match against whole `ASDF_` PATH segments
* add `:` back to string replacement - this still doesn't match against asdf segments when last in PATH
* add `:` back to asdf/PATH merging as it's no longer in the `ASDF_` vars

## Other Information

This fix is a stopgap to address the more serious problems (matching partial segments) raised in https://github.com/asdf-vm/asdf/pull/303#issuecomment-371231967 . I plan to address the rest of the issues is another PR with tests for each edge case.