### PR TITLE
add a more robust check for `bins` in `shims` dir for fish shell users

### DIFF
--- a/asdf.fish
+++ b/asdf.fish
@@ -5,7 +5,7 @@ set -l asdf_dir (dirname (status -f))
 # we get an ugly warning when setting the path if shims does not exist
 mkdir -p $asdf_dir/shims
 
-if not contains $asdf_dir/bin $asdf_dir/shims $PATH
-and test -d $asdf/bin and test -d $asdf/shims
-  set -xg PATH $asdf_dir/bin $asdf_dir/shims $PATH
+if not contains $asdf_dir/{bin,shims} $PATH
+and test -d $asdf/{bin,shims}
+  set -gx PATH $asdf_dir/{bin,shims} $PATH
 end

--- a/asdf.fish
+++ b/asdf.fish
@@ -5,4 +5,7 @@ set -l asdf_dir (dirname (status -f))
 # we get an ugly warning when setting the path if shims does not exist
 mkdir -p $asdf_dir/shims
 
-set -xg PATH $asdf_dir/bin $asdf_dir/shims $PATH
+if not contains $asdf_dir/bin $asdf_dir/shims $PATH
+and test -d $asdf/bin and test -d $asdf/shims
+  set -xg PATH $asdf_dir/bin $asdf_dir/shims $PATH
+end


### PR DESCRIPTION
# Summary

Add a more robust check so the `$asdf_dir/{bin,shims}` directories aren't repeatedly added when launching sub shells from the current shell, or launching a program such as tmux.

## Other Information

Just a quick little fix. 👍

Thank you for contributing to asdf!

cheers 🍻
Chris
