### PR TITLE
Change exit code

### DIFF
--- a/bin/private/asdf-exec
+++ b/bin/private/asdf-exec
@@ -13,7 +13,7 @@ full_version=$(get_preset_version_for "$plugin_name")
 
 if [ "$full_version" == "" ]; then
   display_no_version_set "$plugin_name"
-  exit -1
+  exit 126
 fi
 
 # shellcheck disable=SC2162

--- a/bin/private/asdf-exec
+++ b/bin/private/asdf-exec
@@ -24,7 +24,7 @@ for version in "${versions[@]}"; do
 
   if [ "$version" != "system" ] && [ ! -d "$install_path" ]; then
     echo "$plugin_name $version not installed"
-    exit 1
+    exit 127
   fi
 
   if full_executable_path=$(get_executable_path "$plugin_name" "$version" "$executable_path"); then

--- a/lib/commands/current.sh
+++ b/lib/commands/current.sh
@@ -17,7 +17,7 @@ plugin_current_command() {
 
   if [ -z "$version" ]; then
     printf "%s\\n" "$(display_no_version_set "$plugin_name")"
-    exit 1
+    exit 126
   else
     printf "%-8s%s\\n" "$version" "(set by $version_file_path)"
   fi

--- a/test/current_command.bats
+++ b/test/current_command.bats
@@ -48,7 +48,7 @@ teardown() {
   cd $PROJECT_DIR
 
   run current_command "dummy"
-  [ "$status" -eq 1 ]
+  [ "$status" -eq 126 ]
 }
 
 @test "current should error when a version is set that isn't installed" {


### PR DESCRIPTION
# Summary

As discussed in #305, this PR aligns exit codes for plugin not installed and plugin version not set to the one specified in the [BASH Advanced scripting guide](http://tldp.org/LDP/abs/html/exitcodes.html).

Fixes: #305 

## Other informations

Code `127` has been used to exit when the requested plugin version is not installed, resulting in a  "command not found" error.  
Code `126` has been used to exit when there is no version set for the requested plugin, resulting in a "Command invoked cannot execute" error.

Thank you!
