### PR TITLE
List command without parameter lists all installed packages with versions

### DIFF
--- a/lib/commands/list.sh
+++ b/lib/commands/list.sh
@@ -1,9 +1,28 @@
 list_command() {
   local plugin_name=$1
-  check_if_plugin_exists "$plugin_name"
 
+  if [ -z "$plugin_name" ]; then
+    local plugins_path
+    plugins_path=$(get_plugin_path)
+
+    if ls "$plugins_path" &> /dev/null; then
+      for plugin_path in $plugins_path/* ; do
+        plugin_name=$(basename "$plugin_path")
+        echo "$plugin_name"
+        display_installed_versions "$plugin_name"
+      done
+    else
+      printf "%s\\n" 'Oohes nooes ~! No plugins installed'
+    fi
+  else
+    check_if_plugin_exists "$plugin_name"
+    display_installed_versions "$plugin_name"
+  fi
+}
+
+display_installed_versions() {
   local versions
-  versions=$(list_installed_versions "$plugin_name")
+  versions=$(list_installed_versions "$1")
 
   if [ -n "${versions}" ]; then
     for version in $versions; do

--- a/test/list_command.bats
+++ b/test/list_command.bats
@@ -14,13 +14,21 @@ teardown() {
   clean_asdf_dir
 }
 
-@test "list_command should output error when plugin is not installed" {
+@test "list_command should list plugins with installed versions" {
+  run install_command dummy 1.0
+  run install_command dummy 1.1
+  run list_command
+  [ "$(echo -e "dummy\n1.0\n1.1")" == "$output" ]
+  [ "$status" -eq 0 ]
+}
+
+@test "list_command with plugin should output error when plugin is not installed" {
   run list_command dummy
   [ "No versions installed" == "$output" ]
   [ "$status" -eq 1 ]
 }
 
-@test "list_command should list installed versions" {
+@test "list_command with plugin should list installed versions" {
   run install_command dummy 1.0
   run install_command dummy 1.1
   run list_command dummy


### PR DESCRIPTION
# Summary
* Add feature to command `asdf list` to list all installed plugins with versions
* Add test to test the new behaviour, change the title of the existing tests

Fixes: Add ability to list all installed versions of all packages #307 

## Other Information
Feel free to give me feedback (specially for the bash code style)

