### PR TITLE
Feature: Plugin Hook for Custom Executable Path

### DIFF
--- a/bin/private/asdf-exec
+++ b/bin/private/asdf-exec
@@ -27,6 +27,12 @@ for version in "${versions[@]}"; do
     exit 127
   fi
 
+  # custom plugin hook for executable path
+  if [ -f "${plugin_path}/bin/exec-path" ]; then
+    cmd=$(basename "$executable_path")
+    executable_path="$("${plugin_path}/bin/exec-path" "$install_path" "$cmd" "$executable_path")"
+  fi
+
   if full_executable_path=$(get_executable_path "$plugin_name" "$version" "$executable_path"); then
     if [ -f "$full_executable_path" ]; then
       if [ -f "${plugin_path}/bin/exec-env" ]; then

--- a/docs/creating-plugins.md
+++ b/docs/creating-plugins.md
@@ -57,6 +57,21 @@ If this script is not specified, asdf will look for the `bin` dir in an installa
 
 Setup the env to run the binaries in the package.
 
+#### bin/exec-path
+
+Get the executable path for the specified version of the tool. Must print a string with the relative executable path. This allows the plugin to conditionally override the shim's specified executable path, otherwise return the default path specified by the shim.
+
+```
+Usage:
+  plugin/bin/exec-path <install-path> <command> <executable-path>
+
+Example Call:
+  ~/.asdf/plugins/foo/bin/exec-path "~/.asdf/installs/foo/1.0" "foo" "bin/foo"
+
+Output:
+  bin/foox
+```
+
 #### bin/uninstall
 
 Uninstalls a specific version of a tool.


### PR DESCRIPTION
# Summary

This feature allows a plugin to optionally change the executable path of a shim prior to execution. This is useful when the plugin tool has commands that may exist in multiple locations (like npm).

Note: This is related to fixing the `nodejs` [issue #56](https://github.com/asdf-vm/asdf-nodejs/issues/56) which prohibits upgrading the `npm` package command properly.

Provide a general description of the code changes in your pull request.

This is a small update to the `asdf-exec` command which checks for an optional plugin command called `exec-path` which can override the executable path to be used. In most cases this won't be necessary or would fallback to the original executable path specified in the shim file.

Fixes: https://github.com/asdf-vm/asdf-nodejs/issues/56

## Other Information

See sister PR in `nodejs` repo - https://github.com/asdf-vm/asdf-nodejs/pull/74
