### PR TITLE
Include plugin name in error message if plugin doesn't exist

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -54,14 +54,16 @@ list_installed_versions() {
 }
 
 check_if_plugin_exists() {
+  local plugin_name=$1
+
   # Check if we have a non-empty argument
   if [ -z "${1}" ]; then
     display_error "No plugin given"
     exit 1
   fi
 
-  if [ ! -d "$(asdf_dir)/plugins/$1" ]; then
-    display_error "No such plugin"
+  if [ ! -d "$(asdf_dir)/plugins/$plugin_name" ]; then
+    display_error "No such plugin: $plugin_name"
     exit 1
   fi
 }

--- a/test/current_command.bats
+++ b/test/current_command.bats
@@ -41,7 +41,7 @@ teardown() {
 @test "current should error when the plugin doesn't exist" {
   run current_command "foobar"
   [ "$status" -eq 1 ]
-  [ "$output" = "No such plugin" ]
+  [ "$output" = "No such plugin: foobar" ]
 }
 
 @test "current should error when no version is set" {

--- a/test/remove_command.bats
+++ b/test/remove_command.bats
@@ -31,7 +31,7 @@ teardown() {
 @test "plugin_remove_command should exit with 1 when passed invalid plugin name" {
   run plugin_remove_command "does-not-exist"
   [ "$status" -eq 1 ]
-  [ "$output" = "No such plugin" ]
+  [ "$output" = "No such plugin: does-not-exist" ]
 }
 
 @test "plugin_remove_command should remove installed versions" {

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -19,7 +19,7 @@ teardown() {
 @test "check_if_version_exists should exit with 1 if plugin does not exist" {
   run check_if_version_exists "inexistent" "1.0.0"
   [ "$status" -eq 1 ]
-  [ "$output" = "No such plugin" ]
+  [ "$output" = "No such plugin: inexistent" ]
 }
 
 @test "check_if_version_exists should exit with 1 if version does not exist" {

--- a/test/version_commands.bats
+++ b/test/version_commands.bats
@@ -30,7 +30,7 @@ teardown() {
 @test "local should emit an error when plugin does not exist" {
   run local_command "inexistent" "1.0.0"
   [ "$status" -eq 1 ]
-  [ "$output" = "No such plugin" ]
+  [ "$output" = "No such plugin: inexistent" ]
 }
 
 @test "local should emit an error when plugin version does not exist" {

--- a/test/which_command.bats
+++ b/test/which_command.bats
@@ -43,5 +43,5 @@ teardown() {
 @test "which should error when the plugin doesn't exist" {
   run which_command "foobar"
   [ "$status" -eq 1 ]
-  [ "$output" = "No such plugin" ]
+  [ "$output" = "No such plugin: foobar" ]
 }


### PR DESCRIPTION
# Summary

Previously, if we ran a command like `asdf install` and we encountered a
plugin that didn't exist, asdf produces an error saying "No such
plugin". Without knowing which plugin it could be referring too, we'd
have to manually go through each plugin in `.tool-versions` to find the
culprit.

With this commit, we'll now also include the plugin name as part of the
messaging for easier debugging.

## Other information

Before:

```sh
$ asdf install
No such plugin
```

After:

```sh
# assuming `doesnt-work 1.2.3 is in .tool-versions`
$ asdf install
No such plugin: doesnt-work
```