### PR TITLE
Make the exit code of an already installed plugin distinct

### DIFF
--- a/lib/commands/plugin-add.sh
+++ b/lib/commands/plugin-add.sh
@@ -26,7 +26,7 @@ plugin_add_command() {
 
   if [ -d "$plugin_path" ]; then
     display_error "Plugin named $plugin_name already added"
-    exit 1
+    exit 0
   else
     if ! git clone "$source_url" "$plugin_path"; then
       exit 1

--- a/lib/commands/plugin-add.sh
+++ b/lib/commands/plugin-add.sh
@@ -26,7 +26,7 @@ plugin_add_command() {
 
   if [ -d "$plugin_path" ]; then
     display_error "Plugin named $plugin_name already added"
-    exit 0
+    exit 2
   else
     if ! git clone "$source_url" "$plugin_path"; then
       exit 1


### PR DESCRIPTION
When `plugin-add` is called on a plugin that's already installed, asdf will return `0`.

```shell
$ asdf plugin-add elixir
[ clones repository, clones asdf-elixir ]
$ echo $?       # last exit code
0
$ asdf plugin-add elixir
Plugin named elixir already added
$ echo $?
0
```

Connects asdf-vm/asdf#322.

# Summary

As described in asdf-vm/asdf#322, there should be different exit codes for the cases of running `asdf plugin-add <plugin>`:

case | current exit code
----------------|----------------------
new install, successful |  0
already installed | 1
failed to install | 1

To be clear: **I care about case 2** (_already installed_).

Having the same exit code (`1`) for the second and third cases makes it difficult to write scripts to install asdf in production environments (e.g. via Ansible) because running `asdf plugin-add elixir` twice will fail the playbook.

In my opinion, `0` is the proper exit code for running `asdf plugin-add <plugin>` when `<plugin>` is already installed because with a successful exit code, the user should be able to assume that `<plugin>` is now available.

## Other Information

I am open to debate on whether this exit code should be some other value (e.g. `2`), but not `1`.

### Current workaround

```shell
plugin=elixir
if ! asdf plugin-list | grep $plugin > /dev/null; then
   asdf plugin-add $plugin
fi
```