### PR TITLE
Fix another spot for plugin-name env var lookup

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -123,7 +123,7 @@ find_version() {
   version=$(get_version_from_env "$plugin_name")
   if [ -n "$version" ]; then
       local upcase_name
-      upcase_name=$(echo "$plugin_name" | tr '[:lower:]' '[:upper:]')
+      upcase_name=$(echo "$plugin_name" | tr '[:lower:]-' '[:upper:]_')
       local version_env_var="ASDF_${upcase_name}_VERSION"
 
       echo "$version|$version_env_var environment variable"


### PR DESCRIPTION
After fixing #319 I wondered if there were any other spots where the same/similar bug existed.  I found one other location at line 126 in utils.sh.
