### PR TITLE
Fix for #330 - "asdf list" spacing

### DIFF
--- a/lib/commands/list.sh
+++ b/lib/commands/list.sh
@@ -26,7 +26,7 @@ display_installed_versions() {
 
   if [ -n "${versions}" ]; then
     for version in $versions; do
-      echo "$version"
+      echo "  $version"
     done
   else
     display_error 'No versions installed'

--- a/test/list_command.bats
+++ b/test/list_command.bats
@@ -18,7 +18,7 @@ teardown() {
   run install_command dummy 1.0
   run install_command dummy 1.1
   run list_command
-  [ "$(echo -e "dummy\n1.0\n1.1")" == "$output" ]
+  [ "$(echo -e "dummy\n  1.0\n  1.1")" == "$output" ]
   [ "$status" -eq 0 ]
 }
 
@@ -32,6 +32,6 @@ teardown() {
   run install_command dummy 1.0
   run install_command dummy 1.1
   run list_command dummy
-  [ "$(echo -e "1.0\n1.1")" == "$output" ]
+  [ "$(echo -e "  1.0\n  1.1")" == "$output" ]
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
In order to make the output of "asdf list" a bit easier to read, this commit adds two spaces to the front of each version being written so as to indent them under the plugin.