### PR TITLE
Install data outside asdf installation directory

### DIFF
--- a/asdf.fish
+++ b/asdf.fish
@@ -1,11 +1,11 @@
 #!/usr/bin/env fish
 
-set -l asdf_dir (dirname (status -f))
+set -l asdf_data_dir (dirname (status -f))
 
 # we get an ugly warning when setting the path if shims does not exist
-mkdir -p $asdf_dir/shims
+mkdir -p $asdf_data_dir/shims
 
-for x in $asdf_dir/{bin,shims}
+for x in $asdf_data_dir/{bin,shims}
   if not contains $x $PATH
   and test -d $x
     set -gx PATH $x $PATH

--- a/asdf.sh
+++ b/asdf.sh
@@ -17,8 +17,10 @@ ASDF_DIR="$(dirname "$current_script_path")"
 # replace all occurrences - ${parameter//pattern/string}
 ASDF_BIN="${ASDF_DIR}/bin"
 ASDF_SHIMS="${ASDF_DIR}/shims"
+ASDF_USER_SHIMS="${HOME}/.asdf/shims"
 [[ ":$PATH:" == *":${ASDF_BIN}:"* ]] && PATH="${PATH//$ASDF_BIN:/}"
 [[ ":$PATH:" == *":${ASDF_SHIMS}:"* ]] && PATH="${PATH//$ASDF_SHIMS:/}"
+[[ ":$PATH:" == *":${ASDF_USER_SHIMS}:"* ]] && PATH="${PATH//$ASDF_USER_SHIMS:/}"
 # add to front of $PATH
 PATH="${ASDF_BIN}:$PATH"
 PATH="${ASDF_SHIMS}:$PATH"

--- a/asdf.sh
+++ b/asdf.sh
@@ -17,7 +17,7 @@ ASDF_DIR="$(dirname "$current_script_path")"
 # replace all occurrences - ${parameter//pattern/string}
 ASDF_BIN="${ASDF_DIR}/bin"
 ASDF_SHIMS="${ASDF_DIR}/shims"
-ASDF_USER_SHIMS="${HOME}/.asdf/shims"
+ASDF_USER_SHIMS="${ASDF_DATA_DIR:-$HOME/.asdf}"
 [[ ":$PATH:" == *":${ASDF_BIN}:"* ]] && PATH="${PATH//$ASDF_BIN:/}"
 [[ ":$PATH:" == *":${ASDF_SHIMS}:"* ]] && PATH="${PATH//$ASDF_SHIMS:/}"
 [[ ":$PATH:" == *":${ASDF_USER_SHIMS}:"* ]] && PATH="${PATH//$ASDF_USER_SHIMS:/}"

--- a/lib/commands/plugin-add.sh
+++ b/lib/commands/plugin-add.sh
@@ -22,7 +22,7 @@ plugin_add_command() {
   local plugin_path
   plugin_path=$(get_plugin_path "$plugin_name")
 
-  mkdir -p "$(asdf_dir)/plugins"
+  mkdir -p "$(asdf_data_dir)/plugins"
 
   if [ -d "$plugin_path" ]; then
     display_error "Plugin named $plugin_name already added"

--- a/lib/commands/plugin-list-all.sh
+++ b/lib/commands/plugin-list-all.sh
@@ -2,7 +2,7 @@ plugin_list_all_command() {
   initialize_or_update_repository
 
   local plugins_index_path
-  plugins_index_path="$(asdf_dir)/repository/plugins"
+  plugins_index_path="$(asdf_data_dir)/repository/plugins"
 
   local plugins_local_path
   plugins_local_path="$(get_plugin_path)"

--- a/lib/commands/plugin-push.sh
+++ b/lib/commands/plugin-push.sh
@@ -1,7 +1,7 @@
 plugin_push_command() {
   local plugin_name=$1
   if [ "$plugin_name" = "--all" ]; then
-    for dir in "$(asdf_dir)"/plugins/*; do
+    for dir in "$(asdf_data_dir)"/plugins/*; do
       echo "Pushing $(basename "$dir")..."
       (cd "$dir" && git push)
     done

--- a/lib/commands/plugin-remove.sh
+++ b/lib/commands/plugin-remove.sh
@@ -6,7 +6,7 @@ plugin_remove_command() {
   plugin_path=$(get_plugin_path "$plugin_name")
 
   rm -rf "$plugin_path"
-  rm -rf "$(asdf_dir)/installs/${plugin_name}"
+  rm -rf "$(asdf_data_dir)/installs/${plugin_name}"
 
-  grep -l "asdf-plugin: ${plugin_name}" "$(asdf_dir)"/shims/* 2>/dev/null | xargs rm -f
+  grep -l "asdf-plugin: ${plugin_name}" "$(asdf_data_dir)"/shims/* 2>/dev/null | xargs rm -f
 }

--- a/lib/commands/plugin-update.sh
+++ b/lib/commands/plugin-update.sh
@@ -6,7 +6,7 @@ plugin_update_command() {
 
   local plugin_name=$1
   if [ "$plugin_name" = "--all" ]; then
-    for dir in "$(asdf_dir)"/plugins/*; do
+    for dir in "$(asdf_data_dir)"/plugins/*; do
       echo "Updating $(basename "$dir")..."
       (cd "$dir" && git pull)
     done

--- a/lib/commands/reshim.sh
+++ b/lib/commands/reshim.sh
@@ -23,7 +23,7 @@ reshim_command() {
   else
     # generate for all versions of the package
     local plugin_installs_path
-    plugin_installs_path="$(asdf_dir)/installs/${plugin_name}"
+    plugin_installs_path="$(asdf_data_dir)/installs/${plugin_name}"
 
     for install in "${plugin_installs_path}"/*/; do
       local full_version_name
@@ -37,8 +37,8 @@ reshim_command() {
 
 ensure_shims_dir() {
   # Create shims dir if doesn't exist
-  if [ ! -d "$(asdf_dir)/shims" ]; then
-    mkdir "$(asdf_dir)/shims"
+  if [ ! -d "$(asdf_data_dir)/shims" ]; then
+    mkdir "$(asdf_data_dir)/shims"
   fi
 }
 
@@ -52,7 +52,7 @@ write_shim_script() {
   local plugin_shims_path
   plugin_shims_path=$(get_plugin_path "$plugin_name")/shims
   local shim_path
-  shim_path="$(asdf_dir)/shims/$executable_name"
+  shim_path="$(asdf_data_dir)/shims/$executable_name"
 
   if [ -f "$plugin_shims_path/$executable_name" ]; then
     cp "$plugin_shims_path/$executable_name" "$shim_path"
@@ -169,7 +169,7 @@ remove_obsolete_shims() {
   local plugin_name=$1
   local full_version=$2
   local shims_path
-  shims_path="$(asdf_dir)/shims"
+  shims_path="$(asdf_data_dir)/shims"
 
   IFS=':' read -r -a version_info <<< "$full_version"
   if [ "${version_info[0]}" = "ref" ]; then
@@ -203,7 +203,7 @@ remove_shim_for_version() {
   local plugin_shims_path
   plugin_shims_path=$(get_plugin_path "$plugin_name")/shims
   local shim_path
-  shim_path="$(asdf_dir)/shims/$executable_name"
+  shim_path="$(asdf_data_dir)/shims/$executable_name"
   local count_installed
   count_installed=$(list_installed_versions "$plugin_name" | wc -l)
 

--- a/lib/commands/update.sh
+++ b/lib/commands/update.sh
@@ -2,7 +2,7 @@ update_command() {
   local update_to_head=$1
 
   (
-  cd "$(asdf_dir)" || exit 1
+  cd "$(asdf_data_dir)" || exit 1
 
   if [ -f asdf_updates_disabled ]; then
     echo "Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf."

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -33,10 +33,10 @@ get_install_type(){
 asdf_data_dir(){
   local data_dir
 
-  if [ "$(get_install_type)" = "user" ]; then
-    data_dir="${HOME}/.asdf"
+  if ! [ -z "${ASDF_DATA_DIR}" ]; then
+    data_dir="${ASDF_DATA_DIR}"
   else
-    data_dir="$(asdf_dir)"
+    data_dir="$HOME/.asdf"
   fi
 
   echo "$data_dir"
@@ -65,16 +65,13 @@ list_installed_versions() {
   local plugin_path
   plugin_path=$(get_plugin_path "$plugin_name")
 
-  local install_dir
-  install_dir="$(asdf_data_dir)/installs"
-
   local plugin_installs_path
-  plugin_installs_path=${install_dir}/${plugin_name}
+  plugin_installs_path="$(asdf_data_dir)/installs/${plugin_name}"
 
   if [ -d "$plugin_installs_path" ]; then
-	# shellcheck disable=SC2045
+  # shellcheck disable=SC2045
     for install in $(ls -d "${plugin_installs_path}"/*/ 2>/dev/null); do
-		basename "$install" | sed 's/^ref-/ref:/'
+    basename "$install" | sed 's/^ref-/ref:/'
     done
   fi
 }

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -124,6 +124,14 @@ teardown() {
   [ "$output" = "0.1.0|$HOME/.tool-versions" ]
 }
 
+@test "asdf_data_dir should return user dir if configured" {
+  echo "install_type = user" > $HOME/.asdfrc
+
+  run asdf_data_dir
+  [ "$status" -eq 0 ]
+  [ "$output" = "$HOME/.asdf" ]
+}
+
 @test "find_version should return \$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME if set" {
   ASDF_DEFAULT_TOOL_VERSIONS_FILENAME="$PROJECT_DIR/global-tool-versions"
   echo "dummy 0.1.0" > $ASDF_DEFAULT_TOOL_VERSIONS_FILENAME

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -125,11 +125,11 @@ teardown() {
 }
 
 @test "asdf_data_dir should return user dir if configured" {
-  echo "install_type = user" > $HOME/.asdfrc
+  ASDF_DATA_DIR="/tmp/wadus"
 
   run asdf_data_dir
   [ "$status" -eq 0 ]
-  [ "$output" = "$HOME/.asdf" ]
+  [ "$output" = "$ASDF_DATA_DIR" ]
 }
 
 @test "find_version should return \$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME if set" {


### PR DESCRIPTION
# Summary

This reads a custom configuration variable `install_type`, that can be set to `user` and changes the installation directory from where`asdf` installation is to `$HOME/.asdf`. 

Fixes: #275 

## Other Information

This fixes the problem that users experience using `asdf` with `brew`
