### PR TITLE
Symlink fix and tests

### DIFF
--- a/lib/commands/version_commands.sh
+++ b/lib/commands/version_commands.sh
@@ -17,12 +17,18 @@ version_command() {
     file="$(pwd)/.tool-versions"
   fi
 
+  if [ -L "$file" ]; then
+      # Resolve file path if symlink
+      file="$(resolve_symlink "$file")"
+  fi
+
   check_if_plugin_exists "$plugin"
 
   local version
   for version in "${versions[@]}"; do
     check_if_version_exists "$plugin" "$version"
   done
+
 
   if [ -f "$file" ] && grep "^$plugin " "$file" > /dev/null; then
     sed -i.bak -e "s/^$plugin .*$/$plugin ${versions[*]}/" "$file"

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -360,6 +360,7 @@ resolve_symlink() {
     symlink="$1"
 
     # This seems to be the only cross-platform way to resolve symlink paths to
-    # the real file path
+    # the real file path.
+    # shellcheck disable=SC2012
     ls -l "$symlink" | sed -e "s|.*-> \(.*\)|\1|"
 }

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -362,5 +362,5 @@ resolve_symlink() {
     # This seems to be the only cross-platform way to resolve symlink paths to
     # the real file path.
     # shellcheck disable=SC2012
-    ls -l "$symlink" | sed -e "s|.*-> \(.*\)|\1|"
+    ls -l "$symlink" | sed -e 's|.*-> \(.*\)|\1|'
 }

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -354,3 +354,12 @@ find_tool_versions() {
         search_path=$(dirname "$search_path")
     done
 }
+
+resolve_symlink() {
+    local symlink
+    symlink="$1"
+
+    # This seems to be the only cross-platform way to resolve symlink paths to
+    # the real file path
+    ls -l "$symlink" | sed -e "s|.*-> \(.*\)|\1|"
+}

--- a/test/banned_commands.bats
+++ b/test/banned_commands.bats
@@ -2,7 +2,14 @@
 
 load test_helpers
 
-banned_commands=(realpath eval)
+banned_commands=(
+    realpath
+    # readlink on OSX behaves differently from readlink on other Unix systems
+    readlink
+    # It's best to avoid eval as it makes it easier to accidentally execute
+    # arbitrary strings
+    eval
+    )
 
 setup() {
   setup_asdf_dir

--- a/test/version_commands.bats
+++ b/test/version_commands.bats
@@ -139,3 +139,47 @@ teardown() {
   [ "$(cat $ASDF_DEFAULT_TOOL_VERSIONS_FILENAME)" = "dummy 1.1.0" ]
   [ "$(cat $HOME/.tool-versions)" = "" ]
 }
+
+@test "local should preserve symlinks when setting versions" {
+  mkdir other-dir
+  touch other-dir/.tool-versions
+  ln -s other-dir/.tool-versions .tool-versions
+  run local_command "dummy" "1.1.0"
+  [ "$status" -eq 0 ]
+  [ -L .tool-versions ]
+  [ "$(cat other-dir/.tool-versions)" = "dummy 1.1.0" ]
+}
+
+@test "local should preserve symlinks when updating versions" {
+  mkdir other-dir
+  touch other-dir/.tool-versions
+  ln -s other-dir/.tool-versions .tool-versions
+  run local_command "dummy" "1.1.0"
+  run local_command "dummy" "1.1.0"
+  [ "$status" -eq 0 ]
+  [ -L .tool-versions ]
+  [ "$(cat other-dir/.tool-versions)" = "dummy 1.1.0" ]
+}
+
+@test "global should preserve symlinks when setting versions" {
+  mkdir other-dir
+  touch other-dir/.tool-versions
+  ln -s other-dir/.tool-versions $HOME/.tool-versions
+
+  run global_command "dummy" "1.1.0"
+  [ "$status" -eq 0 ]
+  [ -L $HOME/.tool-versions ]
+  [ "$(cat other-dir/.tool-versions)" = "dummy 1.1.0" ]
+}
+
+@test "global should preserve symlinks when updating versions" {
+  mkdir other-dir
+  touch other-dir/.tool-versions
+  ln -s other-dir/.tool-versions $HOME/.tool-versions
+
+  run global_command "dummy" "1.1.0"
+  run global_command "dummy" "1.1.0"
+  [ "$status" -eq 0 ]
+  [ -L $HOME/.tool-versions ]
+  [ "$(cat other-dir/.tool-versions)" = "dummy 1.1.0" ]
+}


### PR DESCRIPTION
# Summary

Wrote failing tests for the version-changing code for the `asdf global` and `asdf local` functions. I then wrote some code to resolve symlink paths before they make it to the code that actually edits the file, so it edits the real file instead of replacing the symlink with a real file.

Fixes: #329 
