### PR TITLE
Fix issue with Fish shell shim loading script

### DIFF
--- a/asdf.fish
+++ b/asdf.fish
@@ -5,7 +5,9 @@ set -l asdf_dir (dirname (status -f))
 # we get an ugly warning when setting the path if shims does not exist
 mkdir -p $asdf_dir/shims
 
-if not contains $asdf_dir/{bin,shims} $PATH
-and test -d $asdf/{bin,shims}
-  set -gx PATH $asdf_dir/{bin,shims} $PATH
+for x in $asdf_dir/{bin,shims}
+  if not contains $x $PATH
+  and test -d $x
+    set -gx PATH $x $PATH
+  end
 end


### PR DESCRIPTION
Currently, `asdf.fish` uses incorrect arguments for Fish's `contains` and `test` command builtins. 

This fixes the script to use valid arguments patterns.
