### PR TITLE
Allow for at least one space when printing versions in asdf current

### DIFF
--- a/lib/commands/current.sh
+++ b/lib/commands/current.sh
@@ -19,14 +19,18 @@ plugin_current_command() {
     printf "%s\\n" "$(display_no_version_set "$plugin_name")"
     exit 126
   else
-    printf "%-8s%s\\n" "$version" "(set by $version_file_path)"
+    width=$(( 1 + ${#version} ))
+    [[ $width -ge 8 ]] || width=8
+    printf "%-*s%s\\n" $width "$version" "(set by $version_file_path)"
   fi
 }
 
 current_command() {
   if [ $# -eq 0 ]; then
     for plugin in $(plugin_list_command); do
-      printf "%-15s%s\\n" "$plugin" "$(plugin_current_command "$plugin")" >&2
+      width=$(( 1 + ${#plugin} ))
+      [[ $width -ge 15 ]] || width=15
+      printf "%-*s%s\\n" $width "$plugin" "$(plugin_current_command "$plugin")" >&2
     done
   else
     local plugin=$1


### PR DESCRIPTION
# Summary

When `asdf current` prints, plugins with long names or long version strings lose the space between plugin name and version or plugin version and the note ("(set by ...)").
For example, for the `java` plugin:
`java           oracle-8.181(set by PATH_HERE/.tool-versions)`

Personally, and this is a matter of preference, `asdf current` or other tools shouldn't attempt to pretty print and should instead produce machine-readable output that would be easy for the user to format.
Should this opinion be adopted by the project, this PR would devolve to simply adding a simple space between the two pieces of data being `printf`ed.