### PR TITLE
Make help text reflect that <name> and <version> are optional in `asdf install` command

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -10,7 +10,7 @@ MANAGE PLUGINS
 
 
 MANAGE PACKAGES
-  asdf install <name> <version>        Install a specific version of a package or,
+  asdf install [<name> <version>]      Install a specific version of a package or,
                                        with no arguments, install all the package
                                        versions listed in the .tool-versions file
   asdf uninstall <name> <version>      Remove a specific version of a package


### PR DESCRIPTION
The help text shows `<name>` and `<version>` as required options to `asdf install` when they, as a group, are optional. This pull request fixes that.
