### PR TITLE
Fix reshim to generate shims only for executable files and not directories.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# asdf [![Build Status](https://travis-ci.org/asdf-vm/asdf.svg?branch=master)](https://travis-ci.org/asdf-vm/asdf)
+# asdf [![Build Status](https://travis-ci.org/teixeiradiego/asdf.svg?branch=master)](https://travis-ci.org/teixeiradiego/asdf)
 
 ### _extendable version manager_
 

--- a/lib/commands/reshim.sh
+++ b/lib/commands/reshim.sh
@@ -143,7 +143,7 @@ generate_shims_for_version() {
       # because just $executable_file gives absolute path; We don't want version hardcoded in shim
       local executable_path_relative_to_install_path
       executable_path_relative_to_install_path="$bin_path"/$(basename "$executable_file")
-      if [ -x "$executable_file" ]; then
+      if [[ (-f "$executable_file") && (-x "$executable_file") ]]; then
         write_shim_script "$plugin_name" "$version" "$executable_path_relative_to_install_path"
       fi
     done


### PR DESCRIPTION
# Summary

Change reshim to generate shims only for executable files and not directories. 

Problem: When you have sub-directories inside bin path directory, it uses to create shims for the executable file and for all directories inside the path and it causes the error: "No such command in [version] of [plugin-name]"

Fixes: No open issue found with this error description.
