### PR TITLE
Fix reshim to generate shims only for executable files and not directories.

### DIFF
--- a/lib/commands/reshim.sh
+++ b/lib/commands/reshim.sh
@@ -143,7 +143,7 @@ generate_shims_for_version() {
       # because just $executable_file gives absolute path; We don't want version hardcoded in shim
       local executable_path_relative_to_install_path
       executable_path_relative_to_install_path="$bin_path"/$(basename "$executable_file")
-      if [ -x "$executable_file" ]; then
+      if [[ (-f "$executable_file") && (-x "$executable_file") ]]; then
         write_shim_script "$plugin_name" "$version" "$executable_path_relative_to_install_path"
       fi
     done

--- a/test/fixtures/dummy_plugin/bin/install
+++ b/test/fixtures/dummy_plugin/bin/install
@@ -10,3 +10,4 @@ cat <<EOF > "$ASDF_INSTALL_PATH/bin/dummy"
 echo This is Dummy ${ASDF_INSTALL_VERSION}! \$2 \$1
 EOF
 chmod +x "$ASDF_INSTALL_PATH/bin/dummy"
+mkdir -p "$ASDF_INSTALL_PATH/bin/subdir"

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -72,6 +72,15 @@ teardown() {
   [ "$lines_count" -eq "1" ]
 }
 
+@test "install_command should not generate shim for subdir" {
+  cd $PROJECT_DIR
+  echo 'dummy 1.0' > $PROJECT_DIR/.tool-versions
+
+  run install_command
+  [ "$status" -eq 0 ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
+  [ ! -f "$ASDF_DIR/shims/subdir" ]
+}
 
 @test "install_command generated shim should pass all arguments to executable" {
   # asdf lib needed to run generated shims

--- a/test/reshim_command.bats
+++ b/test/reshim_command.bats
@@ -67,3 +67,24 @@ teardown() {
   [ "$status" -eq 0 ]
   [ "1" -eq "$(ls $ASDF_DIR/shims/dummy* | wc -l)" ]
 }
+
+@test "reshim should create shims only for files and not folders" {
+  cd $PROJECT_DIR
+
+  run install_command dummy 1.0
+  run install_command dummy 1.1
+  [ "$status" -eq 0 ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
+  [ ! -f "$ASDF_DIR/shims/subdir" ]
+
+  run rm $ASDF_DIR/shims/*
+  [ "$status" -eq 0 ]
+  [ "0" -eq "$(ls $ASDF_DIR/shims/dummy* | wc -l)" ]
+  [ "0" -eq "$(ls $ASDF_DIR/shims/subdir* | wc -l)" ]
+
+  run reshim_command dummy
+  [ "$status" -eq 0 ]
+  [ "1" -eq "$(ls $ASDF_DIR/shims/dummy* | wc -l)" ]
+  [ "0" -eq "$(ls $ASDF_DIR/shims/subdir* | wc -l)" ]
+
+}


### PR DESCRIPTION
# Summary

Change reshim to generate shims only for executable files and not directories. 

Problem: When you have sub-directories inside bin path directory, it uses to create shims for the executable file and for all directories inside the path and it causes the error: "No such command in [version] of [plugin-name]"

Fixes: No open issue found with this error description.
