### PR TITLE
Add the default asdf_data_dir to path

### DIFF
--- a/asdf.fish
+++ b/asdf.fish
@@ -1,6 +1,6 @@
 #!/usr/bin/env fish
 
-set -l asdf_data_dir (dirname (status -f))
+set -l asdf_data_dir $HOME/.asdf (dirname (status -f))
 
 # we get an ugly warning when setting the path if shims does not exist
 mkdir -p $asdf_data_dir/shims


### PR DESCRIPTION
# Summary

If fish shell users install the asdf by homebrew, can't use commands in $HOME/.asdf/shims.
So, I added the path.

## Other Information

If there is anything else that is relevant to your pull request include that
information here.

Thank you for contributing to asdf!
