### PR TITLE
Add 'asdf local -p' command.

### DIFF
--- a/test/version_commands.bats
+++ b/test/version_commands.bats
@@ -114,6 +114,7 @@ teardown() {
 
 @test "local -p/--parent should allow multiple versions" {
   cd $CHILD_DIR
+  touch $PROJECT_DIR/.tool-versions
   run local_command -p "dummy" "1.1.0" "1.0.0"
   [ "$status" -eq 0 ]
   [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0 1.0.0" ]
@@ -129,7 +130,7 @@ teardown() {
 
 @test "local -p/--parent should set the version if it's unset" {
   cd $CHILD_DIR
-  echo 'dummy 1.0.0' >> $PROJECT_DIR/.tool-versions
+  touch $PROJECT_DIR/.tool-versions
   run local_command -p "dummy" "1.1.0"
   [ "$status" -eq 0 ]
   [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0" ]


### PR DESCRIPTION
# Summary

Add -p/--parent flag to `asdf local` command to tell it to crawl up the directory tree to find the nearest `.tool-versions` set the version there, rather than creating a `.tool-versions` file in the current directory if it doesn't exist.

Fixes: #65
