### PR TITLE
plugin-test fixes

### DIFF
--- a/lib/commands/plugin-test.sh
+++ b/lib/commands/plugin-test.sh
@@ -8,24 +8,25 @@ plugin_test_command() {
     local exit_code
     local TEST_DIR
 
-    TEST_DIR=$(mktemp -dt asdf.XXXX)
-    git clone "$ASDF_DIR/.git" "$TEST_DIR"
-
     fail_test() {
         echo "FAILED: $1"
         rm -rf "$TEST_DIR"
         exit 1
     }
 
+    if [ -z "$plugin_name" ] || [ -z "$plugin_url" ]; then
+      fail_test "please provide a plugin name and url"
+    fi
+
+    TEST_DIR=$(mktemp -dt asdf.XXXX)
+    git clone "$ASDF_DIR/.git" "$TEST_DIR"
+
     plugin_test() {
         export ASDF_DIR=$TEST_DIR
+        export ASDF_DATA_DIR=$TEST_DIR
 
         # shellcheck disable=SC1090
         source "$ASDF_DIR/asdf.sh"
-
-        if [ -z "$plugin_name" ] || [ -z "$plugin_url" ]; then
-            fail_test "please provide a plugin name and url"
-        fi
 
         if ! (asdf plugin-add "$plugin_name" "$plugin_url"); then
             fail_test "could not install $plugin_name from $plugin_url"

--- a/test/plugin_test_command.bats
+++ b/test/plugin_test_command.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+
+load test_helpers
+
+. $(dirname $BATS_TEST_DIRNAME)/lib/commands/plugin-add.sh
+. $(dirname $BATS_TEST_DIRNAME)/lib/commands/plugin-list.sh
+. $(dirname $BATS_TEST_DIRNAME)/lib/commands/plugin-test.sh
+
+setup() {
+  setup_asdf_dir
+}
+
+teardown() {
+  clean_asdf_dir
+}
+
+@test "plugin_test_command with no URL specified prints an error" {
+  run plugin_test_command "elixir"
+  [ "$status" -eq 1 ]
+  [ "$output" = "FAILED: please provide a plugin name and url" ]
+}
+
+@test "plugin_test_command with no name or URL specified prints an error" {
+  run plugin_test_command
+  [ "$status" -eq 1 ]
+  [ "$output" = "FAILED: please provide a plugin name and url" ]
+}


### PR DESCRIPTION
# Summary

Fixes the error in plugin-test command caused by unset `ASDF_DATA_DIR` environment variable. Add primitive unit tests for the plugin-test command.

Fixes: #373 