### PR TITLE
Optimise listing all plugins

### DIFF
--- a/lib/commands/plugin-list-all.sh
+++ b/lib/commands/plugin-list-all.sh
@@ -13,10 +13,7 @@ plugin_list_all_command() {
       source_url=$(get_plugin_source_url "$index_plugin_name")
       installed_flag=""
 
-      for local_plugin in "$plugins_local_path"/*; do
-      local_plugin_name=$(basename "$local_plugin")
-        [[ "$index_plugin_name" == "$local_plugin_name" ]] && installed_flag="*"
-      done
+      [[ -d "${plugins_local_path}/${index_plugin_name}" ]] && installed_flag='*'
 
       printf "%-15s %-1s%s\\n" "$index_plugin_name" "$installed_flag" "$source_url"
     done

--- a/test/fixtures/dummy_plugins_repo/plugins/dummy
+++ b/test/fixtures/dummy_plugins_repo/plugins/dummy
@@ -1,0 +1,1 @@
+repository = http://example.com/dummy

--- a/test/plugin_list_all_command.bats
+++ b/test/plugin_list_all_command.bats
@@ -7,6 +7,7 @@ load test_helpers
 setup() {
   setup_asdf_dir
   setup_repo
+  install_dummy_plugin
 }
 
 teardown() {
@@ -16,6 +17,7 @@ teardown() {
 @test "plugin_list_all list all plugins in the repository" {
   run plugin_list_all_command
   local expected="bar              http://example.com/bar
+dummy           *http://example.com/dummy
 foo              http://example.com/foo"
   [ "$status" -eq 0 ]
   [ "$output" = "$expected" ]


### PR DESCRIPTION
# Summary

When checking if a plugin is installed (to display a flag) it is not
necessary to loop through all installed plugins, since we already have
a name we can check directly.

Also expand test case to test this code path too.
