### PR TITLE
Make where command default to current version

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -16,7 +16,7 @@ MANAGE PACKAGES
   asdf uninstall <name> <version>      Remove a specific version of a package
   asdf current                         Display current version set or being used for all packages
   asdf current <name>                  Display current version set or being used for package
-  asdf where <name> <version>          Display install path for an installed version
+  asdf where <name> [<version>]        Display install path for an installed or current version
   asdf which <name>                    Display install path for current version
   asdf local <name> <version>          Set the package local version
   asdf global <name> <version>         Set the package global version

--- a/lib/commands/where.sh
+++ b/lib/commands/where.sh
@@ -3,13 +3,26 @@ where_command() {
   local full_version=$2
   check_if_plugin_exists "$plugin_name"
 
-  IFS=':' read -r -a version_info <<< "$full_version"
-  if [ "${version_info[0]}" = "ref" ]; then
-    local install_type="${version_info[0]}"
-    local version="${version_info[1]}"
+  local version
+  local install_type="version"
+  if [[ -z ${full_version} ]]; then
+    local version_and_path
+    version_and_path=$(find_version "$plugin_name" "$PWD")
+    version=$(cut -d '|' -f 1 <<< "$version_and_path");
   else
-    local install_type="version"
-    local version="${version_info[0]}"
+    local -a version_info
+    IFS=':' read -r -a version_info <<< "$full_version"
+    if [ "${version_info[0]}" = "ref" ]; then
+      install_type="${version_info[0]}"
+      version="${version_info[1]}"
+    else
+      version="${version_info[0]}"
+    fi
+  fi
+
+  if [ -z "$version" ]; then
+    display_no_version_set "$plugin_name"
+    exit 1
   fi
 
   local install_path

--- a/test/where_command.bats
+++ b/test/where_command.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+
+load test_helpers
+
+. $(dirname $BATS_TEST_DIRNAME)/lib/commands/where.sh
+
+function setup() {
+  setup_asdf_dir
+  install_dummy_plugin
+  install_dummy_version 1.0
+  install_dummy_version 2.1
+  install_dummy_version ref-master
+}
+
+function teardown() {
+  clean_asdf_dir
+}
+
+@test "where shows install location of selected version" {
+  run where_command 'dummy' '1.0'
+  [ "$status" -eq 0 ]
+  [ "$output" = "$ASDF_DIR/installs/dummy/1.0" ]
+}
+
+@test "where understands versions installed by ref" {
+  run where_command 'dummy' 'ref:master'
+  [ "$status" -eq 0 ]
+  [ "$output" = "$ASDF_DIR/installs/dummy/ref-master" ]
+}
+
+@test "where shows install location of current version if no version specified" {
+  echo 'dummy 2.1' >> $HOME/.tool-versions
+
+  run where_command 'dummy'
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "$ASDF_DIR/installs/dummy/2.1" ]
+}
+
+@test "where should error when the plugin doesn't exist" {
+  run where_command "foobar"
+  [ "$status" -eq 1 ]
+  [ "$output" = "No such plugin: foobar" ]
+}
+
+@test "where should error when version is not installed" {
+  run where_command 'dummy' '1.6'
+  [ "$status" -eq 1 ]
+  [ "$output" = "Version not installed" ]
+}
+
+@test "where should error when no current version selected and version not specified" {
+  run where_command 'dummy'
+
+  local expected
+  expected="No version set for dummy; please run \`asdf <global | local> dummy <version>\`"
+
+  [ "$status" -eq 1 ]
+  [ "$output" = "$expected" ]
+}


### PR DESCRIPTION
# Summary

Allow not specifying the version on command line in which case fall back
to looking it up.

Also add tests for the `where` command.
