### PR TITLE
Fix fish shell init snippet

### DIFF
--- a/asdf.fish
+++ b/asdf.fish
@@ -1,13 +1,15 @@
 #!/usr/bin/env fish
 
-set -l asdf_data_dir (dirname (status -f))
+set -l asdf_dir (dirname (status -f))
+set -l asdf_data_dir (
+  if test -n "$ASDF_DATA_DIR"; echo $ASDF_DATA_DIR;
+  else; echo $HOME/.asdf; end)
 
-# we get an ugly warning when setting the path if shims does not exist
-mkdir -p $asdf_data_dir/shims
+# Add asdf to PATH
+set -l asdf_bin_dirs $asdf_dir/bin $asdf_dir/shims $asdf_data_dir/shims
 
-for x in $asdf_data_dir/{bin,shims}
-  if not contains $x $PATH
-  and test -d $x
+for x in $asdf_bin_dirs
+  if begin not contains $x $PATH; and test -d $x; end
     set -gx PATH $x $PATH
   end
 end


### PR DESCRIPTION
# Summary

- add `bin` and `shims` directories from asdf installation to PATH
- add `shims` directory from `$ASDF_DATA_DIR` (default `$HOME/.asdf`) to
  PATH
- don't create directories in init script (directories are only added to
  PATH if they exist, besides there is no warning when a directory does
  not exist (perhaps it was a bug that was fixed))

This brings the fish snippet closer to the one for sh.
