### PR TITLE
Add README documentation on updating asdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,18 @@ asdf plugin-update <name>
 # asdf plugin-update erlang
 ```
 
+##### Update asdf itself
+
+```bash
+asdf update
+```
+
+If you want the latest changes that aren't yet included in a stable release:
+
+```bash
+asdf update --head
+```
+
 ### Manage versions
 
 ```bash


### PR DESCRIPTION
# Summary

My first concern when reading the documentation was installation via checking out a specific release branch. The README didn't show me how to update `asdf` itself, so I held off on setting it up until I knew that in the future I wouldn't have an outdated version that was annoying to update via git.

I'm guessing some others may have similar concerns as well, so I thought it would help (and shouldn't hurt) to add a short section to the README.