### PR TITLE
Fix README typo of maintainer Daniel Perez's username

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Copyright 2014 to the end of time ([MIT License](https://github.com/asdf-vm/asdf
 ### Maintainers
 
 * [@HashNuke](https://github.com/HashNuke)
-* [@danpher](https://github.com/danhper)
+* [@danhper](https://github.com/danhper)
 * [@Stratus3D](https://github.com/Stratus3D)
 * [@vic](https://github.com/vic)
 


### PR DESCRIPTION
# Summary

While updating the README in #397, I noticed that the link text for Daniel Perez did not match the href, so I fixed it as well.

_Would you prefer one commit with a number of tweaks to the README, or accept/reject each on it's own?_