### PR TITLE
Fix current behavior when multiple versions of a plugin are set

### DIFF
--- a/lib/commands/current.sh
+++ b/lib/commands/current.sh
@@ -7,19 +7,22 @@ plugin_current_command() {
   search_path=$(pwd)
   local version_and_path
   version_and_path=$(find_version "$plugin_name" "$search_path")
-  local version
-  version=$(cut -d '|' -f 1 <<< "$version_and_path");
+  local full_version
+  full_version=$(cut -d '|' -f 1 <<< "$version_and_path");
   local version_file_path
   version_file_path=$(cut -d '|' -f 2  <<< "$version_and_path");
 
-  check_if_version_exists "$plugin_name" "$version"
+  IFS=' ' read -r -a versions <<< "$full_version"
+  for version in $versions; do
+    check_if_version_exists "$plugin_name" "$version"
+  done
   check_for_deprecated_plugin "$plugin_name"
 
-  if [ -z "$version" ]; then
+  if [ -z "$full_version" ]; then
     printf "%s\\n" "$(display_no_version_set "$plugin_name")"
     exit 126
   else
-    printf "%-8s (set by %s)\\n" "$version" "$version_file_path"
+    printf "%-8s (set by %s)\\n" "$full_version" "$version_file_path"
   fi
 }
 

--- a/test/current_command.bats
+++ b/test/current_command.bats
@@ -38,6 +38,16 @@ teardown() {
   [ "$output" = "nightly-2000-01-01 (set by $PROJECT_DIR/.tool-versions)" ]
 }
 
+@test "current should handle multiple versions" {
+  cd $PROJECT_DIR
+  echo "dummy 1.2.0 1.1.0" >> $PROJECT_DIR/.tool-versions
+
+  run current_command "dummy"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1.2.0 1.1.0 (set by $PROJECT_DIR/.tool-versions)" ]
+}
+
+
 @test "current should derive from the legacy file if enabled" {
   cd $PROJECT_DIR
   echo 'legacy_version_file = yes' > $HOME/.asdfrc


### PR DESCRIPTION
`asdf current` failed when a plugin had multiple versions set (e.g. `asdf global python 3.6.6 2.7.12`).
This fixes the issue.