### PR TITLE
support .tool-versions content even if it does not end in a newline

### DIFF
--- a/lib/commands/install.sh
+++ b/lib/commands/install.sh
@@ -40,7 +40,7 @@ install_local_tool_versions() {
   local asdf_versions_path
   asdf_versions_path=$(find_tool_versions)
   if [ -f "${asdf_versions_path}" ]; then
-    while read -r tool_line; do
+    while IFS= read -r tool_line || [ -n "$tool_line" ]; do
       IFS=' ' read -r -a tool_info <<< "$tool_line"
       local tool_name
       tool_name=$(echo "${tool_info[0]}" | xargs)

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -23,6 +23,14 @@ teardown() {
   [ $(cat $ASDF_DIR/installs/dummy/1.1/version) = "1.1" ]
 }
 
+@test "install_command installs even if the user is terrible and does not use newlines" {
+  cd $PROJECT_DIR
+  echo -n 'dummy 1.2' > ".tool-versions"
+  run install_command
+  [ "$status" -eq 0 ]
+  [ $(cat $ASDF_DIR/installs/dummy/1.2/version) = "1.2" ]
+}
+
 @test "install_command set ASDF_CONCURRENCY" {
   run install_command dummy 1.0
   [ "$status" -eq 0 ]


### PR DESCRIPTION
# Summary

````
# works
echo "nodejs 8.12.0" > .tool-versions

# does not work
echo -n "nodejs 8.12.0" > .tool-versions
````

I'm really not sure how we ended up with a .tool-versions file without a trailing newline, but it caused a significant amount of confusion. :)

## Other Information

Implementation for fix borrowed from https://unix.stackexchange.com/questions/418060/read-a-line-oriented-file-which-may-not-end-with-a-newline. I'm hoping the existing test coverage will prevent a regression.

Thanks for asdf-vm; it rocks!