### PR TITLE
Silence errors during tab completion

### DIFF
--- a/completions/asdf.bash
+++ b/completions/asdf.bash
@@ -8,7 +8,7 @@ _asdf () {
   local prev
   prev=${COMP_WORDS[COMP_CWORD-1]}
   local plugins
-  plugins=$(asdf plugin-list | tr '\n' ' ')
+  plugins=$(asdf plugin-list 2> /dev/null | tr '\n' ' ')
 
   # We can safely ignore warning SC2207 since it warns that it will uses the
   # shell's sloppy word splitting and globbing. The possible commands here are
@@ -27,14 +27,14 @@ _asdf () {
       ;;
     plugin-add)
       local available_plugins
-      available_plugins=$( (asdf plugin-list && asdf plugin-list-all) | sort | uniq -u)
+      available_plugins=$( (asdf plugin-list 2> /dev/null && asdf plugin-list-all 2> /dev/null) | sort | uniq -u)
       # shellcheck disable=SC2207
       COMPREPLY=($(compgen -W "$available_plugins" -- "$cur"))
       ;;
     install)
       if [[ "$plugins" == *"$prev"* ]] ; then
         local versions
-        versions=$(asdf list-all "$prev")
+        versions=$(asdf list-all "$prev" 2> /dev/null)
         # shellcheck disable=SC2207
         COMPREPLY=($(compgen -W "$versions" -- "$cur"))
       else
@@ -49,7 +49,7 @@ _asdf () {
     uninstall|where|reshim|local|global)
       if [[ "$plugins" == *"$prev"* ]] ; then
         local versions
-        versions=$(asdf list "$prev")
+        versions=$(asdf list "$prev" 2> /dev/null)
         # shellcheck disable=SC2207
         COMPREPLY=($(compgen -W "$versions" -- "$cur"))
       else

--- a/completions/asdf.fish
+++ b/completions/asdf.fish
@@ -27,13 +27,25 @@ function __fish_asdf_arg_at -a number
 end
 
 function __fish_asdf_list_versions -a plugin
-    asdf list $plugin | sed -e 's/^\s*//'
+    asdf list $plugin 2> /dev/null | sed -e 's/^\s*//'
+end
+
+function __fish_asdf_list_all -a plugin
+    asdf list-all $plugin 2> /dev/null
+end
+
+function __fish_asdf_plugin_list
+    asdf plugin-list 2> /dev/null
+end
+
+function __fish_asdf_plugin_list_all
+    asdf plugin-list-all 2> /dev/null
 end
 
 # plugin-add completion
 complete -f -c asdf -n '__fish_asdf_needs_command' -a plugin-add -d "Add git repo as plugin"
-complete -f -c asdf -n '__fish_asdf_using_command plugin-add; and __fish_asdf_arg_number 2' -a '(asdf plugin-list-all | grep -v \'*\' | awk \'{ print $1 }\')'
-complete -f -c asdf -n '__fish_asdf_using_command plugin-add; and __fish_asdf_arg_number 3' -a '(asdf plugin-list-all | grep (__fish_asdf_arg_at 3) | awk \'{ print $2 }\')'
+complete -f -c asdf -n '__fish_asdf_using_command plugin-add; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list_all | grep -v \'*\' | awk \'{ print $1 }\')'
+complete -f -c asdf -n '__fish_asdf_using_command plugin-add; and __fish_asdf_arg_number 3' -a '(__fish_asdf_plugin_list_all | grep (__fish_asdf_arg_at 3) | awk \'{ print $2 }\')'
 complete -f -c asdf -n '__fish_asdf_using_command plugin-add; and __fish_asdf_arg_number 4'
 
 # plugin-list completion
@@ -44,53 +56,53 @@ complete -f -c asdf -n '__fish_asdf_needs_command' -a plugin-list-all -d "List a
 
 # plugin-remove completion
 complete -f -c asdf -n '__fish_asdf_needs_command' -a plugin-remove -d "Remove plugin and package versions"
-complete -f -c asdf -n '__fish_asdf_using_command plugin-remove; and __fish_asdf_arg_number 2' -a '(asdf plugin-list)'
+complete -f -c asdf -n '__fish_asdf_using_command plugin-remove; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
 
 # plugin-update completion
 complete -f -c asdf -n '__fish_asdf_needs_command' -a plugin-update -d "Update plugin"
-complete -f -c asdf -n '__fish_asdf_using_command plugin-update; and __fish_asdf_arg_number 2' -a '(asdf plugin-list)'
+complete -f -c asdf -n '__fish_asdf_using_command plugin-update; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
 complete -f -c asdf -n '__fish_asdf_using_command plugin-update; and __fish_asdf_arg_number 2' -a --all
 
 # install completion
 complete -f -c asdf -n '__fish_asdf_needs_command' -a install -d "Install a specific version of a package"
-complete -f -c asdf -n '__fish_asdf_using_command install; and __fish_asdf_arg_number 2' -a '(asdf plugin-list)'
-complete -f -c asdf -n '__fish_asdf_using_command install; and __fish_asdf_arg_number 3' -a '(asdf list-all (__fish_asdf_arg_at 3))'
+complete -f -c asdf -n '__fish_asdf_using_command install; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
+complete -f -c asdf -n '__fish_asdf_using_command install; and __fish_asdf_arg_number 3' -a '(__fish_asdf_list_all (__fish_asdf_arg_at 3))'
 
 # uninstall completion
 complete -f -c asdf -n '__fish_asdf_needs_command' -a uninstall -d "Remove a specific version of a package"
-complete -f -c asdf -n '__fish_asdf_using_command uninstall; and __fish_asdf_arg_number 2' -a '(asdf plugin-list)'
+complete -f -c asdf -n '__fish_asdf_using_command uninstall; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
 complete -f -c asdf -n '__fish_asdf_using_command uninstall; and __fish_asdf_arg_number 3' -a '(__fish_asdf_list_versions (__fish_asdf_arg_at 3))'
 
 # current completion
 complete -f -c asdf -n '__fish_asdf_needs_command' -a current -d "Display version set or being used for package"
-complete -f -c asdf -n '__fish_asdf_using_command current; and __fish_asdf_arg_number 2' -a '(asdf plugin-list)'
+complete -f -c asdf -n '__fish_asdf_using_command current; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
 
 # where completion
 complete -f -c asdf -n '__fish_asdf_needs_command' -a where -d "Display install path for an installed version"
-complete -f -c asdf -n '__fish_asdf_using_command where; and __fish_asdf_arg_number 2' -a '(asdf plugin-list)'
+complete -f -c asdf -n '__fish_asdf_using_command where; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
 complete -f -c asdf -n '__fish_asdf_using_command where; and __fish_asdf_arg_number 3' -a '(__fish_asdf_list_versions (__fish_asdf_arg_at 3))'
 
 # list completion
 complete -f -c asdf -n '__fish_asdf_needs_command' -a list -d "List installed versions of a package"
-complete -f -c asdf -n '__fish_asdf_using_command list; and __fish_asdf_arg_number 2' -a '(asdf plugin-list)'
+complete -f -c asdf -n '__fish_asdf_using_command list; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
 
 # list-all completion
 complete -f -c asdf -n '__fish_asdf_needs_command' -a list-all -d "List all versions of a package"
-complete -f -c asdf -n '__fish_asdf_using_command list-all; and __fish_asdf_arg_number 2' -a '(asdf plugin-list)'
+complete -f -c asdf -n '__fish_asdf_using_command list-all; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
 
 # reshim completion
 complete -f -c asdf -n '__fish_asdf_needs_command' -a reshim -d "Recreate shims for version of a package"
-complete -f -c asdf -n '__fish_asdf_using_command reshim; and __fish_asdf_arg_number 2' -a '(asdf plugin-list)'
+complete -f -c asdf -n '__fish_asdf_using_command reshim; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
 complete -f -c asdf -n '__fish_asdf_using_command reshim; and __fish_asdf_arg_number 3' -a '(__fish_asdf_list_versions (__fish_asdf_arg_at 3))'
 
 # local completion
 complete -f -c asdf -n '__fish_asdf_needs_command' -a local -d "Set local version for a plugin"
-complete -f -c asdf -n '__fish_asdf_using_command local; and __fish_asdf_arg_number 2' -a '(asdf plugin-list)'
+complete -f -c asdf -n '__fish_asdf_using_command local; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
 complete -f -c asdf -n '__fish_asdf_using_command local; and test (count (commandline -opc)) -gt 2' -a '(__fish_asdf_list_versions (__fish_asdf_arg_at 3)) system'
 
 # global completion
 complete -f -c asdf -n '__fish_asdf_needs_command' -a global -d "Set global version for a plugin"
-complete -f -c asdf -n '__fish_asdf_using_command global; and __fish_asdf_arg_number 2' -a '(asdf plugin-list)'
+complete -f -c asdf -n '__fish_asdf_using_command global; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
 complete -f -c asdf -n '__fish_asdf_using_command global; and test (count (commandline -opc)) -gt 2' -a '(__fish_asdf_list_versions (__fish_asdf_arg_at 3)) system'
 
 # misc


### PR DESCRIPTION
# Summary

Currently, when a message is printed to `stderr` during tab completion, it appears inline, causing an awkward user experience. This is easily reproducible by trying to tab complete with a fresh clone of `asdf` (no plugins installed):

![asdftaberror](https://user-images.githubusercontent.com/5321575/48621758-8a432580-e972-11e8-9757-59f19d5a2c4a.gif)

The fix redirects all `stderr` to `/dev/null` during tab completion, so if there is an error when trying to suggest completions, `asdf` will simply suggest nothing rather than report out a message.

## Other Information

I think this is the most user-friendly approach, but we could also remove the "Oohes nooes" message from `plugin-list` to silence an expected error, while still reporting unexpected errors during tab completion, such as:
```
asdf install golang <TAB> /root/.asdf/plugins/golang/bin/list-all: line 34: curl: command not found
```