### PR TITLE
Fix issues with update command

### DIFF
--- a/lib/commands/update.sh
+++ b/lib/commands/update.sh
@@ -2,9 +2,9 @@ update_command() {
   local update_to_head=$1
 
   (
-  cd "$(asdf_data_dir)" || exit 1
+  cd "${ASDF_DIR}" || exit 1
 
-  if [ -f asdf_updates_disabled ]; then
+  if [ -f asdf_updates_disabled ] || ! git rev-parse --is-inside-work-tree &> /dev/null; then
     echo "Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf."
   else
     do_update "$update_to_head"

--- a/lib/commands/update.sh
+++ b/lib/commands/update.sh
@@ -6,6 +6,7 @@ update_command() {
 
   if [ -f asdf_updates_disabled ] || ! git rev-parse --is-inside-work-tree &> /dev/null; then
     echo "Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf."
+    exit 1
   else
     do_update "$update_to_head"
   fi

--- a/test/update_command.bats
+++ b/test/update_command.bats
@@ -41,6 +41,13 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
+@test "update_command is a noop for non-git repos" {
+  (cd $ASDF_DIR && rm -r .git/)
+  run update_command
+  [ "$(echo -e "Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf.")" == "$output" ]
+  [ "$status" -eq 0 ]
+}
+
 @test "update_command should not remove plugin versions" {
   run install_command dummy 1.1
   [ "$status" -eq 0 ]

--- a/test/update_command.bats
+++ b/test/update_command.bats
@@ -11,13 +11,10 @@ setup() {
   setup_asdf_dir
   install_dummy_plugin
 
-  # Copy over git repo so we have something to test with
-  cp -r .git $ASDF_DIR
   (
   cd $ASDF_DIR
-  git remote remove origin
+  git init
   git remote add origin https://github.com/asdf-vm/asdf.git
-  git checkout .
   )
 
   PROJECT_DIR=$HOME/project
@@ -32,8 +29,7 @@ teardown() {
   run update_command --head
   [ "$status" -eq 0 ]
   cd $ASDF_DIR
-  # TODO: Figure out why this is failing
-  #[ $(git rev-parse --abbrev-ref HEAD) = "master" ]
+  [ $(git rev-parse --abbrev-ref HEAD) = "master" ]
 }
 
 @test "update_command should checkout the latest tag" {

--- a/test/update_command.bats
+++ b/test/update_command.bats
@@ -44,8 +44,8 @@ teardown() {
 @test "update_command is a noop for non-git repos" {
   (cd $ASDF_DIR && rm -r .git/)
   run update_command
+  [ "$status" -eq 1 ]
   [ "$(echo -e "Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf.")" == "$output" ]
-  [ "$status" -eq 0 ]
 }
 
 @test "update_command should not remove plugin versions" {


### PR DESCRIPTION
# Summary

`asdf update` should be using `ASDF_DIR`, the directory of the git repo, rather than `ASDF_DATA_DIR`, the location of various data.

The following changes are included as a result of this fix:
- `cd` into `${ASDF_DIR}` instead of `$(asdf_data_dir)` before performing an update
- Make sure that the directory is part of a `git` repo before performing an update. This gives a better error message, and works for homebrew installations as well
- Add a test case for the above behavior
- Fix test setup to work for certain `asdf` installations. Details below

## Other Information

I have a somewhat unique setup in that I have `asdf` installed as a git submodule in my dotfiles, but I keep the `ASDF_DATA_DIR` separately as the default of `$HOME/.asdf`. The `update_command` tests were failing for me unrelated to this change because they use the `.git` directory for a submodule, which doesn't work the same way as a fresh `.git` directory. The current test set up is more system agnostic.

