### PR TITLE
Fix shellcheck warnings on OSX

### DIFF
--- a/lib/commands/current.sh
+++ b/lib/commands/current.sh
@@ -13,7 +13,7 @@ plugin_current_command() {
   version_file_path=$(cut -d '|' -f 2  <<< "$version_and_path");
 
   IFS=' ' read -r -a versions <<< "$full_version"
-  for version in $versions; do
+  for version in "${versions[@]}"; do
     check_if_version_exists "$plugin_name" "$version"
   done
   check_for_deprecated_plugin "$plugin_name"

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -26,7 +26,7 @@ asdf_repository_url() {
 asdf_data_dir(){
   local data_dir
 
-  if ! [ -z "${ASDF_DATA_DIR}" ]; then
+  if [ -n "${ASDF_DATA_DIR}" ]; then
     data_dir="${ASDF_DATA_DIR}"
   else
     data_dir="$HOME/.asdf"


### PR DESCRIPTION
# Summary

Travis.CI build was failing on OSX.
