### PR TITLE
Continue list even when version is not found

### DIFF
--- a/lib/commands/list.sh
+++ b/lib/commands/list.sh
@@ -30,6 +30,5 @@ display_installed_versions() {
     done
   else
     display_error 'No versions installed'
-    exit 1
   fi
 }

--- a/test/list_command.bats
+++ b/test/list_command.bats
@@ -22,10 +22,15 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
-@test "list_command with plugin should output error when plugin is not installed" {
-  run list_command dummy
-  [ "No versions installed" == "$output" ]
-  [ "$status" -eq 1 ]
+@test "list_command should continue listing even when no version is installed for any of the plugins" {
+  run install_mock_plugin "dummy"
+  run install_mock_plugin "mummy"
+  run install_mock_plugin "tummy"
+  run install_command dummy 1.0
+  run install_command tummy 2.0
+  run list_command
+  [ "$(echo -e "dummy\n  1.0\nmummy\nNo versions installed\ntummy\n  2.0")" == "$output" ]
+  [ "$status" -eq 0 ]
 }
 
 @test "list_command with plugin should list installed versions" {


### PR DESCRIPTION
# Summary

Previous implementation exits abruptly when no version is installed for
a plugin. This prevented the list command from listing the versions for
some other plugins.

This commit allows list command to continue executing even when no
version is installed for some plugins.

## Other Information

Example, plugin a with 1.0, b with none, and c with 2.0.

Previous implementation:

```
$ asdf list

a
  1.0
b
No versions installed
```

After commit changes:

```
$ asdf list

a
  1.0
b
No versions installed
c
  2.0
```
