### PR TITLE
Fixed user paths for fish

### DIFF
--- a/asdf.fish
+++ b/asdf.fish
@@ -9,7 +9,7 @@ set -l asdf_data_dir (
 set -l asdf_bin_dirs $asdf_dir/bin $asdf_dir/shims $asdf_data_dir/shims
 
 for x in $asdf_bin_dirs
-  if begin not contains $x $PATH; and test -d $x; end
+  if begin not contains $x $fish_user_paths; and test -d $x; end
     set -gx fish_user_paths $fish_user_paths $x
   end
 end

--- a/asdf.fish
+++ b/asdf.fish
@@ -10,6 +10,6 @@ set -l asdf_bin_dirs $asdf_dir/bin $asdf_dir/shims $asdf_data_dir/shims
 
 for x in $asdf_bin_dirs
   if begin not contains $x $PATH; and test -d $x; end
-    set -gx PATH $x $PATH
+    set -gx fish_user_paths $fish_user_paths $x
   end
 end


### PR DESCRIPTION
# Summary

This sets `fish_user_path` instead of `PATH`. This is the proper way to load custom paths in fish. Prior to this change the asdf shim path was being appended to the default path for newer versions of fish, resulting in asdf using system executables. I've only confirmed the bug in the fish 3.0, but I suspect it didn't exist prior to 3.0.

Fixes: https://github.com/asdf-vm/asdf/issues/420

## Other Information

This fix will not work for versions of fish prior to 2.1. This latest 2.1 version was published in Feb 2015.