### PR TITLE
Add instructions for brew install

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,20 @@ Depending on your OS and shell, run the following:
 
 * Fish:
 
+  If installed using `git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.6.2`:
+
   ```bash
   echo 'source ~/.asdf/asdf.fish' >> ~/.config/fish/config.fish
-  mkdir -p ~/.config/fish/completions; and cp ~/.asdf/completions/asdf.fish ~/.config/fish/completions
+  mkdir -p ~/.config/fish/completions && cp ~/.asdf/completions/asdf.fish ~/.config/fish/completions
   ```
+  
+  If installed using `brew install asdf`:
+  
+  ```bash
+  echo 'source /usr/local/share/fish/vendor_completions.d/asdf.fish' >> ~/.config/fish/config.fish
+  mkdir -p ~/.config/fish/completions && cp /usr/local/share/fish/vendor_completions.d/asdf.fish ~/.config/fish/completions
+  ```
+  
 Restart your shell so that PATH changes take effect. (Opening a new terminal
 tab will usually do it.)
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Depending on your OS and shell, run the following:
   If installed using `brew install asdf`:
   
   ```bash
-  echo 'source /usr/local/share/fish/vendor_completions.d/asdf.fish' >> ~/.config/fish/config.fish
+  echo 'source /usr/local/opt/asdf/asdf.fish' >> ~/.config/fish/config.fish
   mkdir -p ~/.config/fish/completions && cp /usr/local/share/fish/vendor_completions.d/asdf.fish ~/.config/fish/completions
   ```
   


### PR DESCRIPTION
# Summary

This will add instructions on how to install asdf when using the fish shell and when it is installed using homebrew instead of git. Fish is now at 3.0, which means it now supports && as well.

Fixes: https://github.com/asdf-vm/asdf/issues/425

## Other Information

Do we still need instructions on bash? It also doesn't look like the `asdf.fish` file get executed upon install, as I'm still unable to use the shims. This is on a fresh install too.