### PR TITLE
Readme uninstall fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ managers (e.g. `.ruby-version` in the case of Ruby's rbenv).
 
 ## Uninstall
 
-[Uninstalling asdf is easy](https://github.com/asdf-vm/asdf/blob/master/docs/uninstall.md).
+[Uninstalling asdf is easy](https://github.com/asdf-vm/asdf/blob/master/docs/core-manage-asdf-vm.md#remove).
 
 ## Homebrew on macOS
 

--- a/docs/core-manage-asdf-vm.md
+++ b/docs/core-manage-asdf-vm.md
@@ -111,6 +111,8 @@ asdf update --head
 
 ## Remove
 
+Uninstalling `asdf` is as simple as:
+
 1.  In your `.bashrc` (or `.bash_profile` if you are on OSX) or `.zshrc` find the lines that source `asdf.sh` and the autocompletions. The lines should look something like this:
 
         . $HOME/.asdf/asdf.sh


### PR DESCRIPTION
# Summary

Update README link to uninstall instructions of the new `docs/`

Fixes: this comment - https://github.com/asdf-vm/asdf/commit/2fcde332ae5a0026d4ff40cb0713216e53111170#commitcomment-31950054

## Other Information

