### PR TITLE
Add `asdf env` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 Features
 
 
-* Shims can be invoked directly via `asdf exec <tool> [args...]` without requiring to have all shims on path (#374).
+* Shims can be invoked directly via `asdf exec <command> [args...]` without requiring to have all shims on path (#374).
+* New `asdf env <command>` can be used to print or execute with the env that would be used to execute a shim.
 * Configurable command hooks from `.asdfrc`
   Suppose a `foo` plugin is installed and provides a `bar` executable,
   The following hooks will be executed when set:
@@ -30,7 +31,7 @@ Features
 * Added lots of tests for shim execution.
   We now make sure that shim execution obeys plugins hooks like `list-bin-paths` and
   `exec-path`. 
-* Shim exec is now performed by a new `bin/private/asdf-tool-exec` that might be faster
+* Shims now are thin wrappers around `asdf exec` that might be faster
   for most common use case: (versions on local .tool-versions file) but fallbacks to
   slower `get_preset_version_for` which takes legacy formats into account.
 * Shim exec recommends which plugins or versions to set when command is not found.

--- a/bin/asdf
+++ b/bin/asdf
@@ -7,6 +7,8 @@ source "$(dirname "$(dirname "$0")")/lib/utils.sh"
 source "$(dirname "$(dirname "$0")")/lib/commands/help.sh"
 # shellcheck source=lib/commands/shim-exec.sh
 source "$(dirname "$(dirname "$0")")/lib/commands/shim-exec.sh"
+# shellcheck source=lib/commands/shim-env.sh
+source "$(dirname "$(dirname "$0")")/lib/commands/shim-env.sh"
 # shellcheck source=lib/commands/update.sh
 source "$(dirname "$(dirname "$0")")/lib/commands/update.sh"
 # shellcheck source=lib/commands/install.sh
@@ -56,6 +58,9 @@ case $1 in
 
   "exec")
     shim_exec_command $callback_args;;
+
+  "env")
+    shim_env_command $callback_args;;
 
   "help")
     help_command $callback_args;;

--- a/help.txt
+++ b/help.txt
@@ -17,7 +17,7 @@ MANAGE PACKAGES
   asdf current                         Display current version set or being used for all packages
   asdf current <name>                  Display current version set or being used for package
   asdf where <name> [<version>]        Display install path for an installed or current version
-  asdf which <executable>              Display the path to an executable
+  asdf which <command>                 Display the path to an executable
   asdf local <name> <version>          Set the package local version
   asdf global <name> <version>         Set the package global version
   asdf list <name>                     List installed versions of a package
@@ -25,9 +25,10 @@ MANAGE PACKAGES
 
 
 UTILS
-  asdf exec <executable> [args..]      Run an executable command shim
+  asdf exec <command> [args..]         Executes the command shim for current version
+  asdf env <command> [executable]      Prints or runs an executable under a command environment
   asdf reshim <name> <version>         Recreate shims for version of a package
-  asdf shim-versions <executable>      List on which plugins and versions is an executable provided.
+  asdf shim-versions <command>         List on which plugins and versions is command available
   asdf update                          Update asdf to the latest stable release
   asdf update --head                   Update asdf to the latest on the master branch
 

--- a/lib/commands/shim-env.sh
+++ b/lib/commands/shim-env.sh
@@ -1,0 +1,32 @@
+shim_env_command() {
+  local shim_name="$1"
+  local env_cmd="${2}"
+
+  if [ -z "$env_cmd" ]; then
+    env_cmd="env"
+  fi
+
+  local selected_version
+  selected_version=$(select_from_tool_versions)
+
+  if [ -z "$selected_version" ]; then
+    selected_version=$(select_from_preset_version)
+  fi
+
+  if [ -n "$selected_version" ]; then
+    local plugin_name
+    plugin_name=$(cut -d ' ' -f 1 <<< "$selected_version");
+    local version
+    version=$(cut -d ' ' -f 2- <<< "$selected_version");
+    plugin_exec_env "$plugin_name" "$version"
+    exec "$env_cmd" "${@:3}"
+  fi
+
+  (
+    echo "asdf: No version set for command ${shim_name}"
+    echo "you might want to add one of the following in your .tool-versions file:"
+    echo ""
+    shim_plugin_versions "${shim_name}"
+  ) >&2
+  exit 126
+}

--- a/test/shim_env_command.bats
+++ b/test/shim_env_command.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+
+load test_helpers
+
+. $(dirname $BATS_TEST_DIRNAME)/lib/commands/shim-env.sh
+. $(dirname $BATS_TEST_DIRNAME)/lib/commands/reshim.sh
+. $(dirname $BATS_TEST_DIRNAME)/lib/commands/install.sh
+
+setup() {
+  setup_asdf_dir
+  install_dummy_plugin
+
+  PROJECT_DIR=$HOME/project
+  mkdir -p $PROJECT_DIR
+  cd $PROJECT_DIR
+
+  # asdf lib needed to run generated shims
+  cp -rf $BATS_TEST_DIRNAME/../{bin,lib} $ASDF_DIR/
+}
+
+teardown() {
+  clean_asdf_dir
+}
+
+@test "asdf env should execute under the environment used for a shim" {
+  echo "dummy 1.0" > $PROJECT_DIR/.tool-versions
+  run install_command
+
+  run $ASDF_DIR/bin/asdf env dummy which dummy
+  [ "$status" -eq 0 ]
+  [ "$output" == "$ASDF_DIR/installs/dummy/1.0/bin/dummy" ]
+}
+
+
+@test "asdf env should execute under plugin custom environment used for a shim" {
+  echo "dummy 1.0" > $PROJECT_DIR/.tool-versions
+  run install_command
+
+  echo "export FOO=bar" > $ASDF_DIR/plugins/dummy/bin/exec-env
+  chmod +x $ASDF_DIR/plugins/dummy/bin/exec-env
+
+  run $ASDF_DIR/bin/asdf env dummy
+  [ "$status" -eq 0 ]
+  echo $output | grep 'FOO=bar'
+}
+
+@test "asdf env should ignore plugin custom environment on system version" {
+  echo "dummy 1.0" > $PROJECT_DIR/.tool-versions
+  run install_command
+
+  echo "export FOO=bar" > $ASDF_DIR/plugins/dummy/bin/exec-env
+  chmod +x $ASDF_DIR/plugins/dummy/bin/exec-env
+
+  echo "dummy system" > $PROJECT_DIR/.tool-versions
+
+  run $ASDF_DIR/bin/asdf env dummy
+  [ "$status" -eq 0 ]
+
+  run grep 'FOO=bar' <(echo $output)
+  [ "$output" == "" ]
+  [ "$status" -eq 1 ]
+
+  run $ASDF_DIR/bin/asdf env dummy which dummy
+  [ "$output" == "" ]
+  [ "$status" -eq 1 ]
+}


### PR DESCRIPTION
New `asdf env <command>` can be used to print or execute with the env that would be used to execute a shim.
