### PR TITLE
Mention ~/.tool-versions in uninstalling instructions

### DIFF
--- a/docs/core-manage-asdf-vm.md
+++ b/docs/core-manage-asdf-vm.md
@@ -120,6 +120,6 @@ Uninstalling `asdf` is as simple as:
 
     Remove these lines and save the file.
 
-2.  Run `rm -rf ~/.asdf/` to completely remove all the asdf files from your system.
+2.  Run `rm -rf ~/.asdf/ ~/.tool-versions` to completely remove all the asdf files from your system.
 
 That's it!


### PR DESCRIPTION
# Summary

Hi. Just a quick 'n easy doc improvement :+1.

_Note: I still use asdf, just needed a way to temporarily disable a global version and stumble upon #238 which mentioned ~/.tool-versions and this piece of documentation. Actually it could be nice adding a `global-unset` command or something :question:_
