### PR TITLE
update README:  asdf cannot be installed via homebrew on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Supporting a new language is as simple as [this plugin API][plugin_api].
 
 ## INSTALLATION
 
-If you're on macOS you can [Install using Homebrew](https://github.com/asdf-vm/asdf#homebrew-on-macos)
+If you're on macOS, you [can't install using Homebrew](https://github.com/thoughtbot/dotfiles/issues/577) because the installation will be in [a non-standard location](https://github.com/thoughtbot/dotfiles/issues/577#issuecomment-354332924)
 
 ### Basic Installation
 


### PR DESCRIPTION
see [issue 577](https://github.com/thoughtbot/dotfiles/issues/577), opened by @dcalhoun

resolves #577 by changing readme to specify that asdf can't be installed via homebrew

further comments:

the documentation could also use the specific language `shouldn't` instead of `can't`
OR
the line can be removed altogether