### PR TITLE
Update fish_user_paths only if it is defined

### DIFF
--- a/asdf.fish
+++ b/asdf.fish
@@ -10,10 +10,6 @@ set -l asdf_bin_dirs $ASDF_DIR/bin $ASDF_DIR/shims $asdf_data_dir/shims
 
 for x in $asdf_bin_dirs
   if begin not contains $x $PATH; and test -d $x; end
-    if set -q fish_user_paths
-      set -gx fish_user_paths $fish_user_paths $x
-    else
-      set PATH $PATH $x
-    end
+    set PATH $x $PATH
   end
 end

--- a/asdf.fish
+++ b/asdf.fish
@@ -9,7 +9,11 @@ set -l asdf_data_dir (
 set -l asdf_bin_dirs $ASDF_DIR/bin $ASDF_DIR/shims $asdf_data_dir/shims
 
 for x in $asdf_bin_dirs
-  if begin not contains $x $fish_user_paths; and test -d $x; end
-    set -gx fish_user_paths $fish_user_paths $x
+  if begin not contains $x $PATH; and test -d $x; end
+    if set -q fish_user_paths
+      set -gx fish_user_paths $fish_user_paths $x
+    else
+      set PATH $PATH $x
+    end
   end
 end


### PR DESCRIPTION

# Summary

fish_user_paths variable is prepended to $PATH automatically. Some people set fish_user_paths, while others set PATH.
It will be better to test if fish_user_paths is set, and prepend it if it is, while just prepending to PATH otherwise.

## Other Information

[setting $PATH in fish shell](http://fishshell.com/docs/current/tutorial.html#tut_path)

Thank you for contributing to asdf!