### PR TITLE
Add the word `version` to README tagline and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # asdf-vm [![Build Status](https://travis-ci.org/asdf-vm/asdf.svg?branch=master)](https://travis-ci.org/asdf-vm/asdf)
 
-**Manage multiple runtimes with a single CLI tool, extendable via plugins** - [docs site](https://asdf-vm.github.io/asdf/)
+**Manage multiple runtime versions with a single CLI tool, extendable via plugins** - [docs site](https://asdf-vm.github.io/asdf/)
 
-asdf-vm is a CLI tool that can manage multiple language runtimes on a per-project basis. It is like `gvm`, `nvm`, `rbenv` & `pyenv` (and more) all in one! Simply install your language's plugin!
+asdf-vm is a CLI tool that can manage multiple language runtime versions on a per-project basis. It is like `gvm`, `nvm`, `rbenv` & `pyenv` (and more) all in one! Simply install your language's plugin!
 
 ## Why use asdf-vm?
 


### PR DESCRIPTION
An attempt to clarify the purpose of asdf by making it clear it's for managing multiple versions of runtimes. I'm not sure if this makes it more understandable or not. I just noticed we didn't say much about versions. What do you think @jthegedus ?