### PR TITLE
Fix "Edit on Github" link for changelog

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -41,7 +41,7 @@
           ".*?/plugins-all":
             "https://raw.githubusercontent.com/asdf-vm/asdf-plugins/master/README.md",
           ".*?/changelog":
-            "/CHANGELOG.md",
+            "../CHANGELOG.md",
         },
         markdown: {
           smartypants: true,

--- a/docs/index.html
+++ b/docs/index.html
@@ -41,7 +41,7 @@
           ".*?/plugins-all":
             "https://raw.githubusercontent.com/asdf-vm/asdf-plugins/master/README.md",
           ".*?/changelog":
-            "https://raw.githubusercontent.com/asdf-vm/asdf/master/CHANGELOG.md",
+            "/CHANGELOG.md",
         },
         markdown: {
           smartypants: true,


### PR DESCRIPTION
Currently the URL used by the "Edit on Github" link is `https://github.com/asdf-vm/asdf/edit/master/docs/https://raw.githubusercontent.com/asdf-vm/asdf/master/CHANGELOG.md`. Not sure if this change will fix it, but it will correct the URL used when the link is clicked.

Note this is still a problem for the "Edit on Github" link on the plugins page.