### PR TITLE
Add a note about Spack installation

### DIFF
--- a/docs/core-manage-asdf-vm.md
+++ b/docs/core-manage-asdf-vm.md
@@ -75,10 +75,18 @@ tab will usually do it.)
 
 #### ** macOS **
 
-Install these via homebrew:
+Installation via Homebrew:
 
 ```shell
 brew install \
+  coreutils automake autoconf openssl \
+  libyaml readline libxslt libtool unixodbc
+```
+
+Installation via Spack:
+
+```shell
+spack install \
   coreutils automake autoconf openssl \
   libyaml readline libxslt libtool unixodbc
 ```


### PR DESCRIPTION
This PR adds documentation to cover that components can be installed via [Spack](https://spack.io/) on macOS. There's really no difference in the package names (and so on), but this serves to show that there are more options than just Homebrew! 

As a side note, I do not know if the website is automatically generated from GitHub. If so, it might be good to wait on this PR for a little while. I recently had the final specification for `libyaml` merged into Spack - I'm not entirely sure when that becomes more broadly available. 