### PR TITLE
asdf.sh: support mksh

### DIFF
--- a/asdf.sh
+++ b/asdf.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# For Korn shells (ksh, mksh, etc.), capture $_ (the final parameter passed to
+# the last command) straightaway, as it will contain the path to this script.
+# For Bash, ${BASH_SOURCE[0]} will be used to obtain this script's path.
+# For Zsh and others, $0 (the path to the shell or script) will be used.
 _under="$_"
 if [[ "$_under" == *".sh" ]]; then
   current_script_path="$_under"

--- a/asdf.sh
+++ b/asdf.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
-if [ "${BASH_SOURCE[0]}" != "" ]; then
+_under="$_"
+if [[ "$_under" == *".sh" ]]; then
+  current_script_path="$_under"
+elif [ "${BASH_SOURCE[0]}" != "" ]; then
   current_script_path="${BASH_SOURCE[0]}"
 else
   current_script_path="$0"


### PR DESCRIPTION
The mksh shell (and perhaps others too) will not be able to determine a
sourced script's path by looking at either `${BASH_SOURCE[0]}` or `$0`.

By capturing the value of `$_` as the very first thing the script does,
`asdf.sh` can use that as the input for `dirname` in order to determine
a value to use for `$ASDF_DIR`.

I have tested this change with mksh to confirm that it works, and have
also tested it with both bash and zsh to verify that neither of those
stop working.

This resolves the only compatibility issue I've ran into with asdf,
caused by mksh sourcing a script. All subsequent asdf usage involves an
asdf executable doing the sourcing, so it's bash to bash at that point.