### PR TITLE
Set fish_user_paths as universal variable

### DIFF
--- a/asdf.fish
+++ b/asdf.fish
@@ -10,6 +10,6 @@ set -l asdf_bin_dirs $ASDF_DIR/bin $ASDF_DIR/shims $asdf_data_dir/shims
 
 for x in $asdf_bin_dirs
   if begin not contains $x $fish_user_paths; and test -d $x; end
-    set -gx fish_user_paths $fish_user_paths $x
+    set -U fish_user_paths $fish_user_paths $x
   end
 end


### PR DESCRIPTION
# Summary

For fish shell users, `$fish_user_paths` is incorrectly being set as a global variable and will clobber anyone setting `$fish_user_paths` the way recommended by the [fish documentation](https://fishshell.com/docs/current/tutorial.html#tut_path) (as a universal variable).

This change correctly sets `$fish_user_paths` as a universal variable. See more details [here](https://github.com/asdf-vm/asdf/issues/449#issuecomment-465550336).

Fixes: #449 