### PR TITLE
Fix version handling

### DIFF
--- a/docs/core-configuration.md
+++ b/docs/core-configuration.md
@@ -18,6 +18,14 @@ The versions can be in the following format:
 - `path:/src/elixir` - a path to custom compiled version of a tool to use. For use by language developers and such.
 - `system` - this keyword causes asdf to passthrough to the version of the tool on the system that is not managed by asdf.
 
+Multiple versions can be set by separating them with a space. For example, to use
+Python 3.7.2, fallback to Python 2.7.15 and finally to the system Python, the
+following line can be added to `.tool-versions`.
+
+```
+python 3.7.2 2.7.15 system
+```
+
 To install all the tools defined in a `.tool-versions` file run `asdf install` with no other arguments in the directory containing the `.tool-versions` file.
 
 Edit the file directly or use `asdf local` (or `asdf global`) which updates it.

--- a/docs/core-manage-versions.md
+++ b/docs/core-manage-versions.md
@@ -24,8 +24,8 @@ asdf list-all <name>
 ## Set Current Version
 
 ```shell
-asdf global <name> <version>
-asdf local <name> <version>
+asdf global <name> <version> [<version>...]
+asdf local <name> <version> [<version>...]
 # asdf global elixir 1.2.4
 ```
 

--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -116,9 +116,19 @@ teardown() {
 @test "shim exec should execute first plugin that is installed and set" {
   run asdf install dummy 3.0
 
-  echo "dummy 1.0" > $PROJECT_DIR/.tool-versions
-  echo "dummy 3.0" >> $PROJECT_DIR/.tool-versions
-  echo "dummy 2.0" >> $PROJECT_DIR/.tool-versions
+  echo "dummy 1.0 3.0 2.0" > $PROJECT_DIR/.tool-versions
+
+  run $ASDF_DIR/shims/dummy world hello
+  [ "$status" -eq 0 ]
+
+  echo "$output" | grep -q "This is Dummy 3.0! hello world" 2>/dev/null
+}
+
+@test "shim exec should only use the first version found for a plugin" {
+  run asdf install dummy 3.0
+
+  echo "dummy 3.0" > $PROJECT_DIR/.tool-versions
+  echo "dummy 1.0" >> $PROJECT_DIR/.tool-versions
 
   run $ASDF_DIR/shims/dummy world hello
   [ "$status" -eq 0 ]

--- a/test/which_command.bats
+++ b/test/which_command.bats
@@ -9,6 +9,7 @@ setup() {
   setup_asdf_dir
   install_dummy_plugin
   run asdf install dummy 1.0
+  run asdf install dummy 1.1
 
   PROJECT_DIR=$HOME/project
   mkdir $PROJECT_DIR
@@ -84,4 +85,17 @@ teardown() {
   run asdf which "dummy"
   [ "$status" -eq 0 ]
   [ "$output" = "$ASDF_DIR/installs/dummy/1.0/bin/custom/dummy" ]
+}
+
+@test "which should return the path set by the legacy file" {
+  cd $PROJECT_DIR
+
+  echo 'dummy 1.0' >> $HOME/.tool-versions
+  echo '1.1' >> $PROJECT_DIR/.dummy-version
+  rm $PROJECT_DIR/.tool-versions
+  echo 'legacy_version_file = yes' > $HOME/.asdfrc
+
+  run asdf which "dummy"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$ASDF_DIR/installs/dummy/1.1/bin/dummy" ]
 }


### PR DESCRIPTION
# Summary

Some regressions had been introduced in version handling, the most important one being the support for legacy files.

Support for multiple versions of the same plugin had also changed, making it incompatible with `asdf current`, `asdf local` and `asdf global` commands.
Up to 9b27848d07b86a7fe5c5294e89bf7f3674ea50f2, multiple versions could be set in `.tool-versions` by separating versions with a space. After 9b27848d07b86a7fe5c5294e89bf7f3674ea50f2, the same could be achieved by adding multiple lines with the same plugin name.
However, this plays badly with `asdf local` and `asdf global` as there is no easy way to set multiple versions, while it is trivial with the single line approach.
This PR reverts the behavior to use space separated versions.

I also added a regression test for legacy files and some documentation for using multiple versions.

Please take a look when you have a moment @vic @Stratus3D 

Fixes: #482, #470
