### PR TITLE
Fix select version when multiple versions available

### DIFF
--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -114,6 +114,7 @@ teardown() {
 }
 
 @test "shim exec should execute first plugin that is installed and set" {
+  run asdf install dummy 2.0
   run asdf install dummy 3.0
 
   echo "dummy 1.0 3.0 2.0" > $PROJECT_DIR/.tool-versions


### PR DESCRIPTION
With the previous version, the following case would fail.
It would use python 2.7.15 when running pip
instead of version 3.7.2.

Shim for `pip`

```bash
exec /home/daniel/.asdf/bin/asdf exec "pip" "$@"
```

`.tool-versions`:

```
python 3.7.2 2.7.15 system
```
