### PR TITLE
rename homepage.md & default to README.md for homepage

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+<!-- asdf-vm homepage -->
+
+<!-- include the repo readme -->
+[](https://raw.githubusercontent.com/asdf-vm/asdf/master/README.md ':include')
+
+<!-- include the ballad of asdf-vm -->
+[](https://raw.githubusercontent.com/asdf-vm/asdf/master/ballad-of-asdf.md ':include')

--- a/docs/homepage.md
+++ b/docs/homepage.md
@@ -1,7 +1,0 @@
-<!-- asdf-vm homepage -->
-
-<!-- include the repo readme -->
-[](https://raw.githubusercontent.com/asdf-vm/asdf/master/README.md ":include")
-
-<!-- include the ballad of asdf-vm -->
-[](https://raw.githubusercontent.com/asdf-vm/asdf/master/ballad-of-asdf.md ":include")

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,6 @@
         name: "asdf-vm",
         repo: "https://github.com/asdf-vm/asdf",
         el: "#app",
-        homepage: "homepage.md",
         coverpage: true,
         loadNavbar: true,
         loadSidebar: true,


### PR DESCRIPTION
# Summary

rename `docs/homepage.md` to `docs/README.md` as the Docsify default of loading `README.md` works in a multi-lang setup whereas defining a custom homepage does not at this time.