### PR TITLE
Improve output of where command when system version is set

### DIFF
--- a/lib/commands/where.sh
+++ b/lib/commands/where.sh
@@ -32,7 +32,12 @@ where_command() {
     echo "$install_path"
     exit 0
   else
-    echo "Version not installed"
-    exit 1
+    if [ "$version" = "system" ]; then
+      echo "System version is selected"
+      exit 1
+    else
+      echo "Version not installed"
+      exit 1
+    fi
   fi
 }

--- a/test/where_command.bats
+++ b/test/where_command.bats
@@ -49,6 +49,12 @@ function teardown() {
   [ "$output" = "Version not installed" ]
 }
 
+@test "where should error when system version is set" {
+  run asdf where 'dummy' 'system'
+  [ "$status" -eq 1 ]
+  [ "$output" = "System version is selected" ]
+}
+
 @test "where should error when no current version selected and version not specified" {
   run asdf where 'dummy'
 


### PR DESCRIPTION
# Summary

Update `where` command so `System version is selected` is printed instead of `Version not installed` when the system version is selected for the plugin.

Fixes: #477 