### PR TITLE
Fix shim_plugin_version

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -567,7 +567,7 @@ shim_plugin_versions() {
   local shim_path
   shim_path="$(asdf_data_dir)/shims/${executable_name}"
   if [ -x "$shim_path" ]; then
-    grep -y "# asdf-plugin: " "$shim_path" 2>/dev/null | sed -e "s/# asdf-plugin: //" | uniq
+    grep "# asdf-plugin: " "$shim_path" 2>/dev/null | sed -e "s/# asdf-plugin: //" | uniq
   else
     echo "asdf: unknown shim $executable_name"
     return 1

--- a/test/banned_commands.bats
+++ b/test/banned_commands.bats
@@ -9,6 +9,9 @@ banned_commands=(
     # It's best to avoid eval as it makes it easier to accidentally execute
     # arbitrary strings
     eval
+
+    # does not work on alpine and should be grep -i either way
+    "grep -y"
     )
 
 setup() {


### PR DESCRIPTION
`grep -y` seems to be available only on some implementations on `grep` and was not needed here.
This should fix #488