### PR TITLE
Use custom edit on github plugin. Fix #469

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -24,7 +24,7 @@
   <body>
     <div id="app"></div>
     <!-- edit on github plugin must appear here -->
-    <script src="//unpkg.com/docsify-edit-on-github@1.0.1/index.js"></script>
+    <script src="scripts/docsify-edit-on-github.js"></script>
     <script>
       window.$docsify = {
         name: "asdf-vm",
@@ -62,8 +62,12 @@
         },
         plugins: [
           EditOnGithubPlugin.create(
-            "https://github.com/asdf-vm/asdf/blob/master/docs/"
-          ),
+            "https://github.com/asdf-vm/asdf/blob/master/docs/", {
+            customURLs: {
+              "https://raw.githubusercontent.com/asdf-vm/asdf-plugins/master/README.md": "https://github.com/asdf-vm/asdf-plugins/edit/master/README.md",
+              "https://raw.githubusercontent.com/asdf-vm/asdf/master/CHANGELOG.md": "https://github.com/asdf-vm/asdf/edit/master/CHANGELOG.md"
+            }
+          })
         ],
       };
     </script>

--- a/docs/scripts/docsify-edit-on-github.js
+++ b/docs/scripts/docsify-edit-on-github.js
@@ -1,0 +1,47 @@
+;(function(win) {
+  win.EditOnGithubPlugin = {}
+
+  function create(docBase, options) {
+    options = options || {}
+    title = options.title || 'Edit on github'
+    customURLs = options.customURLs || {}
+    var docEditBase = docBase.replace(/\/blob\//, '/edit/')
+
+    function editDoc(event, vm) {
+      var docName = vm.route.file
+
+      if (docName) {
+        var editLink = customURLs[docName] || docEditBase + docName
+        window.open(editLink)
+        event.preventDefault()
+        return false
+      } else {
+        return true
+      }
+    }
+
+    win.EditOnGithubPlugin.editDoc = editDoc
+
+    return function(hook, vm) {
+      win.EditOnGithubPlugin.onClick = function(event) {
+        EditOnGithubPlugin.editDoc(event, vm)
+      }
+
+      var header = [
+        '<div style="overflow: auto">',
+        '<p style="float: right"><a href="',
+        docBase,
+        '" target="_blank" onclick="EditOnGithubPlugin.onClick(event)">',
+        title,
+        '</a></p>',
+        '</div>'
+      ].join('')
+
+      hook.afterEach(function (html) {
+        return header + html
+      })
+    }
+  }
+
+  win.EditOnGithubPlugin.create = create
+}) (window)


### PR DESCRIPTION
This should fix #469 
Edit on github plugin is trivial so I think we're better off hosting our customized version than trying to get this merged upstream.