### PR TITLE
Add Homebrew instructions

### DIFF
--- a/docs/core-manage-asdf-vm.md
+++ b/docs/core-manage-asdf-vm.md
@@ -1,5 +1,9 @@
 ## Install asdf-vm
 
+<!-- tabs:start -->
+
+#### ** Git **
+
 Clone only the latest branch:
 
 ```shell
@@ -14,6 +18,16 @@ cd ~/.asdf
 git checkout "$(git describe --abbrev=0 --tags)"
 ```
 
+#### ** Homebrew **
+
+Install using the Homebrew package manager on macOS:
+
+```shell
+brew install asdf
+```
+
+<!-- tabs:end -->
+
 ### Add to your Shell
 
 <!-- tabs:start -->
@@ -27,9 +41,23 @@ echo -e '\n. $HOME/.asdf/completions/asdf.bash' >> ~/.bashrc
 
 #### ** Bash on macOS **
 
+Installation via **Git**:
+
 ```bash
 echo -e '\n. $HOME/.asdf/asdf.sh' >> ~/.bash_profile
 echo -e '\n. $HOME/.asdf/completions/asdf.bash' >> ~/.bash_profile
+```
+
+Installation via **Homebrew**:
+
+?> If you have Homebrew's Bash completions configured, the second line below is
+unnecessary. See [Configuring Completions
+in Bash](https://docs.brew.sh/Shell-Completion#configuring-completions-in-bash)
+in the Homebrew docs.
+
+```bash
+echo -e '\n. $(brew --prefix asdf)/asdf.sh' >> ~/.bash_profile
+echo -e '\n. $(brew --prefix asdf)/etc/bash_completion.d/asdf.bash' >> ~/.bash_profile
 ```
 
 #### ** ZSH **
@@ -115,6 +143,10 @@ That's all! You are ready to use asdf 🎉
 
 ## Update
 
+<!-- tabs:start -->
+
+### ** Git **
+
 ```shell
 asdf update
 ```
@@ -124,6 +156,14 @@ If you want the latest changes that aren't yet included in a stable release:
 ```shell
 asdf update --head
 ```
+
+### ** Homebrew **
+
+```shell
+brew upgrade asdf
+```
+
+<!-- tabs:end -->
 
 ## Remove
 
@@ -138,6 +178,10 @@ Uninstalling `asdf` is as simple as:
 
     Remove these lines and save the file.
 
-2.  Run `rm -rf ~/.asdf/ ~/.tool-versions` to completely remove all the asdf files from your system.
+2.  Run `rm -rf ~/.asdf/ ~/.tool-versions` to completely remove all the asdf
+    files from your system.
+
+3.  _(Optional)_ If you installed asdf using a package manager, you may want to use
+    that package manager to uninstall the core asdf files.
 
 That's it! 🎉


### PR DESCRIPTION
# Summary

Added installation, shell setup, and upgrade instructions for use with Homebrew.
Added a brief item for uninstall related to package managers.

Fixes: #425

## Other Information

I decided to not make the `Add to your Shell` portion a tab item of its own, instead keeping it under `Bash on macOS`. I followed nomenclature found elsewhere in the document to clarify variant install situations.

It's worth noting that Homebrew can be used with Windows 10 with Windows Subsystem for Linux, though I'm not sure if that is applicable to `asdf` at present.
