### PR TITLE
Make install command ignore comments

### DIFF
--- a/lib/commands/install.sh
+++ b/lib/commands/install.sh
@@ -40,19 +40,17 @@ install_local_tool_versions() {
   local asdf_versions_path
   asdf_versions_path=$(find_tool_versions)
   if [ -f "${asdf_versions_path}" ]; then
-    while IFS= read -r tool_line || [ -n "$tool_line" ]; do
-      if ! (echo "$tool_line" | grep "^#.*" > /dev/null); then
-        IFS=' ' read -r -a tool_info <<< "$tool_line"
-        local tool_name
-        tool_name=$(echo "${tool_info[0]}" | xargs)
-        local tool_version
-        tool_version=$(echo "${tool_info[1]}" | xargs)
+    while IFS= read -r tool_line; do
+      IFS=' ' read -r -a tool_info <<< "$tool_line"
+      local tool_name
+      tool_name=$(echo "${tool_info[0]}" | xargs)
+      local tool_version
+      tool_version=$(echo "${tool_info[1]}" | xargs)
 
-        if ! [[ -z "$tool_name" || -z "$tool_version" ]]; then
-          install_tool_version "$tool_name" "$tool_version"
-        fi
+      if ! [[ -z "$tool_name" || -z "$tool_version" ]]; then
+        install_tool_version "$tool_name" "$tool_version"
       fi
-    done < "$asdf_versions_path"
+    done <<<"$(strip_tool_version_comments "$asdf_versions_path")"
   else
     echo "Either specify a tool & version in the command"
     echo "OR add .tool-versions file in this directory"

--- a/lib/commands/install.sh
+++ b/lib/commands/install.sh
@@ -41,14 +41,16 @@ install_local_tool_versions() {
   asdf_versions_path=$(find_tool_versions)
   if [ -f "${asdf_versions_path}" ]; then
     while IFS= read -r tool_line || [ -n "$tool_line" ]; do
-      IFS=' ' read -r -a tool_info <<< "$tool_line"
-      local tool_name
-      tool_name=$(echo "${tool_info[0]}" | xargs)
-      local tool_version
-      tool_version=$(echo "${tool_info[1]}" | xargs)
+      if ! (echo "$tool_line" | grep "^#.*" > /dev/null); then
+        IFS=' ' read -r -a tool_info <<< "$tool_line"
+        local tool_name
+        tool_name=$(echo "${tool_info[0]}" | xargs)
+        local tool_version
+        tool_version=$(echo "${tool_info[1]}" | xargs)
 
-      if ! [[ -z "$tool_name" || -z "$tool_version" ]]; then
-        install_tool_version "$tool_name" "$tool_version"
+        if ! [[ -z "$tool_name" || -z "$tool_version" ]]; then
+          install_tool_version "$tool_name" "$tool_version"
+        fi
       fi
     done < "$asdf_versions_path"
   else

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -574,6 +574,19 @@ shim_plugin_versions() {
   fi
 }
 
+strip_tool_version_comments() {
+  local tool_version_path="$1"
+
+  while IFS= read -r tool_line || [ -n "$tool_line" ]; do
+    # Remove whitespace before pound sign, the pound sign, and everything after it
+    new_line="$(echo "$tool_line" | sed -r -e 's/(\s*\#.*)//')"
+
+    # Only print the line if it is not empty
+    if [[ ! -z "$new_line" ]]; then
+      echo "$new_line"
+    fi
+  done < "$tool_version_path"
+}
 
 asdf_run_hook() {
   local hook_name=$1

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -582,7 +582,7 @@ strip_tool_version_comments() {
     new_line="$(echo "$tool_line" | cut -f1 -d"#" | sed -e 's/[[:space:]]*$//')"
 
     # Only print the line if it is not empty
-    if [[ ! -z "$new_line" ]]; then
+    if [[ -n "$new_line" ]]; then
       echo "$new_line"
     fi
   done < "$tool_version_path"

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -579,7 +579,7 @@ strip_tool_version_comments() {
 
   while IFS= read -r tool_line || [ -n "$tool_line" ]; do
     # Remove whitespace before pound sign, the pound sign, and everything after it
-    new_line="$(echo "$tool_line" | sed -r -e 's/(\s*\#.*)//')"
+    new_line="$(echo "$tool_line" | cut -f1 -d"#" | sed -e 's/[[:space:]]*$//')"
 
     # Only print the line if it is not empty
     if [[ ! -z "$new_line" ]]; then

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -153,3 +153,12 @@ EOM
   run asdf install dummy 1.0
   [ "$output" == "HEY 1.0 FROM dummy" ]
 }
+
+@test "install_command skips comments in .tool-versions file" {
+  cd $PROJECT_DIR
+  echo -n '# dummy 1.2' > ".tool-versions"
+  run asdf install
+  [ "$status" -eq 0 ]
+  [ "$output" == "" ]
+  [ ! -f $ASDF_DIR/installs/dummy/1.2/version ]
+}

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -314,3 +314,51 @@ teardown() {
   [ "$output" = $(pwd)/foo ]
   rm -f foo bar
 }
+
+@test "strip_tool_version_comments removes lines that only contain comments" {
+  cat <<EOF > test_file
+# comment line
+ruby 2.0.0
+EOF
+  run strip_tool_version_comments test_file
+  [ "$status" -eq 0 ]
+  [ "$output" = "ruby 2.0.0" ]
+}
+@test "strip_tool_version_comments removes lines that only contain comments even with missing newline" {
+  echo -n "# comment line" > test_file
+  run strip_tool_version_comments test_file
+  [ "$status" -eq 0 ]
+  [ "$output" = "" ]
+}
+
+@test "strip_tool_version_comments removes trailing comments on lines containing version information" {
+  cat <<EOF > test_file
+ruby 2.0.0 # inline comment
+EOF
+  run strip_tool_version_comments test_file
+  [ "$status" -eq 0 ]
+  [ "$output" = "ruby 2.0.0" ]
+}
+
+@test "strip_tool_version_comments removes trailing comments on lines containing version information even with missing newline" {
+  echo -n "ruby 2.0.0 # inline comment" > test_file
+  run strip_tool_version_comments test_file
+  [ "$status" -eq 0 ]
+  [ "$output" = "ruby 2.0.0" ]
+}
+
+@test "strip_tool_version_comments removes all comments from the version file" {
+  cat <<EOF > test_file
+ruby 2.0.0 # inline comment
+# comment line
+erlang 18.2.1 # inline comment
+EOF
+  expected="$(cat <<EOF
+ruby 2.0.0
+erlang 18.2.1
+EOF
+)"
+  run strip_tool_version_comments test_file
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
+}


### PR DESCRIPTION
# Summary

Make install command ignore comments. Skip lines matching the pattern `^#.*`, e.g. any line starting with `#`.

Fixes: #489
