### PR TITLE
Revert to using exec when running a shim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@
 Features
 
 * Add documentation about using multiple versions of the same plugin
+* Remove post_COMMAND hooks
 
 Fixed Bugs
 
 * Restore support for legacy file version
+* Run executable using `exec`
 
 ## 0.7.0
 

--- a/lib/commands/shim-exec.sh
+++ b/lib/commands/shim-exec.sh
@@ -20,15 +20,10 @@ shim_exec_command() {
 
     asdf_run_hook "pre_${plugin_name}_${shim_name}" "${shim_args[@]}"
     pre_status=$?
-    if [ "$pre_status" -eq 0 ]; then
-      "$executable_path" "${shim_args[@]}"
-      exit_status=$?
+    if [ "$pre_status" -ne 0 ]; then
+      return "$pre_status"
     fi
-    if [ "${exit_status:-${pre_status}}" -eq 0 ]; then
-      asdf_run_hook "post_${plugin_name}_${shim_name}" "${shim_args[@]}"
-      post_status=$?
-    fi
-    exit "${post_status:-${exit_status:-${pre_status}}}"
+    exec "$executable_path" "${shim_args[@]}"
   }
 
   with_shim_executable "$shim_name" exec_shim || exit $?

--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -406,32 +406,3 @@ EOM
   [ "$status" -eq 1 ]
 }
 
-@test "shim exec executes configured post-hook if command was successful" {
-  run asdf install dummy 1.0
-  echo dummy 1.0 > $PROJECT_DIR/.tool-versions
-
-  cat > $HOME/.asdfrc <<-'EOM'
-post_dummy_dummy = echo POST $version $1 $2
-EOM
-
-  run $ASDF_DIR/shims/dummy hello world
-  [ "$status" -eq 0 ]
-  echo "$output" | grep "This is Dummy 1.0! world hello"
-  echo "$output" | grep "POST 1.0 hello world"
-}
-
-@test "shim exec does not executes configured post-hook if command failed" {
-  run asdf install dummy 1.0
-  echo dummy 1.0 > $PROJECT_DIR/.tool-versions
-
-  cat > $HOME/.asdfrc <<-'EOM'
-post_dummy_dummy = echo POST
-EOM
-
-  echo "false" > $ASDF_DIR/installs/dummy/1.0/bin/dummy
-  chmod +x $ASDF_DIR/installs/dummy/1.0/bin/dummy
-
-  run $ASDF_DIR/shims/dummy hello world
-  [ "$status" -eq 1 ]
-  [ "$output" == "" ]
-}


### PR DESCRIPTION
As discussed, this reverts to the previous behavior of executing shims with `exec`.
This is a step back towards #409 but I do not think we have a way around it.
Fixes #475