### PR TITLE
Fix current when .tool-versions contains comments

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -269,7 +269,7 @@ parse_asdf_version_file() {
 
   if [ -f "$file_path" ]; then
     local version
-    version=$(grep "^${plugin_name} " "$file_path" | sed -e "s/^${plugin_name} //")
+    version=$(strip_tool_version_comments "$file_path" | grep "^${plugin_name} "| sed -e "s/^${plugin_name} //")
     if [ -n "$version" ]; then
       echo "$version"
       return 0

--- a/test/current_command.bats
+++ b/test/current_command.bats
@@ -121,3 +121,13 @@ foobar         1.0.0    (set by $PROJECT_DIR/.tool-versions)"
   [ "$status" -eq 0 ]
   echo "$output" | grep "Oohes nooes ~! No plugins installed"
 }
+
+@test "current should handle comments" {
+  cd $PROJECT_DIR
+  echo "dummy 1.2.0  # this is a comment" >> $PROJECT_DIR/.tool-versions
+
+  run asdf current "dummy"
+  echo "$output"
+  [ "$status" -eq 0 ]
+  [ "$output" = "1.2.0    (set by $PROJECT_DIR/.tool-versions)" ]
+}


### PR DESCRIPTION
#498 did not support comments when using `asdf current`.
This should fix the issue. 