### PR TITLE
Add more plugin dependencies 

### DIFF
--- a/docs/core-manage-asdf-vm.md
+++ b/docs/core-manage-asdf-vm.md
@@ -108,7 +108,8 @@ Installation via Homebrew:
 ```shell
 brew install \
   coreutils automake autoconf openssl \
-  libyaml readline libxslt libtool unixodbc unzip curl
+  libyaml readline libxslt libtool unixodbc \
+  unzip curl
 ```
 
 Installation via Spack:
@@ -116,7 +117,8 @@ Installation via Spack:
 ```shell
 spack install \
   coreutils automake autoconf openssl \
-  libyaml readline libxslt libtool unixodbc unzip curl
+  libyaml readline libxslt libtool unixodbc \
+  unzip curl
 ```
 
 #### ** Ubuntu **

--- a/docs/core-manage-asdf-vm.md
+++ b/docs/core-manage-asdf-vm.md
@@ -108,7 +108,7 @@ Installation via Homebrew:
 ```shell
 brew install \
   coreutils automake autoconf openssl \
-  libyaml readline libxslt libtool unixodbc
+  libyaml readline libxslt libtool unixodbc unzip curl
 ```
 
 Installation via Spack:
@@ -116,7 +116,7 @@ Installation via Spack:
 ```shell
 spack install \
   coreutils automake autoconf openssl \
-  libyaml readline libxslt libtool unixodbc
+  libyaml readline libxslt libtool unixodbc unzip curl
 ```
 
 #### ** Ubuntu **
@@ -125,7 +125,8 @@ spack install \
 sudo apt install \
   automake autoconf libreadline-dev \
   libncurses-dev libssl-dev libyaml-dev \
-  libxslt-dev libffi-dev libtool unixodbc-dev
+  libxslt-dev libffi-dev libtool unixodbc-dev \
+  unzip curl
 ```
 
 #### **Fedora**
@@ -134,7 +135,8 @@ sudo apt install \
 sudo dnf install \
   automake autoconf readline-devel \
   ncurses-devel openssl-devel libyaml-devel \
-  libxslt-devel libffi-devel libtool unixODBC-devel
+  libxslt-devel libffi-devel libtool unixODBC-devel \
+  unzip curl
 ```
 
 <!-- tabs:end -->


### PR DESCRIPTION
# Summary

I was doing a test of getting up and running using asdf on a fresh Ubuntu install it became aparant that curl and unzip were required for some plugins to install, it makes sense to me to add these to the base dependencies list to give a better getting started experience.
