### PR TITLE
Run source after .bashrc update in Linux bash

### DIFF
--- a/docs/core-manage-asdf-vm.md
+++ b/docs/core-manage-asdf-vm.md
@@ -37,6 +37,7 @@ brew install asdf
 ```bash
 echo -e '\n. $HOME/.asdf/asdf.sh' >> ~/.bashrc
 echo -e '\n. $HOME/.asdf/completions/asdf.bash' >> ~/.bashrc
+source ~/.bashrc
 ```
 
 #### ** Bash on macOS **


### PR DESCRIPTION
After you update .bashrc in Linux, you either need to run source or re-open the terminal. Added the source command in this install recommendation doc.