### PR TITLE
update setup documentation for zsh and homebrew

### DIFF
--- a/docs/core-manage-asdf-vm.md
+++ b/docs/core-manage-asdf-vm.md
@@ -66,9 +66,23 @@ If you are using a framework, such as oh-my-zsh, use these lines. (Be sure
 that if you make future changes to .zshrc these lines remain _below_ the line
 where you source your framework.)
 
+Installation via **Git**:
+
 ```shell
 echo -e '\n. $HOME/.asdf/asdf.sh' >> ~/.zshrc
 echo -e '\n. $HOME/.asdf/completions/asdf.bash' >> ~/.zshrc
+```
+
+Installation via **Homebrew**:
+
+?> If you have Homebrew's Bash completions configured, the second line below is
+unnecessary. See [Configuring Completions
+in Bash](https://docs.brew.sh/Shell-Completion#configuring-completions-in-bash)
+in the Homebrew docs.
+
+```shell
+echo -e '\n. $(brew --prefix asdf)/asdf.sh' >> ~/.zshrc
+echo -e '\n. $(brew --prefix asdf)/completions/asdf.bash' >> ~/.zshrc
 ```
 
 If you are not using a framework, or if on starting your shell you get an


### PR DESCRIPTION
Minor update the setup documentation for zsh and homebrew users. Hope this makes it easier for some people in the future to add the correct lines to their `~/.zshrc` file