### PR TITLE
WIP: Bash Strict Mode

### DIFF
--- a/bin/asdf
+++ b/bin/asdf
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+set -o nounset -o pipefail -o errexit
+IFS=$'\t\n' # Stricter IFS settings
 
 # shellcheck source=lib/utils.sh
 source "$(dirname "$(dirname "$0")")/lib/utils.sh"

--- a/lib/commands/current.sh
+++ b/lib/commands/current.sh
@@ -1,5 +1,8 @@
+set -o nounset -o pipefail -o errexit
+IFS=$'\t\n' # Stricter IFS settings
+
 plugin_current_command() {
-  local plugin_name=$1
+  local plugin_name=${1:-}
 
   check_if_plugin_exists "$plugin_name"
 
@@ -32,7 +35,7 @@ current_command() {
       printf "%-15s%s\\n" "$plugin" "$(plugin_current_command "$plugin")" >&2
     done
   else
-    local plugin=$1
+    local plugin=${1:-}
     plugin_current_command "$plugin"
   fi
 }
@@ -44,7 +47,7 @@ check_for_deprecated_plugin() {
   local plugin_path
   plugin_path=$(get_plugin_path "$plugin_name")
   local legacy_config
-  legacy_config=$(get_asdf_config_value "legacy_version_file")
+  legacy_config=$(get_asdf_config_value "legacy_version_file" || true)
   local deprecated_script="${plugin_path}/bin/get-version-from-legacy-file"
   local new_script="${plugin_path}/bin/list-legacy-filenames"
 

--- a/lib/commands/list.sh
+++ b/lib/commands/list.sh
@@ -1,5 +1,8 @@
+set -o nounset -o pipefail -o errexit
+IFS=$'\t\n' # Stricter IFS settings
+
 list_command() {
-  local plugin_name=$1
+  local plugin_name=${1:-}
 
   if [ -z "$plugin_name" ]; then
     local plugins_path

--- a/lib/commands/plugin-add.sh
+++ b/lib/commands/plugin-add.sh
@@ -1,13 +1,16 @@
+set -o nounset -o pipefail -o errexit
+IFS=$'\t\n' # Stricter IFS settings
+
 plugin_add_command() {
   if [[ $# -lt 1 || $# -gt 2 ]]; then
     display_error "usage: asdf plugin-add <name> [<git-url>]"
     exit 1
   fi
 
-  local plugin_name=$1
+  local plugin_name=${1:-}
 
-  if [ -n "$2" ]; then
-    local source_url=$2
+  if [ -n "${2:-}" ]; then
+    local source_url=${2:-}
   else
     initialize_or_update_repository
     local source_url

--- a/lib/commands/plugin-list.sh
+++ b/lib/commands/plugin-list.sh
@@ -1,5 +1,8 @@
+set -o nounset -o pipefail -o errexit
+IFS=$'\t\n' # Stricter IFS settings
+
 plugin_list_command() {
-  local flag=$1
+  local flag=${1:-}
 
   # 0 || 1 with flag
   if [ $# -eq 0 ] || { [ $# -eq 1 ] && [ "$flag" = "--urls" ]; }; then

--- a/lib/commands/plugin-remove.sh
+++ b/lib/commands/plugin-remove.sh
@@ -1,5 +1,8 @@
+set -o nounset -o pipefail -o errexit
+IFS=$'\t\n' # Stricter IFS settings
+
 plugin_remove_command() {
-  local plugin_name=$1
+  local plugin_name=${1:-}
   check_if_plugin_exists "$plugin_name"
 
   local plugin_path
@@ -8,5 +11,6 @@ plugin_remove_command() {
   rm -rf "$plugin_path"
   rm -rf "$(asdf_data_dir)/installs/${plugin_name}"
 
-  grep -l "asdf-plugin: ${plugin_name}" "$(asdf_data_dir)"/shims/* 2>/dev/null | xargs rm -f
+  # This command may fail if no shims are found
+  grep -l "asdf-plugin: ${plugin_name}" "$(asdf_data_dir)"/shims/* 2>/dev/null | xargs rm -f || true
 }

--- a/lib/commands/plugin-test.sh
+++ b/lib/commands/plugin-test.sh
@@ -1,7 +1,9 @@
-plugin_test_command() {
+set -o nounset -o pipefail -o errexit
+IFS=$'\t\n' # Stricter IFS settings
 
-    local plugin_name=$1
-    local plugin_url=$2
+plugin_test_command() {
+    local plugin_name=${1:-}
+    local plugin_url=${2:-}
     local plugin_command_array=()
     local plugin_command
     local tool_version
@@ -30,7 +32,7 @@ plugin_test_command() {
 
     fail_test() {
         echo "FAILED: $1"
-        rm -rf "$TEST_DIR"
+        rm -rf "${TEST_DIR:-}"
         exit 1
     }
 

--- a/lib/commands/reshim.sh
+++ b/lib/commands/reshim.sh
@@ -1,6 +1,9 @@
+set -o nounset -o pipefail -o errexit
+IFS=$'\t\n' # Stricter IFS settings
+
 reshim_command() {
-  local plugin_name=$1
-  local full_version=$2
+  local plugin_name=${1:-}
+  local full_version=${2:-}
 
   if [ -z "$plugin_name" ]; then
     local plugins_path
@@ -20,7 +23,7 @@ reshim_command() {
 
   if [ "$full_version" != "" ]; then
     # generate for the whole package version
-    asdf_run_hook "pre_asdf_reshim_$plugin_name" "$full_version_name"
+    asdf_run_hook "pre_asdf_reshim_$plugin_name" "$full_version"
     generate_shims_for_version "$plugin_name" "$full_version"
     asdf_run_hook "post_asdf_reshim_$plugin_name" "$full_version"
   else
@@ -120,7 +123,7 @@ remove_obsolete_shims() {
   obsolete_shims=$(comm -23 <(echo "$shims") <(echo "$exec_names"))
 
   for shim_name in $obsolete_shims; do
-    remove_shim_for_version "$plugin_name" "$version" "$shim_name"
+    remove_shim_for_version "$plugin_name" "$full_version" "$shim_name"
   done
 }
 

--- a/lib/commands/shim-env.sh
+++ b/lib/commands/shim-env.sh
@@ -1,6 +1,9 @@
+set -o nounset -o pipefail -o errexit
+IFS=$'\t\n' # Stricter IFS settings
+
 shim_env_command() {
-  local shim_name="$1"
-  local env_cmd="${2}"
+  local shim_name="${1:-}"
+  local env_cmd="${2:-}"
   local env_args=("${@:3}")
 
   if [ -z "$shim_name" ]; then

--- a/lib/commands/shim-exec.sh
+++ b/lib/commands/shim-exec.sh
@@ -1,6 +1,9 @@
+set -o nounset -o pipefail -o errexit
+IFS=$'\t\n' # Stricter IFS settings
+
 shim_exec_command() {
   local shim_name
-  shim_name=$(basename "$1")
+  shim_name=$(basename "${1:-}")
   local shim_args=("${@:2}")
 
   if [ -z "$shim_name" ]; then

--- a/lib/commands/update.sh
+++ b/lib/commands/update.sh
@@ -1,5 +1,8 @@
+set -o nounset -o pipefail -o errexit
+IFS=$'\t\n' # Stricter IFS settings
+
 update_command() {
-  local update_to_head=$1
+  local update_to_head=${1:-}
 
   (
   cd "$(asdf_dir)" || exit 1

--- a/lib/commands/version_commands.sh
+++ b/lib/commands/version_commands.sh
@@ -1,3 +1,6 @@
+set -o nounset -o pipefail -o errexit
+IFS=$'\t\n' # Stricter IFS settings
+
 version_command() {
   local cmd=$1
   local plugin=$2
@@ -12,7 +15,8 @@ version_command() {
   fi
 
   shift 2
-  local versions=("$@")
+  local versions
+  IFS=$' ' versions=("$@")
 
   local file
   if [ "$cmd" = "global" ]; then
@@ -37,10 +41,10 @@ version_command() {
 
 
   if [ -f "$file" ] && grep "^$plugin " "$file" > /dev/null; then
-    sed -i.bak -e "s/^$plugin .*$/$plugin ${versions[*]}/" "$file"
+    IFS=$' ' sed -i.bak -e "s/^$plugin .*$/$plugin ${versions[*]}/" "$file"
     rm "$file".bak
   else
-    echo "$plugin ${versions[*]}" >> "$file"
+    IFS=$' ' echo "$plugin ${versions[*]}" >> "$file"
   fi
 }
 
@@ -86,8 +90,8 @@ shell_command() {
     exit 1
   fi
 
-  local plugin=$1
-  local version=$2
+  local plugin=${1:-}
+  local version=${2:-}
 
   if ! (check_if_version_exists "$plugin" "$version"); then
     echo 'false'
@@ -98,7 +102,7 @@ shell_command() {
   upcase_name=$(echo "$plugin" | tr '[:lower:]-' '[:upper:]_')
   local version_env_var="ASDF_${upcase_name}_VERSION"
 
-  case $ASDF_SHELL in
+  case ${ASDF_SHELL:-} in
     fish )
       echo "set -gx $version_env_var \"$version\"";;
     * )

--- a/lib/commands/where.sh
+++ b/lib/commands/where.sh
@@ -1,6 +1,9 @@
+set -o nounset -o pipefail -o errexit
+IFS=$'\t\n' # Stricter IFS settings
+
 where_command() {
-  local plugin_name=$1
-  local full_version=$2
+  local plugin_name=${1:-}
+  local full_version=${2:-}
   check_if_plugin_exists "$plugin_name"
 
   local version

--- a/lib/commands/which.sh
+++ b/lib/commands/which.sh
@@ -1,6 +1,9 @@
+set -o nounset -o pipefail -o errexit
+IFS=$'\t\n' # Stricter IFS settings
+
 which_command() {
   local shim_name
-  shim_name=$(basename "$1")
+  shim_name=$(basename "${1:-}")
 
   if [ -z "$shim_name" ]; then
     echo "usage: asdf which <command>"

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -104,7 +104,7 @@ check_if_version_exists() {
 }
 
 get_plugin_path() {
-  echo "$(asdf_data_dir)/plugins/$1"
+  echo "$(asdf_data_dir)/plugins/${1:-}"
 }
 
 display_error() {
@@ -153,7 +153,7 @@ find_version() {
   local plugin_path
   plugin_path=$(get_plugin_path "$plugin_name")
   local legacy_config
-  legacy_config=$(get_asdf_config_value "legacy_version_file")
+  legacy_config=$(get_asdf_config_value "legacy_version_file" || true)
   local legacy_list_filenames_script
   legacy_list_filenames_script="${plugin_path}/bin/list-legacy-filenames"
   local legacy_filenames=""

--- a/test/asdf_sh.bats
+++ b/test/asdf_sh.bats
@@ -12,7 +12,10 @@ cleaned_path() {
 }
 
 @test "exports ASDF_DIR" {
+  # Mimic a real interactive shell, we need to turn off the "Bash strict mode"
+  # settings.
   result=$(
+    set +euo
     unset -f asdf
     unset ASDF_DIR
     PATH=$(cleaned_path)
@@ -27,7 +30,10 @@ cleaned_path() {
 }
 
 @test "adds asdf dirs to PATH" {
+  # Mimic a real interactive shell, we need to turn off the "Bash strict mode"
+  # settings.
   result=$(
+    set +euo
     unset -f asdf
     unset ASDF_DIR
     PATH=$(cleaned_path)
@@ -42,7 +48,10 @@ cleaned_path() {
 }
 
 @test "does not add paths to PATH more than once" {
+  # Mimic a real interactive shell, we need to turn off the "Bash strict mode"
+  # settings.
   result=$(
+    set +euo
     unset -f asdf
     unset ASDF_DIR
     PATH=$(cleaned_path)
@@ -58,7 +67,10 @@ cleaned_path() {
 }
 
 @test "defines the asdf function" {
+  # Mimic a real interactive shell, we need to turn off the "Bash strict mode"
+  # settings.
   output=$(
+    set +euo
     unset -f asdf
     unset ASDF_DIR
     PATH=$(cleaned_path)

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -71,7 +71,6 @@ teardown() {
 @test "parse_asdf_version_file should output path on project with spaces" {
   PROJECT_DIR="$PROJECT_DIR/outer space"
   mkdir -p "$PROJECT_DIR"
-  cd $outer
   echo "dummy 0.1.0" > "$PROJECT_DIR/.tool-versions"
   run parse_asdf_version_file "$PROJECT_DIR/.tool-versions" dummy
   [ "$status" -eq 0 ]


### PR DESCRIPTION
# Summary

Add Bash strict mode to all Bash script that are not sourced directly by the user.

We can't add Bash script mode to any files the user may source, or may get sourced by any other scripts, as the strict mode settings will leak into other contexts. I've had to make some changes to a few of the tests that emulate a user shell to get around this in the tests.

Fixes: #160, #247
