### PR TITLE
fix: check shims for the full version

### DIFF
--- a/lib/commands/reshim.sh
+++ b/lib/commands/reshim.sh
@@ -65,7 +65,7 @@ write_shim_script() {
   shim_path="$(asdf_data_dir)/shims/$executable_name"
 
   if [ -f "$shim_path" ]; then
-    if ! grep "# asdf-plugin: ${plugin_name} ${version}" "$shim_path" >/dev/null; then
+    if ! grep -x "# asdf-plugin: ${plugin_name} ${version}" "$shim_path" >/dev/null; then
      sed -i.bak -e "s/exec /# asdf-plugin: ${plugin_name} ${version}\\"$'\n''exec /' "$shim_path"
      rm "$shim_path".bak
     fi

--- a/lib/commands/reshim.sh
+++ b/lib/commands/reshim.sh
@@ -120,7 +120,7 @@ remove_obsolete_shims() {
   obsolete_shims=$(comm -23 <(echo "$shims") <(echo "$exec_names"))
 
   for shim_name in $obsolete_shims; do
-    remove_shim_for_version "$plugin_name" "$version" "$shim_name"
+    remove_shim_for_version "$plugin_name" "$full_version" "$shim_name"
   done
 }
 
@@ -137,11 +137,11 @@ remove_shim_for_version() {
   local count_installed
   count_installed=$(list_installed_versions "$plugin_name" | wc -l)
 
-  if ! grep "# asdf-plugin: $plugin_name $version" "$shim_path" > /dev/null 2>&1; then
+  if ! grep -x "# asdf-plugin: $plugin_name $version" "$shim_path" > /dev/null 2>&1; then
     return 0
   fi
 
-  sed -i.bak -e "/# asdf-plugin: $plugin_name $version/d" "$shim_path"
+  sed -i.bak -e "/# asdf-plugin: $plugin_name $version"'$/d' "$shim_path"
   rm "$shim_path".bak
 
   if ! grep "# asdf-plugin:" "$shim_path" > /dev/null || \
@@ -154,6 +154,6 @@ remove_shims_for_version() {
   local plugin_name=$1
   local full_version=$2
   for shim_path in $(plugin_shims "$plugin_name" "$full_version"); do
-    remove_shim_for_version "$plugin_name" "$version" "$shim_path"
+    remove_shim_for_version "$plugin_name" "$full_version" "$shim_path"
   done
 }

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -545,7 +545,7 @@ is_executable() {
 plugin_shims() {
   local plugin_name=$1
   local full_version=$2
-  grep -l "# asdf-plugin: $plugin_name $full_version" "$(asdf_data_dir)/shims"/* 2>/dev/null
+  grep -lx "# asdf-plugin: $plugin_name $full_version" "$(asdf_data_dir)/shims"/* 2>/dev/null
 }
 
 shim_plugin_versions() {

--- a/test/reshim_command.bats
+++ b/test/reshim_command.bats
@@ -57,6 +57,17 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
+@test "reshim should not remove metadata of removed prefix versions" {
+  run asdf install dummy 1.0
+  run asdf install dummy 1.0.1
+  run rm "$ASDF_DIR/installs/dummy/1.0/bin/dummy"
+  run asdf reshim dummy
+  [ "$status" -eq 0 ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
+  run grep "asdf-plugin: dummy 1.0.1" "$ASDF_DIR/shims/dummy"
+  [ "$status" -eq 0 ]
+}
+
 @test "reshim should not duplicate shims" {
   cd $PROJECT_DIR
 

--- a/test/reshim_command.bats
+++ b/test/reshim_command.bats
@@ -15,6 +15,19 @@ teardown() {
 }
 
 
+@test "reshim should allow prefixes of other versions" {
+  run asdf install dummy 1.0.1
+  run asdf install dummy 1.0
+
+  run asdf reshim
+  [ "$status" -eq 0 ]
+
+  run grep "asdf-plugin: dummy 1.0.1" "$ASDF_DIR/shims/dummy"
+  [ "$status" -eq 0 ]
+  run grep "asdf-plugin: dummy 1.0\$" "$ASDF_DIR/shims/dummy"
+  [ "$status" -eq 0 ]
+}
+
 @test "reshim command should remove shims of removed binaries" {
   run asdf install dummy 1.0
   [ "$status" -eq 0 ]


### PR DESCRIPTION
The current behavior in shims is to check if there's an existing shim for
which the shim we're currently checking is a prefix. For example, if the shim
has

    # asdf-plugin: erlang 21.2.6

Then adding a shim for `erlang 21.2` will fail.

This updates the `grep` check to match the end of the line as well so we
always get a full version check.

Fixes #517