### PR TITLE
Change `asdf install` to loop through available plugins and check legacy version files

### DIFF
--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -20,7 +20,7 @@ teardown() {
   [ $(cat $ASDF_DIR/installs/dummy/1.1/version) = "1.1" ]
 }
 
-@test "install_command installs even if the user is terrible and does not use newlines" {
+@test "install_command without arguments installs even if the user is terrible and does not use newlines" {
   cd $PROJECT_DIR
   echo -n 'dummy 1.2' > ".tool-versions"
   run asdf install
@@ -36,7 +36,7 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
-@test "install_command should work in directory containing whitespace" {
+@test "install_command without arguments should work in directory containing whitespace" {
   WHITESPACE_DIR="$PROJECT_DIR/whitespace\ dir"
   mkdir -p "$WHITESPACE_DIR"
   cd "$WHITESPACE_DIR"
@@ -78,7 +78,7 @@ teardown() {
   [ "$lines_count" -eq "1" ]
 }
 
-@test "install_command should not generate shim for subdir" {
+@test "install_command without arguments should not generate shim for subdir" {
   cd $PROJECT_DIR
   echo 'dummy 1.0' > $PROJECT_DIR/.tool-versions
 
@@ -88,7 +88,7 @@ teardown() {
   [ ! -f "$ASDF_DIR/shims/subdir" ]
 }
 
-@test "install_command generated shim should pass all arguments to executable" {
+@test "install_command without arguments should generate shim that passes all arguments to executable" {
   # asdf lib needed to run generated shims
   cp -rf $BATS_TEST_DIRNAME/../{bin,lib} $ASDF_DIR/
 
@@ -114,7 +114,7 @@ teardown() {
   [ ! -f $ASDF_DIR/installs/dummy/1.1/version ]
 }
 
-@test "install_command uses a parent directory .tool-versions file if present" {
+@test "install_command without arguments uses a parent directory .tool-versions file if present" {
   # asdf lib needed to run generated shims
   cp -rf $BATS_TEST_DIRNAME/../{bin,lib} $ASDF_DIR/
 
@@ -154,11 +154,24 @@ EOM
   [ "$output" == "HEY 1.0 FROM dummy" ]
 }
 
-@test "install_command skips comments in .tool-versions file" {
-  cd $PROJECT_DIR
-  echo -n '# dummy 1.2' > ".tool-versions"
+@test "install command without arguments installs versions from legacy files" {
+  echo 'legacy_version_file = yes' > $HOME/.asdfrc
+  echo '1.2' >> $PROJECT_DIR/.dummy-version
   run asdf install
   [ "$status" -eq 0 ]
   [ "$output" == "" ]
-  [ ! -f $ASDF_DIR/installs/dummy/1.2/version ]
+  [ -f $ASDF_DIR/installs/dummy/1.2/version ]
+}
+
+@test "install command without arguments installs versions from legacy files in parent directories" {
+  echo 'legacy_version_file = yes' > $HOME/.asdfrc
+  echo '1.2' >> $PROJECT_DIR/.dummy-version
+
+  mkdir -p $PROJECT_DIR/child
+  cd $PROJECT_DIR/child
+
+  run asdf install
+  [ "$status" -eq 0 ]
+  [ "$output" == "" ]
+  [ -f $ASDF_DIR/installs/dummy/1.2/version ]
 }


### PR DESCRIPTION
I set out with the goal to make `asdf install` install plugin versions from legacy version files (like `.nvmrc`).

However, since `asdf install` normally loops through the `.tool-versions` file, and wouldn't do anything at all if the `.tool-versions` file doesn't exist, I had to change the general approach to determining what to install.

So now, instead of looping through the `.tool-versions` file, **the command will loop through all available plugins, and ensure that whatever version is selected for the plugin and in whichever way, this version is installed.**

(One downside is it might try to install tools irrelevant to my current project - for example: if I have the elixir plugin, and the nodejs plugin, and I'm only using the latter in my current project, but I don't have the globally selected elixir version installed yet - it will go and install elixir, too. But that would only happen if I have set a global elixir version and haven't installed it yet.)

Fixes: #269