### PR TITLE
Add Homebrew instructions for ZSH

### DIFF
--- a/docs/core-manage-asdf-vm.md
+++ b/docs/core-manage-asdf-vm.md
@@ -66,9 +66,23 @@ If you are using a framework, such as oh-my-zsh, use these lines. (Be sure
 that if you make future changes to .zshrc these lines remain _below_ the line
 where you source your framework.)
 
+Installation via **Git**:
+
 ```shell
 echo -e '\n. $HOME/.asdf/asdf.sh' >> ~/.zshrc
 echo -e '\n. $HOME/.asdf/completions/asdf.bash' >> ~/.zshrc
+```
+
+Installation via **Homebrew**:
+
+?> If you have Homebrew's ZSH completions configured, the second line below is
+unnecessary. See [Configuring Completions in
+ZSH](https://docs.brew.sh/Shell-Completion#configuring-completions-in-zsh) in
+the Homebrew docs.
+
+```bash
+echo -e '\n. $(brew --prefix asdf)/asdf.sh' >> ~/.zshrc
+echo -e '\n. $(brew --prefix asdf)/etc/bash_completion.d/asdf.bash' >> ~/zshrc.
 ```
 
 If you are not using a framework, or if on starting your shell you get an

--- a/docs/core-manage-asdf-vm.md
+++ b/docs/core-manage-asdf-vm.md
@@ -82,7 +82,7 @@ the Homebrew docs.
 
 ```bash
 echo -e '\n. $(brew --prefix asdf)/asdf.sh' >> ~/.zshrc
-echo -e '\n. $(brew --prefix asdf)/etc/bash_completion.d/asdf.bash' >> ~/zshrc.
+echo -e '\n. $(brew --prefix asdf)/etc/bash_completion.d/asdf.bash' >> ~/.zshrc
 ```
 
 If you are not using a framework, or if on starting your shell you get an


### PR DESCRIPTION
# Summary

Adds instructions for adding asdf to your shell when using zsh and Homebrew.

This was mostly copied from https://github.com/asdf-vm/asdf/pull/496

I believe similar instructions should also be added for fish but I don't use it and cannot test it at the moment.