### PR TITLE
Fix PATH spacing issue in asdf.fish

### DIFF
--- a/asdf.fish
+++ b/asdf.fish
@@ -9,9 +9,15 @@ set -l asdf_data_dir (
 set -l asdf_bin_dirs $ASDF_DIR/bin $ASDF_DIR/shims $asdf_data_dir/shims
 
 for x in $asdf_bin_dirs
-  if test -d $x; and not contains $x $PATH
-    set PATH $x $PATH
+  if test -d $x
+    for i in (seq 1 (count $PATH))
+      if test $PATH[$i] = $x
+        set -e PATH[$i]
+        break
+      end
+    end
   end
+  set PATH $x $PATH
 end
 
 # Add function wrapper so we can export variables

--- a/asdf.fish
+++ b/asdf.fish
@@ -9,8 +9,8 @@ set -l asdf_data_dir (
 set -l asdf_bin_dirs $ASDF_DIR/bin $ASDF_DIR/shims $asdf_data_dir/shims
 
 for x in $asdf_bin_dirs
-  if test -d $x
-    set PATH $x (echo $PATH | command xargs printf '%s\n' | command grep -v $x)
+  if test -d $x; and not contains $x $PATH
+    set PATH $x $PATH
   end
 end
 


### PR DESCRIPTION
# Summary

Rather than doing string munging to identify if a directory is in the path already, use the fish builtin `contains`.

Fixes: #550 

## Other Information

I'm by no means a fish expert. I'm using this patch locally to fix #550 and it's working, but I can't guarantee it works across all versions of fish, for example.

Just as a reference for people not familiar with fish shell:

* [`contains`](https://fishshell.com/docs/current/commands.html#contains) function
* [Example](https://fishshell.com/docs/current/tutorial.html#tut_conditionals) of boolean logic (`if expr;  and expr`).