### PR TITLE
Docs: Homebrew setup: do not add brew commands to the shell profile

### DIFF
--- a/docs/core-manage-asdf-vm.md
+++ b/docs/core-manage-asdf-vm.md
@@ -56,8 +56,8 @@ in Bash](https://docs.brew.sh/Shell-Completion#configuring-completions-in-bash)
 in the Homebrew docs.
 
 ```bash
-echo -e '\n. $(brew --prefix asdf)/asdf.sh' >> ~/.bash_profile
-echo -e '\n. $(brew --prefix asdf)/etc/bash_completion.d/asdf.bash' >> ~/.bash_profile
+echo -e "\n. $(brew --prefix asdf)/asdf.sh" >> ~/.bash_profile
+echo -e "\n. $(brew --prefix asdf)/etc/bash_completion.d/asdf.bash" >> ~/.bash_profile
 ```
 
 #### ** ZSH **
@@ -80,9 +80,9 @@ unnecessary. See [Configuring Completions in
 ZSH](https://docs.brew.sh/Shell-Completion#configuring-completions-in-zsh) in
 the Homebrew docs.
 
-```bash
-echo -e '\n. $(brew --prefix asdf)/asdf.sh' >> ~/.zshrc
-echo -e '\n. $(brew --prefix asdf)/etc/bash_completion.d/asdf.bash' >> ~/.zshrc
+```shell
+echo -e "\n. $(brew --prefix asdf)/asdf.sh" >> ~/.zshrc
+echo -e "\n. $(brew --prefix asdf)/etc/bash_completion.d/asdf.bash" >> ~/.zshrc
 ```
 
 If you are not using a framework, or if on starting your shell you get an


### PR DESCRIPTION
# Summary

The recommended Homebrew setup required running two `brew --prefix` commands
to the shell profile. `brew` commands can be slow, so this introduced a notable
lag when sourcing the shell profile.

Homebrew paths do not change, so we can determine the necessary paths one time
during setup and use static paths in the shell profile.

Also changes one `` ```bash`` to `` ```shell`` in the ZSH documentation, to match the rest of the ZSH documentation.