### PR TITLE
Add Homebrew instructions for fish shell

### DIFF
--- a/docs/core-manage-asdf-vm.md
+++ b/docs/core-manage-asdf-vm.md
@@ -95,9 +95,21 @@ autoload -Uz compinit && compinit
 
 #### ** Fish **
 
+Installation via **Git**:
+
 ```shell
 echo 'source ~/.asdf/asdf.fish' >> ~/.config/fish/config.fish
 mkdir -p ~/.config/fish/completions; and cp ~/.asdf/completions/asdf.fish ~/.config/fish/completions
+```
+
+Installation via **Homebrew**:
+
+?> Homebrew takes care of [installing the completions for fish
+shell](https://docs.brew.sh/Shell-Completion#configuring-completions-in-fish).
+Friendly!
+
+```shell
+echo 'source (brew --prefix asdf)/asdf.fish' >> ~/.config/fish/config.fish
 ```
 
 <!-- tabs:end -->


### PR DESCRIPTION
# Summary

Adds instructions for configuring asdf in fish shell using Homebrew.

Fixes #545 

## Other Information

Based on #537 