### PR TITLE
Fix for asdf plugin-test when installed with brew, and a minor logic fix to a warning

### DIFF
--- a/lib/commands/plugin-test.sh
+++ b/lib/commands/plugin-test.sh
@@ -39,7 +39,9 @@ plugin_test_command() {
     fi
 
     TEST_DIR=$(mktemp -dt asdf.XXXX)
-    cp -R "$ASDF_DIR/" "$TEST_DIR"
+    cp -R "$ASDF_DIR/bin" "$TEST_DIR"
+    cp -R "$ASDF_DIR/lib" "$TEST_DIR"
+    cp -R "$ASDF_DIR/asdf.sh" "$TEST_DIR"
 
     plugin_test() {
         export ASDF_DIR=$TEST_DIR

--- a/lib/commands/plugin-test.sh
+++ b/lib/commands/plugin-test.sh
@@ -39,7 +39,7 @@ plugin_test_command() {
     fi
 
     TEST_DIR=$(mktemp -dt asdf.XXXX)
-    git clone "$ASDF_DIR/.git" "$TEST_DIR"
+    cp -R "$ASDF_DIR/" "$TEST_DIR"
 
     plugin_test() {
         export ASDF_DIR=$TEST_DIR
@@ -72,8 +72,8 @@ plugin_test_command() {
                 fail_test "$plugin_name/bin/list-all does not set GitHub Authorization token"
             fi
 
-            # test for most common token names we have on plugins
-            if [ -z "$OAUTH_TOKEN" ] || [ -z "$GITHUB_API_TOKEN" ] ; then
+            # test for most common token names we have on plugins. If both are empty show this warning
+            if [ -z "$OAUTH_TOKEN" ] && [ -z "$GITHUB_API_TOKEN" ] ; then
                 echo "$plugin_name/bin/list-all is using GitHub API, just be sure you provide an API Authorization token"
                 echo "via your travis settings. This is the current rate_limit:"
                 echo

--- a/lib/commands/plugin-test.sh
+++ b/lib/commands/plugin-test.sh
@@ -41,7 +41,7 @@ plugin_test_command() {
     TEST_DIR=$(mktemp -dt asdf.XXXX)
     cp -R "$ASDF_DIR/bin" "$TEST_DIR"
     cp -R "$ASDF_DIR/lib" "$TEST_DIR"
-    cp -R "$ASDF_DIR/asdf.sh" "$TEST_DIR"
+    cp "$ASDF_DIR/asdf.sh" "$TEST_DIR"
 
     plugin_test() {
         export ASDF_DIR=$TEST_DIR


### PR DESCRIPTION
# Summary

This makes 2 changes:
1. Provides an alternative way for `asdf plugin-test` to set up its environment, by copying the contents of $ASDF_DIR to $TEST_DIR instead of doing a git clone. This fixes `plugin-test` for homebrew installations
2. Makes a small logic fix to silence a warning when GITHUB_API_TOKEN or OAUTH_TOKEN are present, but not both (before both needed to be set before the warning would disappear, which seems incorrect).

Fixes: #509

## Other Information

This may be an inadequate solution if someone installs asdf such that $ASDF_DIR is equal to $ASDF_DATA_DIR, since all installed plugins and packages will also be copied which could be wasteful of time and resources. I don't know if that's typical or not of a pure git installation as I haven't done that myself, though.