### PR TITLE
with_plugin_env PATH fix

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -499,8 +499,12 @@ with_plugin_env() {
   plugin_path=$(get_plugin_path "$plugin_name")
 
   # add the plugin listed exec paths to PATH
-  local path
-  path="$(list_plugin_exec_paths "$plugin_name" "$full_version" | tr '\n' ':'):$PATH"
+  local path exec_paths
+  exec_paths="$(list_plugin_exec_paths "$plugin_name" "$full_version")"
+
+  # exec_paths contains a trailing newline which is converted to a colon, so no
+  # colon is needed between the subshell and the PATH variable in this string
+  path="$(echo "$exec_paths" | tr '\n' ':')$PATH"
 
   # If no custom exec-env transform, just execute callback
   if [ ! -f "${plugin_path}/bin/exec-env" ]; then

--- a/test/shim_env_command.bats
+++ b/test/shim_env_command.bats
@@ -66,3 +66,19 @@ teardown() {
   [ "$output" == "$ASDF_DIR/shims/dummy" ]
   [ "$status" -eq 0 ]
 }
+
+@test "asdf env should set PATH correctly" {
+  echo "dummy 1.0" > $PROJECT_DIR/.tool-versions
+  run asdf install
+
+  run asdf env dummy
+  [ "$status" -eq 0 ]
+
+  # Should set path
+  path_line=$(echo "$output" | grep '^PATH=')
+  [ "$path_line" != "" ]
+
+  # Should not contain duplicate colon
+  run grep '::' <(echo "$path_line")
+  [ "$duplicate_colon" == "" ]
+}


### PR DESCRIPTION
# Summary

Correct logic that constructs path for callback in the `with_plugin_env` function.

Fixes: https://github.com/asdf-vm/asdf/issues/543
