### PR TITLE
Fix PATH construction on fish

### DIFF
--- a/asdf.fish
+++ b/asdf.fish
@@ -10,7 +10,7 @@ set -l asdf_bin_dirs $ASDF_DIR/bin $ASDF_DIR/shims $asdf_data_dir/shims
 
 for x in $asdf_bin_dirs
   if test -d $x
-    set PATH $x (echo $PATH | command xargs printf '%s\n' | command grep -v $x)
+    set PATH $x (string match -v $x $PATH)
   end
 end
 


### PR DESCRIPTION
When prepending asdf_bin_dirs to $PATH on asdf startup script for fish shell
there was a problem when PATH elements contained blank characters.

This patch gets it working again and also improves on simplicity and
performance by not spawning external processes for simple strings
handling stuff.

# Summary

Provide a general description of the code changes in your pull request.

Fixes: List issue numbers here

## Other Information

If there is anything else that is relevant to your pull request include that
information here.

Thank you for contributing to asdf!
