### PR TITLE
Add --unset option to shell subcommand

### DIFF
--- a/lib/commands/version_commands.sh
+++ b/lib/commands/version_commands.sh
@@ -81,7 +81,7 @@ global_command() {
 # Output from this command must be executable shell code
 shell_command() {
   if [ "$#" -lt "2" ]; then
-    echo "Usage: asdf shell <name> <version>" >&2
+    echo "Usage: asdf shell <name> <version> | --unset" >&2
     echo 'false'
     exit 1
   fi
@@ -89,14 +89,18 @@ shell_command() {
   local plugin=$1
   local version=$2
 
+  local upcase_name
+  upcase_name=$(echo "$plugin" | tr '[:lower:]-' '[:upper:]_')
+  local version_env_var="ASDF_${upcase_name}_VERSION"
+
+  if [ "$version" = "--unset" ]; then
+    echo "unset $version_env_var"
+    exit 0
+  fi
   if ! (check_if_version_exists "$plugin" "$version"); then
     echo 'false'
     exit 1
   fi
-
-  local upcase_name
-  upcase_name=$(echo "$plugin" | tr '[:lower:]-' '[:upper:]_')
-  local version_env_var="ASDF_${upcase_name}_VERSION"
 
   case $ASDF_SHELL in
     fish )

--- a/lib/commands/version_commands.sh
+++ b/lib/commands/version_commands.sh
@@ -81,7 +81,7 @@ global_command() {
 # Output from this command must be executable shell code
 shell_command() {
   if [ "$#" -lt "2" ]; then
-    echo "Usage: asdf shell <name> <version> | --unset" >&2
+    echo "Usage: asdf shell <name> {<version>|--unset}" >&2
     echo 'false'
     exit 1
   fi

--- a/test/version_commands.bats
+++ b/test/version_commands.bats
@@ -242,7 +242,7 @@ teardown() {
   source $(dirname "$BATS_TEST_DIRNAME")/asdf.sh
   asdf shell "dummy" "1.1.0"
   [ $(echo $ASDF_DUMMY_VERSION) = "1.1.0" ]
-  asdf shell "dummy" "--unset"
+  asdf shell "dummy" --unset
   [ -z "$(echo $ASDF_DUMMY_VERSION)" ]
   unset ASDF_DUMMY_VERSION
 }

--- a/test/version_commands.bats
+++ b/test/version_commands.bats
@@ -238,6 +238,15 @@ teardown() {
   unset ASDF_DUMMY_VERSION
 }
 
+@test "shell wrapper function with --unset should unset ENV var" {
+  source $(dirname "$BATS_TEST_DIRNAME")/asdf.sh
+  asdf shell "dummy" "1.1.0"
+  [ $(echo $ASDF_DUMMY_VERSION) = "1.1.0" ]
+  asdf shell "dummy" "--unset"
+  [ -z "$(echo $ASDF_DUMMY_VERSION)" ]
+  unset ASDF_DUMMY_VERSION
+}
+
 @test "shell wrapper function should return an error for missing plugins" {
   source $(dirname "$BATS_TEST_DIRNAME")/asdf.sh
   run asdf shell "nonexistent" "1.0.0"


### PR DESCRIPTION
# Summary

Issue #378 proposes the `shell` subcommand and PR #480 implements it.

But #378 also mentions about its `--unset` option to unset ASDF_WHATEVER_VERSION variable which is missing from PR #480.

This PR adds support of `--unset`.

## Example

before
```shell
$ asdf current ruby
2.7.0-dev (set by /Users/sakuro/.tool-versions)
$ asdf shell ruby 2.6.3
$ asdf current ruby
2.6.3    (set by ASDF_RUBY_VERSION environment variable)
$ asdf shell ruby --unset
version --unset is not installed for ruby
```

after
```shell
$ asdf shell ruby
Usage: asdf shell <name> <version> | --unset
$ asdf current ruby
2.7.0-dev (set by /Users/sakuro/.tool-versions)
$ asdf shell ruby 2.6.3
$ asdf current ruby
2.6.3    (set by ASDF_RUBY_VERSION environment variable)
$ asdf shell ruby --unset
$ asdf current ruby
2.7.0-dev (set by /Users/sakuro/.tool-versions)
```

## Other Information

I've moved the assignment to `version_env_var` up because `--unset` needs the variable name to unset.
