### PR TITLE
Fix crash when running shimmed command with a "-"

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -687,7 +687,7 @@ with_shim_executable() {
 
       if [ -x "${plugin_path}/bin/exec-path" ]; then
         install_path=$(find_install_path "$plugin_name" "$full_version")
-        executable_path=$(get_custom_executable_path "${plugin_path}" "${install_path}" "${executable_path:${shim_name}}")
+        executable_path=$(get_custom_executable_path "${plugin_path}" "${install_path}" "${executable_path}")
       fi
 
       "$shim_exec" "$plugin_name" "$full_version" "$executable_path"


### PR DESCRIPTION
# Summary

When trying to run `standard-version` as a global npm command, crashes happened/

From a few test, I could determine it is due to this line: https://github.com/asdf-vm/asdf/blob/master/lib/utils.sh#L690

And more precisely this expression: `"...:${shim_name}"`.
It seems that bash interprets the dash (`-`) in the "shim name" as a "minus operator" and raises an error.

This patch removes the expressions that causes the crash.

Fixes: #565 

## Other Information

I'm no bash guru, so I might have missed something here...
Please provide guidance 😁
