### PR TITLE
Removed parenthesis that are causing errors

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -603,7 +603,7 @@ with_shim_executable() {
   }
 
   select_from_preset_version() {
-    grep -f <(get_shim_versions) <(preset_versions) | head -n 1 | xargs echo
+    grep -f <get_shim_versions <preset_versions | head -n 1 | xargs echo
   }
 
   select_version() {


### PR DESCRIPTION
# Summary

Discovered a syntax error in `lib/utils.sh` while using asdf in Ansible. I reported the issue here: #568 

This commit removes the offending code.

Fixes: List issue numbers here

#568 

## Other Information

If there is anything else that is relevant to your pull request include that
information here.

Thank you for contributing to asdf!
