### PR TITLE
Add support for installing the latest stable version of a tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## 0.7.6-dev
 
+Features
+
+* Add support for installing the latest stable version of a tool (#216, #575)
+
+    ```shell
+    asdf install python latest
+    asdf install python latest:3.7 # installs latest Python 3.7 version
+    ```
+
+* Add `asdf latest` command to display the latest stable version of a tool (#575)
+
+    ```shell
+    asdf latest python
+    asdf latest python 3.7 # displays latest Python 3.7 version
+    ```
+
+* Add support for filtering versions returned by `asdf list-all` (#575)
+
+    ```shell
+    asdf list-all python 3.7 # lists available Python 3.7 versions
+    ````
+
 ## 0.7.5
 
 Features

--- a/bin/asdf
+++ b/bin/asdf
@@ -62,6 +62,10 @@ case "$1" in
     load_cmd "version_commands"
     global_command "${cmd_args[@]}";;
 
+  "latest")
+    load_cmd "latest"
+    latest_command "${cmd_args[@]}";;
+
   "list")
     load_cmd "list"
     list_command "${cmd_args[@]}";;

--- a/completions/asdf.fish
+++ b/completions/asdf.fish
@@ -99,7 +99,7 @@ complete -f -c asdf -n '__fish_asdf_needs_command' -a which -d "Display executab
 complete -f -c asdf -n '__fish_asdf_using_command which; and __fish_asdf_arg_number 2' -a '(__fish_asdf_list_shims)'
 
 # latest completion
-complete -f -c asdf -n '__fish_asdf_needs_command' -a latest -d "Show latest available version of a package"
+complete -f -c asdf -n '__fish_asdf_needs_command' -a latest -d "Show latest stable version of a package"
 complete -f -c asdf -n '__fish_asdf_using_command latest; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
 
 # list completion

--- a/completions/asdf.fish
+++ b/completions/asdf.fish
@@ -98,6 +98,10 @@ complete -f -c asdf -n '__fish_asdf_using_command where; and __fish_asdf_arg_num
 complete -f -c asdf -n '__fish_asdf_needs_command' -a which -d "Display executable path for a command"
 complete -f -c asdf -n '__fish_asdf_using_command which; and __fish_asdf_arg_number 2' -a '(__fish_asdf_list_shims)'
 
+# latest completion
+complete -f -c asdf -n '__fish_asdf_needs_command' -a latest -d "Show latest available version of a package"
+complete -f -c asdf -n '__fish_asdf_using_command latest; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
+
 # list completion
 complete -f -c asdf -n '__fish_asdf_needs_command' -a list -d "List installed versions of a package"
 complete -f -c asdf -n '__fish_asdf_using_command list; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'

--- a/docs/core-commands.md
+++ b/docs/core-commands.md
@@ -13,19 +13,22 @@
 
 ## Manage Packages
 
-| Command                           | Effect                                                                |
-| --------------------------------- | --------------------------------------------------------------------- |
-| `asdf install [<name> <version>]` | Install a specific version of a package, or with no arguments,        |
-|                                   | ...install all the package versions listed in the .tool-versions file |
-| `asdf uninstall <name> <version>` | Remove a specific version of a package                                |
-| `asdf current`                    | Display current version set or being used for all packages            |
-| `asdf current <name>`             | Display current version set or being used for package                 |
-| `asdf where <name> [<version>]`   | Display install path for an installed or current version              |
-| `asdf which <name>`               | Display install path for current version                              |
-| `asdf local <name> <version>`     | Set the package local version                                         |
-| `asdf global <name> <version>`    | Set the package global version                                        |
-| `asdf list <name>`                | List installed versions of a package                                  |
-| `asdf list-all <name>`            | List all versions of a package                                        |
+| Command                                  | Effect                                                                     |
+| ---------------------------------------- | -------------------------------------------------------------------------- |
+| `asdf install [<name> <version>]`        | Install a specific version of a package, or with no arguments,             |
+|                                          | ...install all the package versions listed in the .tool-versions file      |
+| `asdf install <name> latest[:<version>]` | Install the latest stable version of a package, or with optional version,  |
+|                                          | ...install the latest stable version that begins with the given string     |
+| `asdf uninstall <name> <version>`        | Remove a specific version of a package                                     |
+| `asdf current`                           | Display current version set or being used for all packages                 |
+| `asdf current <name>`                    | Display current version set or being used for package                      |
+| `asdf where <name> [<version>]`          | Display install path for an installed or current version                   |
+| `asdf which <name>`                      | Display install path for current version                                   |
+| `asdf local <name> <version>`            | Set the package local version                                              |
+| `asdf global <name> <version>`           | Set the package global version                                             |
+| `asdf latest <name> [<version>]`         | Show latest stable version of a package                                    |
+| `asdf list <name>`                       | List installed versions of a package                                       |
+| `asdf list-all <name> [<version>]`       | List all versions of a package and optionally filter the returned versions |
 
 ## Utils
 

--- a/docs/core-manage-versions.md
+++ b/docs/core-manage-versions.md
@@ -21,6 +21,13 @@ asdf list-all <name>
 # asdf list-all erlang
 ```
 
+Limit versions to those that begin with a given string.
+
+```shell
+asdf list-all <name> <version>
+# asdf list-all erlang 17
+```
+
 ## Set Current Version
 
 ```shell

--- a/docs/core-manage-versions.md
+++ b/docs/core-manage-versions.md
@@ -7,6 +7,20 @@ asdf install <name> <version>
 
 _If a plugin supports downloading & compiling from source, you can specify `ref:foo` where `foo` is a specific branch, tag, or commit. You'll need to use the same name and reference when uninstalling too._
 
+## Install Latest Stable Version
+
+```shell
+asdf install <name> latest
+# asdf install erlang latest
+```
+
+Install latest stable version that begins with a given string.
+
+```shell
+asdf install <name> latest:<version>
+# asdf install erlang latest:17
+```
+
 ## List Installed Versions
 
 ```shell

--- a/docs/core-manage-versions.md
+++ b/docs/core-manage-versions.md
@@ -28,6 +28,20 @@ asdf list-all <name> <version>
 # asdf list-all erlang 17
 ```
 
+## Show Latest Stable Version
+
+```shell
+asdf latest <name>
+# asdf latest erlang
+```
+
+Show latest stable version that begins with a given string.
+
+```shell
+asdf latest <name> <version>
+# asdf latest erlang 17
+```
+
 ## Set Current Version
 
 ```shell

--- a/lib/commands/install.sh
+++ b/lib/commands/install.sh
@@ -96,7 +96,8 @@ install_tool_version() {
 
     if [ "${version_info[0]}" = "latest" ]; then
       load_cmd "latest"
-      local version=$(latest_command "$plugin_name" "${version_info[1]}")
+      local version
+      version=$(latest_command "$plugin_name" "${version_info[1]}")
       full_version=$version
     else
       local version="${version_info[0]}"

--- a/lib/commands/install.sh
+++ b/lib/commands/install.sh
@@ -93,7 +93,14 @@ install_tool_version() {
     local version="${version_info[1]}"
   else
     local install_type="version"
-    local version="${version_info[0]}"
+
+    if [ "${version_info[0]}" = "latest" ]; then
+      load_cmd "latest"
+      local version=$(latest_command "$plugin_name" "${version_info[1]}")
+      full_version=$version
+    else
+      local version="${version_info[0]}"
+    fi
   fi
 
 

--- a/lib/commands/latest.sh
+++ b/lib/commands/latest.sh
@@ -1,0 +1,15 @@
+latest_command() {
+  DEFAULT_QUERY="[0-9]"
+
+  local plugin_name=$1
+  local query=$2
+
+  [[ -z $query ]] && query="$DEFAULT_QUERY"
+
+  load_cmd "list-all"
+  echo $(list_all_command "$plugin_name" "$query" \
+    | grep -vE "(^Available versions:|-src|-dev|-latest|-stm|[-\.]rc|-alpha|-beta|[-\.]pre|-next|(a|b|c)[0-9]+|snapshot|master)" \
+    | sed 's/^\s\+//' \
+    | sort --version-sort \
+    | tail -1)
+}

--- a/lib/commands/latest.sh
+++ b/lib/commands/latest.sh
@@ -7,9 +7,9 @@ latest_command() {
   [[ -z $query ]] && query="$DEFAULT_QUERY"
 
   load_cmd "list-all"
-  echo $(list_all_command "$plugin_name" "$query" \
+  list_all_command "$plugin_name" "$query" \
     | grep -vE "(^Available versions:|-src|-dev|-latest|-stm|[-\.]rc|-alpha|-beta|[-\.]pre|-next|(a|b|c)[0-9]+|snapshot|master)" \
     | sed 's/^\s\+//' \
     | sort --version-sort \
-    | tail -1)
+    | tail -1
 }

--- a/lib/commands/latest.sh
+++ b/lib/commands/latest.sh
@@ -6,6 +6,7 @@ latest_command() {
 
   [[ -z $query ]] && query="$DEFAULT_QUERY"
 
+  # pattern from xxenv-latest (https://github.com/momo-lab/xxenv-latest)
   load_cmd "list-all"
   list_all_command "$plugin_name" "$query" \
     | grep -vE "(^Available versions:|-src|-dev|-latest|-stm|[-\.]rc|-alpha|-beta|[-\.]pre|-next|(a|b|c)[0-9]+|snapshot|master)" \

--- a/lib/commands/list-all.sh
+++ b/lib/commands/list-all.sh
@@ -1,11 +1,19 @@
 list_all_command() {
   local plugin_name=$1
+  local query=$2
   local plugin_path
   plugin_path=$(get_plugin_path "$plugin_name")
   check_if_plugin_exists "$plugin_name"
 
   local versions
   versions=$(bash "${plugin_path}/bin/list-all")
+
+  if [[ $query ]]; then
+    versions=$(echo "$versions" \
+      | tr ' ' '\n' \
+      | grep -E "^\s*$query" \
+      | tr '\n' ' ')
+  fi
 
   IFS=' ' read -r -a versions_list <<< "$versions"
 

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -188,3 +188,15 @@ EOM
   [ "$output" == "" ]
   [ -f $ASDF_DIR/installs/dummy/1.2/version ]
 }
+
+@test "install_command latest installs latest stable version" {
+  run asdf install dummy latest
+  [ "$status" -eq 0 ]
+  [ $(cat $ASDF_DIR/installs/dummy/2.0/version) = "2.0" ]
+}
+
+@test "install_command latest:version installs latest stable version that matches the given string" {
+  run asdf install dummy latest:1
+  [ "$status" -eq 0 ]
+  [ $(cat $ASDF_DIR/installs/dummy/1.1/version) = "1.1" ]
+}

--- a/test/latest_command.bats
+++ b/test/latest_command.bats
@@ -1,0 +1,24 @@
+#!/usr/bin/env bats
+
+load test_helpers
+
+setup() {
+  setup_asdf_dir
+  install_dummy_plugin
+}
+
+teardown() {
+  clean_asdf_dir
+}
+
+@test "latest_command shows latest stable version" {
+  run asdf latest dummy
+  [ "$(echo -e "2.0")" == "$output" ]
+  [ "$status" -eq 0 ]
+}
+
+@test "latest_command with version shows latest stable version that matches the given string" {
+  run asdf latest dummy 1
+  [ "$(echo -e "1.1")" == "$output" ]
+  [ "$status" -eq 0 ]
+}

--- a/test/list_command.bats
+++ b/test/list_command.bats
@@ -37,3 +37,15 @@ teardown() {
   [ "$(echo -e "  1.0\n  1.1")" == "$output" ]
   [ "$status" -eq 0 ]
 }
+
+@test "list_all_command lists available versions" {
+  run asdf list-all dummy
+  [ "$(echo -e "1.0\n1.1\n2.0")" == "$output" ]
+  [ "$status" -eq 0 ]
+}
+
+@test "list_all_command with version filters available versions" {
+  run asdf list-all dummy 1
+  [ "$(echo -e "1.0\n1.1")" == "$output" ]
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
# Summary

This PR integrates the logic from [xxenv-latest](https://github.com/momo-lab/xxenv-latest) to install the latest stable version of a tool. It adds a `latest` command to show the latest version:

- `asdf latest python` prints `3.7.4`
- `asdf latest python 3.6` prints `3.6.9`

This gets used by `asdf install` to install the latest version:

- `asdf install python latest` installs Python 3.7.4
- `asdf install python latest:3.6` installs Python 3.6.9

It also adds the ability to filter versions returned by `asdf list-all` by accepting an additional version substring:

- `asdf list-all python 3.7` only lists Python 3.7 versions

Fixes: #216 

## Other Information

I need to add unit tests. Any suggestions are welcomed.