### PR TITLE
asdf_data_dir() returning incorrect path when running as root.

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -30,7 +30,7 @@ asdf_data_dir(){
 
   if [ -n "${ASDF_DATA_DIR}" ]; then
     data_dir="${ASDF_DATA_DIR}"
-  elif [ asdf_run_as_root ]; then
+  elif [ "${asdf_run_as_root}" ]; then
     data_dir="$(asdf_dir)"
   else
     data_dir="$HOME/.asdf"

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -27,20 +27,16 @@ asdf_repository_url() {
 
 asdf_data_dir(){
   local data_dir
-
+  
   if [ -n "${ASDF_DATA_DIR}" ]; then
     data_dir="${ASDF_DATA_DIR}"
-  elif [ "${asdf_run_as_root}" ]; then
-    data_dir="$(asdf_dir)"
-  else
+  elif [[ $EUID -ne 0 ]]; then
     data_dir="$HOME/.asdf"
+  else
+    data_dir="$(asdf_dir)"
   fi
 
   echo "$data_dir"
-}
-
-asdf_run_as_root() {
-  [ $(id -u) -eq 0 ]
 }
 
 get_install_path() {

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -26,9 +26,13 @@ asdf_repository_url() {
 }
 
 asdf_data_dir(){
-  local data_dir="$(asdf_dir)"
+  local data_dir
 
-  if [ -z "$data_dir" ]; then
+  if [ -n "${ASDF_DATA_DIR}" ]; then
+    data_dir="${ASDF_DATA_DIR}"
+  elif [ -n "$(asdf_dir)" ]; then
+    data_dir="$(asdf_dir)"
+  else
     data_dir="$HOME/.asdf"
   fi
 

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -26,11 +26,9 @@ asdf_repository_url() {
 }
 
 asdf_data_dir(){
-  local data_dir
+  local data_dir="$(asdf_dir)"
 
-  if [ -n "${ASDF_DATA_DIR}" ]; then
-    data_dir="${ASDF_DATA_DIR}"
-  else
+  if [ -z "$data_dir" ]; then
     data_dir="$HOME/.asdf"
   fi
 

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -30,13 +30,17 @@ asdf_data_dir(){
 
   if [ -n "${ASDF_DATA_DIR}" ]; then
     data_dir="${ASDF_DATA_DIR}"
-  elif [ -n "$(asdf_dir)" ]; then
+  elif [ asdf_run_as_root ]; then
     data_dir="$(asdf_dir)"
   else
     data_dir="$HOME/.asdf"
   fi
 
   echo "$data_dir"
+}
+
+asdf_run_as_root() {
+  [ $(id -u) -eq 0 ]
 }
 
 get_install_path() {


### PR DESCRIPTION
# Summary

In some Linux distributions it is possible to run hooks after upgrading the system. These hooks, in the case of [pacman](https://wiki.archlinux.org/index.php/pacman), which is the package manager for [Arch Linux](https://www.archlinux.org/), are run as root. 

With that in mind, when plugins are updated, several calls to the ```asdf_data_dir()``` are processed, returning a path containing ```$HOME``` environment variable, which is incorrect since the current user executing the update is different from the one who installed ```asdf``` in the home directory. 
Also at this point ```$ASDF_DATA_DIR``` is empty (for some reason has not been set). 

This fix reuses the existing method: ```asdf_dir()``` in order to retrieve the correct path where the plugins are installed. 

Fixes: #582

## Other Information

For some reason I could not see in the code where the ```$ASDF_DATA_DIR``` is being set. The method ```asdf_dir()``` indeed is setting ```$ASDF_DIR``` as environment variable which is being used but not in the case of ```$ASDF_DATA_DIR```.

Should we also replace the usage of ```$ASDF_DATA_DIR``` with calls to the mentioned ```asdf_data_dir()``` method? 

Maybe in another PR?

```bash
asdf_data_dir(){
  local data_dir="$(asdf_dir)"

  if [ -z "$data_dir" ]; then
    data_dir="$HOME/.asdf"
  fi

  echo "$data_dir"
}
```