### PR TITLE
Fix multiple version install

### DIFF
--- a/lib/commands/current.sh
+++ b/lib/commands/current.sh
@@ -6,7 +6,7 @@ plugin_current_command() {
   local search_path
   search_path=$(pwd)
   local version_and_path
-  version_and_path=$(find_version "$plugin_name" "$search_path")
+  version_and_path=$(find_versions "$plugin_name" "$search_path")
   local full_version
   full_version=$(cut -d '|' -f 1 <<< "$version_and_path");
   local version_file_path

--- a/lib/commands/install.sh
+++ b/lib/commands/install.sh
@@ -56,8 +56,10 @@ install_local_tool_versions() {
       if [ -n "$plugin_version_and_path" ]; then
         local plugin_version
         some_tools_installed='yes'
-        plugin_version=$(cut -d '|' -f 1 <<< "$plugin_version_and_path")
-        install_tool_version "$plugin_name" "$plugin_version"
+        plugin_versions=$(cut -d '|' -f 1 <<< "$plugin_version_and_path")
+        for plugin_version in $plugin_versions; do
+          install_tool_version "$plugin_name" "$plugin_version"
+        done
       fi
     done
   else

--- a/lib/commands/install.sh
+++ b/lib/commands/install.sh
@@ -51,7 +51,7 @@ install_local_tool_versions() {
       plugin_name=$(basename "$plugin_path")
 
       local plugin_version_and_path
-      plugin_version_and_path="$(find_version "$plugin_name" "$search_path")"
+      plugin_version_and_path="$(find_versions "$plugin_name" "$search_path")"
 
       if [ -n "$plugin_version_and_path" ]; then
         local plugin_version

--- a/lib/commands/where.sh
+++ b/lib/commands/where.sh
@@ -7,7 +7,7 @@ where_command() {
   local install_type="version"
   if [[ -z ${full_version} ]]; then
     local version_and_path
-    version_and_path=$(find_version "$plugin_name" "$PWD")
+    version_and_path=$(find_versions "$plugin_name" "$PWD")
     version=$(cut -d '|' -f 1 <<< "$version_and_path");
   else
     local -a version_info

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -133,7 +133,7 @@ get_version_in_dir() {
   done
 }
 
-find_version() {
+find_versions() {
   local plugin_name=$1
   local search_path=$2
 
@@ -172,9 +172,9 @@ find_version() {
   get_version_in_dir "$plugin_name" "$HOME" "$legacy_filenames"
 
   if [ -f "$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME" ]; then
-    version=$(parse_asdf_version_file "$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME" "$plugin_name")
-    if [ -n "$version" ]; then
-      echo "$version|$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME"
+    versions=$(parse_asdf_version_file "$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME" "$plugin_name")
+    if [ -n "$versions" ]; then
+      echo "$versions|$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME"
       return 0
     fi
   fi
@@ -300,7 +300,7 @@ get_preset_version_for() {
   local search_path
   search_path=$(pwd)
   local version_and_path
-  version_and_path=$(find_version "$plugin_name" "$search_path")
+  version_and_path=$(find_versions "$plugin_name" "$search_path")
   local version
   version=$(cut -d '|' -f 1 <<< "$version_and_path");
 
@@ -635,7 +635,7 @@ with_shim_executable() {
       local version_string
       local usable_plugin_versions
       local _path
-      version_and_path=$(find_version "$plugin_name" "$search_path")
+      version_and_path=$(find_versions "$plugin_name" "$search_path")
       IFS='|' read -r version_string _path <<< "$version_and_path"
       IFS=' ' read -r -a usable_plugin_versions <<< "$version_string"
       for plugin_version in "${usable_plugin_versions[@]}"; do

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -130,6 +130,18 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
+@test "install_command installs multiple tool versions when they are specified in a .tool-versions file" {
+  echo 'dummy 1.0 1.2' > $PROJECT_DIR/.tool-versions
+  cd $PROJECT_DIR
+
+  run asdf install
+  echo $output
+  [ "$status" -eq 0 ]
+
+  [ $(cat $ASDF_DIR/installs/dummy/1.0/version) = "1.0" ]
+  [ $(cat $ASDF_DIR/installs/dummy/1.2/version) = "1.2" ]
+}
+
 @test "install_command doesn't install system version" {
   run asdf install dummy system
   [ "$status" -eq 0 ]

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -85,49 +85,49 @@ teardown() {
   [ "$output" == "path:/some/dummy path" ]
 }
 
-@test "find_version should return .tool-versions if legacy is disabled" {
+@test "find_versions should return .tool-versions if legacy is disabled" {
   echo "dummy 0.1.0" > $PROJECT_DIR/.tool-versions
   echo "0.2.0" > $PROJECT_DIR/.dummy-version
 
-  run find_version "dummy" $PROJECT_DIR
+  run find_versions "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
   [ "$output" = "0.1.0|$PROJECT_DIR/.tool-versions" ]
 }
 
-@test "find_version should return the legacy file if supported" {
+@test "find_versions should return the legacy file if supported" {
   echo "legacy_version_file = yes" > $HOME/.asdfrc
   echo "dummy 0.1.0" > $HOME/.tool-versions
   echo "0.2.0" > $PROJECT_DIR/.dummy-version
 
-  run find_version "dummy" $PROJECT_DIR
+  run find_versions "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
   [ "$output" = "0.2.0|$PROJECT_DIR/.dummy-version" ]
 }
 
-@test "find_version skips .tool-version file that don't list the plugin" {
+@test "find_versions skips .tool-version file that don't list the plugin" {
   echo "dummy 0.1.0" > $HOME/.tool-versions
   echo "another_plugin 0.3.0" > $PROJECT_DIR/.tool-versions
 
-  run find_version "dummy" $PROJECT_DIR
+  run find_versions "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
   [ "$output" = "0.1.0|$HOME/.tool-versions" ]
 }
 
-@test "find_version should return .tool-versions if unsupported" {
+@test "find_versions should return .tool-versions if unsupported" {
   echo "dummy 0.1.0" > $HOME/.tool-versions
   echo "0.2.0" > $PROJECT_DIR/.dummy-version
   echo "legacy_version_file = yes" > $HOME/.asdfrc
   rm $ASDF_DIR/plugins/dummy/bin/list-legacy-filenames
 
-  run find_version "dummy" $PROJECT_DIR
+  run find_versions "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
   [ "$output" = "0.1.0|$HOME/.tool-versions" ]
 }
 
-@test "find_version should return the version set by envrionment variable" {
+@test "find_versions should return the version set by envrionment variable" {
   export ASDF_DUMMY_VERSION=0.2.0
 
-  run find_version "dummy" $PROJECT_DIR
+  run find_versions "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
   echo $output
   [ "$output" = "0.2.0|ASDF_DUMMY_VERSION environment variable" ]
@@ -155,22 +155,22 @@ teardown() {
   [ "$output" = "" ]
 }
 
-@test "find_version should return \$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME if set" {
+@test "find_versions should return \$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME if set" {
   ASDF_DEFAULT_TOOL_VERSIONS_FILENAME="$PROJECT_DIR/global-tool-versions"
   echo "dummy 0.1.0" > $ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
 
-  run find_version "dummy" $PROJECT_DIR
+  run find_versions "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
   [ "$output" = "0.1.0|$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME" ]
 }
 
-@test "find_version should check \$HOME legacy files before \$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME" {
+@test "find_versions should check \$HOME legacy files before \$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME" {
   ASDF_DEFAULT_TOOL_VERSIONS_FILENAME="$PROJECT_DIR/global-tool-versions"
   echo "dummy 0.2.0" > $ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
   echo "dummy 0.1.0" > $HOME/.dummy-version
   echo "legacy_version_file = yes" > $HOME/.asdfrc
 
-  run find_version "dummy" $PROJECT_DIR
+  run find_versions "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
   [[ "$output" =~ "0.1.0|$HOME/.dummy-version" ]]
 }


### PR DESCRIPTION
# Summary

The install code did not take into account the possibility of multiple tool versions specified in a single `.tool-versions` file separated by whitespace.

Fixes: #540

## Other Information

I decided to rename the `find_version` function to `find_versions`, since it can return multiple space-delimited versions. If anyone feels this change is unnecessary I'll be happy to revert it.
