### PR TITLE
Handle dashes in executable names properly

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -687,7 +687,7 @@ with_shim_executable() {
 
       if [ -x "${plugin_path}/bin/exec-path" ]; then
         install_path=$(find_install_path "$plugin_name" "$full_version")
-        executable_path=$(get_custom_executable_path "${plugin_path}" "${install_path}" "${executable_path:${shim_name}}")
+        executable_path=$(get_custom_executable_path "${plugin_path}" "${install_path}" "${executable_path:-${shim_name}}")
       fi
 
       "$shim_exec" "$plugin_name" "$full_version" "$executable_path"

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -362,3 +362,22 @@ EOF
   [ "$status" -eq 0 ]
   [ "$output" = "$expected" ]
 }
+
+@test "with_shim_executable doesn't crash when executable names contain dashes" {
+  cd $PROJECT_DIR
+  echo "dummy 0.1.0" > $PROJECT_DIR/.tool-versions
+  mkdir -p $ASDF_DIR/installs/dummy/0.1.0/bin
+  touch $ASDF_DIR/installs/dummy/0.1.0/bin/test-dash
+  chmod +x $ASDF_DIR/installs/dummy/0.1.0/bin/test-dash
+  run asdf reshim dummy 0.1.0
+
+  message="callback invoked"
+
+  function callback() {
+    echo $message
+  }
+
+  run with_shim_executable test-dash callback
+  [ "$status" -eq 0 ]
+  [ "$output" = "$message" ]
+}


### PR DESCRIPTION
# Summary

Handle executable names with dashes as regular strings. Write unit test to ensure the `with_shim_executable` handles shims like this properly.

Fixes: #565 
