### PR TITLE
Fix sed command so it handles paths correctly

### DIFF
--- a/lib/commands/version_commands.sh
+++ b/lib/commands/version_commands.sh
@@ -37,7 +37,7 @@ version_command() {
 
 
   if [ -f "$file" ] && grep "^$plugin " "$file" > /dev/null; then
-    sed -i.bak -e "s/^$plugin .*$/$plugin ${versions[*]}/" "$file"
+    sed -i.bak -e "s|^$plugin .*$|$plugin ${versions[*]}|" "$file"
     rm "$file".bak
   else
     echo "$plugin ${versions[*]}" >> "$file"


### PR DESCRIPTION
# Summary

This sed command was using `/` as the delimiter for the find and replace command. This caused problems when the variable used in the expression also contained `/`, such as when a path was specified. See #559 for more details.

I was unable to write a unit tests for this, as the problem only manifests in an error when the path starts with `/U`, and I didn't want the unit tests trying to create a directory in root.

Fixes #559
