### PR TITLE
Add AppVeyor badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# asdf-vm [![Build Status](https://travis-ci.org/asdf-vm/asdf.svg?branch=master)](https://travis-ci.org/asdf-vm/asdf)
+# asdf-vm [![Build Status](https://travis-ci.org/asdf-vm/asdf.svg?branch=master)](https://travis-ci.org/asdf-vm/asdf)[![Build status](https://ci.appveyor.com/api/projects/status/2fkj7jngt8qeu8kw?svg=true)](https://ci.appveyor.com/project/TrevorBrown/asdf)
 
 **Manage multiple runtime versions with a single CLI tool, extendable via plugins** - [docs at asdf-vm.com](https://asdf-vm.github.io/asdf/)
 


### PR DESCRIPTION
# Summary

Encourage us to pay attention to #450.

I'm not really sure I setup AppVeyor right. It links to the build I setup for asdf-vm/asdf, so it shows as TrevorBrown/asdf.
