### PR TITLE
Fix completion suggestions for OSX / fish

### DIFF
--- a/completions/asdf.fish
+++ b/completions/asdf.fish
@@ -31,7 +31,7 @@ function __fish_asdf_arg_at -a number
 end
 
 function __fish_asdf_list_versions -a plugin
-    asdf list $plugin 2> /dev/null | sed -e 's/^\s*//'
+    asdf list $plugin 2> /dev/null | sed -e 's/^[[:space:]]*//'
 end
 
 function __fish_asdf_list_all -a plugin


### PR DESCRIPTION
# Summary

Fixes issue with suggestions when running `fish` on OSX.

## Other Information

OSX `sed` is not GNU `sed`, and doesn't support the `\s` whitespace character sequence. This results in autocompletion suggestions including leading spaces, e.g.,
```
$ asdf local python \ \ 3.8.0
```

Using the POSIX compliant `[[:space:]]` sequence is more compatible, and removes the unnecessary spaces on OSX.