### PR TITLE
`asdf --version` shows git-revision when asdf_dir is a git clone.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 Features
 
+* `asdf --version` displays git revision when asdf_dir is a git clone.
+
+   This will allow better bug reports since people can now include the
+   git commit they are using.
+
 * Add support for asdf extension commands.
 
    When a plugin provides custom executables or bash-scripts under its `bin/` directory,

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -8,7 +8,14 @@ GREP_COLORS=
 ASDF_DIR=${ASDF_DIR:-''}
 
 asdf_version() {
-  cat "$(asdf_dir)/VERSION"
+  local version git_rev
+  version="$(cat "$(asdf_dir)/VERSION")"
+  if [ -d "$(asdf_dir)/.git" ]; then
+    git_rev="$(git --git-dir "$(asdf_dir)/.git" rev-parse --short HEAD)"
+    echo "${version}-${git_rev}"
+  else
+    echo "${version}"
+  fi
 }
 
 asdf_dir() {


### PR DESCRIPTION
This will help people running on asdf master be able to report
issues and maintainers can know the precise git commit where the
error was reported.

For example, on #598 it would be better to know the exact version being used.
