### PR TITLE
Clarify instructions when <version> of a <shim_name> is missing.

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -711,16 +711,23 @@ with_shim_executable() {
   fi
 
   (
-    local version
-    version=$(get_preset_version_for "$shim_name")
-    echo "asdf: No version ${version} installed for command ${shim_name}"
-    echo "Please install the missing version by running"
-    echo ""
-    echo "asdf install ${shim_name} ${version}"
-    echo ""
-    echo "or add one of the following in your .tool-versions file:"
+    local preset_version
+    preset_version=$(get_preset_version_for "$shim_name")
+
+    if [ -n "$preset_version" ]; then
+      echo "asdf: No version ${preset_version} installed for command ${shim_name}"
+      echo "Please install the missing version by running"
+      echo ""
+      echo "asdf install ${shim_name} ${preset_version}"
+      echo ""
+      echo "or add one of the following in your .tool-versions file:"
+    else
+      echo "asdf: No version set for command ${shim_name}"
+      echo "you might want to add one of the following in your .tool-versions file:"
+    fi
     echo ""
     shim_plugin_versions "${shim_name}"
   ) >&2
+
   return 126
 }

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -711,8 +711,14 @@ with_shim_executable() {
   fi
 
   (
-    echo "asdf: No version set for command ${shim_name}"
-    echo "you might want to add one of the following in your .tool-versions file:"
+    local version
+    version=$(get_preset_version_for "$shim_name")
+    echo "asdf: No version ${version} installed for command ${shim_name}"
+    echo "Please install the missing version by running"
+    echo ""
+    echo "asdf install ${shim_name} ${version}"
+    echo ""
+    echo "or add one of the following in your .tool-versions file:"
     echo ""
     shim_plugin_versions "${shim_name}"
   ) >&2

--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -113,6 +113,20 @@ teardown() {
   echo "$output" | grep -q "mummy 3.0" 2>/dev/null
 }
 
+@test "shim exec should suggest to install missing version" {
+  run asdf install dummy 1.0
+
+  echo "dummy 2.0" > $PROJECT_DIR/.tool-versions
+
+  run $ASDF_DIR/shims/dummy world hello
+  [ "$status" -eq 126 ]
+  echo "$output" | grep -q "No version 2.0 installed for command dummy"  2>/dev/null
+  echo "$output" | grep -q "Please install the missing version by running"  2>/dev/null
+  echo "$output" | grep -q "asdf install dummy 2.0"  2>/dev/null
+  echo "$output" | grep -q "or add one of the following in your .tool-versions file:"  2>/dev/null
+  echo "$output" | grep -q "dummy 1.0"  2>/dev/null
+}
+
 @test "shim exec should execute first plugin that is installed and set" {
   run asdf install dummy 2.0
   run asdf install dummy 3.0


### PR DESCRIPTION
# Summary

Often time when working on multiple projects and multiple versions, the version that specified in `.tool-versions` or legacy config like `.ruby-version` is not yet installed in the system. When that happens this is what we see

<img width="516" alt="Screenshot 2019-12-03 at 11 47 48" src="https://user-images.githubusercontent.com/1259814/70059498-d04c4500-15d8-11ea-8dea-e7b30ae68326.png">

So instead of telling us what version is missing, asdf tell us to change the configuration into one that has been installed in our system.

This PR changes the warning by giving us information about which version is missing, and option to install the missing version or replace existing project to use different version that is available.

<img width="403" alt="Screenshot 2019-12-03 at 14 10 55" src="https://user-images.githubusercontent.com/1259814/70059751-39cc5380-15d9-11ea-85dc-42e62f1f718b.png">
