### PR TITLE
Fix errors in list-all command documentation

### DIFF
--- a/docs/core-manage-versions.md
+++ b/docs/core-manage-versions.md
@@ -31,15 +31,15 @@ asdf list <name>
 ## List All Available Versions
 
 ```shell
-asdf list all <name>
-# asdf list all erlang
+asdf list-all <name>
+# asdf list-all erlang
 ```
 
 Limit versions to those that begin with a given string.
 
 ```shell
-asdf list all <name> <version>
-# asdf list all erlang 17
+asdf list-all <name> <version>
+# asdf list-all erlang 17
 ```
 
 ## Show Latest Stable Version


### PR DESCRIPTION
# Summary

Documentation fix

Fixes: N/A

## Other Information

Need `list-all` rather than `list all`:

```
> asdf list all nodejs
No such plugin: all
```