### PR TITLE
Update installation for Zsh on macOS Catalina

### DIFF
--- a/docs/core-manage-asdf-vm.md
+++ b/docs/core-manage-asdf-vm.md
@@ -54,6 +54,12 @@ echo -e '\n. $HOME/.asdf/asdf.sh' >> ~/.bash_profile
 echo -e '\n. $HOME/.asdf/completions/asdf.bash' >> ~/.bash_profile
 ```
 
+Note if you are using Catalina or newer, the default shell has changed to Zsh:
+
+```bash
+echo -e '\n. $HOME/.asdf/asdf.sh' >> ~/.zprofile
+```
+
 Installation via **Homebrew**:
 
 ?> If you have Homebrew's Bash completions configured, the second line below is


### PR DESCRIPTION
# Summary
MacOS now ships with Zsh as the default shell. I added a note for this in the Mac installation area of the docs.