### PR TITLE
Change 'list all' to 'list-all'

### DIFF
--- a/docs/core-manage-versions.md
+++ b/docs/core-manage-versions.md
@@ -31,15 +31,15 @@ asdf list <name>
 ## List All Available Versions
 
 ```shell
-asdf list all <name>
-# asdf list all erlang
+asdf list-all <name>
+# asdf list-all erlang
 ```
 
 Limit versions to those that begin with a given string.
 
 ```shell
-asdf list all <name> <version>
-# asdf list all erlang 17
+asdf list-all <name> <version>
+# asdf list-all erlang 17
 ```
 
 ## Show Latest Stable Version


### PR DESCRIPTION
When I ran `asdf list all mysql ` I got `No such plugin: all`. When I checked out their docs, I noticed they wrote `asdf list-all mysql`, and it worked.