### PR TITLE
Update core-manage-versions.md

### DIFF
--- a/docs/core-manage-versions.md
+++ b/docs/core-manage-versions.md
@@ -31,29 +31,8 @@ asdf list <name>
 ## List All Available Versions
 
 ```shell
-asdf list all <name>
+asdf list-all <name>
 # asdf list all erlang
-```
-
-Limit versions to those that begin with a given string.
-
-```shell
-asdf list all <name> <version>
-# asdf list all erlang 17
-```
-
-## Show Latest Stable Version
-
-```shell
-asdf latest <name>
-# asdf latest erlang
-```
-
-Show latest stable version that begins with a given string.
-
-```shell
-asdf latest <name> <version>
-# asdf latest erlang 17
 ```
 
 ## Set Current Version


### PR DESCRIPTION
Updating documentation for deprecated commands.

# Summary

Update documentation for managing language versions. `list all` command does not seem to be supported any more and instead we use the `list-all` command.

In addition `asdf latest` does not seem to be supported as well. I've tested the command against Nodejs and Ruby.