### PR TITLE
doc: fix list all to list-all command

### DIFF
--- a/docs/core-commands.md
+++ b/docs/core-commands.md
@@ -28,7 +28,7 @@
 | `asdf global <name> <version>`           | Set the package global version                                             |
 | `asdf latest <name> [<version>]`         | Show latest stable version of a package                                    |
 | `asdf list <name>`                       | List installed versions of a package                                       |
-| `asdf list all <name> [<version>]`       | List all versions of a package and optionally filter the returned versions |
+| `asdf list-all <name> [<version>]`       | List all versions of a package and optionally filter the returned versions |
 
 ## Utils
 

--- a/docs/core-manage-versions.md
+++ b/docs/core-manage-versions.md
@@ -31,15 +31,15 @@ asdf list <name>
 ## List All Available Versions
 
 ```shell
-asdf list all <name>
-# asdf list all erlang
+asdf list-all <name>
+# asdf list-all erlang
 ```
 
 Limit versions to those that begin with a given string.
 
 ```shell
-asdf list all <name> <version>
-# asdf list all erlang 17
+asdf list-all <name> <version>
+# asdf list-all erlang 17
 ```
 
 ## Show Latest Stable Version


### PR DESCRIPTION
# Summary

Fix typo that  `list all` to `list-all`

