### PR TITLE
Fix issue with preset version warning assuming that the shim name and plugin name are the same

### DIFF
--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -116,13 +116,14 @@ teardown() {
 @test "shim exec should suggest to install missing version" {
   run asdf install dummy 1.0
 
-  echo "dummy 2.0" > $PROJECT_DIR/.tool-versions
+  echo "dummy 2.0 1.3" > $PROJECT_DIR/.tool-versions
 
   run $ASDF_DIR/shims/dummy world hello
   [ "$status" -eq 126 ]
-  echo "$output" | grep -q "No version 2.0 installed for command dummy"  2>/dev/null
-  echo "$output" | grep -q "Please install the missing version by running"  2>/dev/null
+  echo "$output" | grep -q "No preset version installed for command dummy"  2>/dev/null
+  echo "$output" | grep -q "Please install the missing version by running one of the following:"  2>/dev/null
   echo "$output" | grep -q "asdf install dummy 2.0"  2>/dev/null
+  echo "$output" | grep -q "asdf install dummy 1.3"  2>/dev/null
   echo "$output" | grep -q "or add one of the following in your .tool-versions file:"  2>/dev/null
   echo "$output" | grep -q "dummy 1.0"  2>/dev/null
 }


### PR DESCRIPTION
# Summary
In #609 a clearer error message was added when you're trying to run a shimmed command, but you don't have a correct version. This PR fixes an issue where that code was assuming that the shim and plugin share a name.

An example of where this is not the case is the "nodejs" plugin, as the shim is installed as "node"

In other areas of the utils file, it works on the basis that there may be multiple plugins that provide for that shim, so I have worked on the same basis
