### PR TITLE
Ignore shim directory for executable lookups

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -674,10 +674,8 @@ with_shim_executable() {
     plugin_path=$(get_plugin_path "$plugin_name")
 
     run_within_env() {
-      local path=$PATH
-      if [ "system" == "$full_version" ]; then
-        path=$(echo "$PATH" | sed -e "s|$(asdf_data_dir)/shims||g; s|::|:|g")
-      fi
+      local path
+      path=$(echo "$PATH" | sed -e "s|$(asdf_data_dir)/shims||g; s|::|:|g")
 
       executable_path=$(PATH=$path command -v "$shim_name")
 

--- a/test/get_asdf_config_value.bats
+++ b/test/get_asdf_config_value.bats
@@ -3,6 +3,7 @@
 load test_helpers
 
 setup() {
+    cd $BATS_TMPDIR
     ASDF_CONFIG_FILE=$BATS_TMPDIR/asdfrc
     cat > $ASDF_CONFIG_FILE <<-EOM
 key1 = value1

--- a/test/which_command.bats
+++ b/test/which_command.bats
@@ -99,3 +99,13 @@ teardown() {
   [ "$status" -eq 0 ]
   [ "$output" = "$ASDF_DIR/installs/dummy/1.1/bin/dummy" ]
 }
+
+@test "which should not return shim path" {
+  cd $PROJECT_DIR
+  echo 'dummy 1.0' > $PROJECT_DIR/.tool-versions
+  rm "$ASDF_DIR/installs/dummy/1.0/bin/dummy"
+
+  run env PATH=$PATH:$ASDF_DIR/shims asdf which dummy
+  [ "$status" -eq 1 ]
+  [ "$output" == "No dummy executable found for dummy 1.0" ]
+}


### PR DESCRIPTION
# Summary

Previously, the shims directory was only excluded for system versions, which meant that `asdf exec` would fall back to a shim if the install didn't have the desired binary. If the shims are up to date this isn't a problem since we check the metadata, but if those were out of sync the command would just infinitely recurse.

I'm not sure what the reason was for the current setup, but I looked through the uses of the function and I'm not seeing anywhere it is required.

Fixes: No issue

## Other Information

I also made a small tweak to the config test to make it pass, it was picking up my user `.asdfrc`.