### PR TITLE
Fix relative symlink path resolution

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -450,12 +450,16 @@ resolve_symlink() {
   # If it is a slash we can assume it's root and absolute. Otherwise we treat it
   # as relative
   case $resolved_path in
-  /*)
-    echo "$resolved_path"
-    ;;
-  *)
-    echo "$PWD/$resolved_path"
-    ;;
+    /*)
+      echo "$resolved_path"
+      ;;
+    *)
+      (
+        # shellcheck disable=SC2164
+        cd "$(dirname "$symlink")"
+        echo "$PWD/$resolved_path"
+      )
+      ;;
   esac
 }
 

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -361,14 +361,15 @@ teardown() {
 }
 
 @test "resolve_symlink converts relative symlink path to the real file path" {
+  mkdir dir
   touch foo
-  ln -s foo bar
+  ln -s ../foo dir/bar
 
-  run resolve_symlink bar
+  run resolve_symlink dir/bar
   [ "$status" -eq 0 ]
   echo $status
-  [ "$output" = $(pwd)/foo ]
-  rm -f foo bar
+  [ "$output" = $(pwd)/dir/../foo ]
+  rm -rf dir foo
 }
 
 @test "strip_tool_version_comments removes lines that only contain comments" {


### PR DESCRIPTION
# Summary

I've only just started using asdf, and (similarly to https://github.com/asdf-vm/asdf/issues/366), I have `~/.tool-versions` as a symlink to a config repository of mine. Running `asdf global global <plugin> <version>` fails, apparently due to a bug in relative symlink resolution.

I've modified the relative symlink test, and verified that it fails without my change to utils.sh.

Fixes: https://github.com/asdf-vm/asdf/issues/366

Hope this helps! :slightly_smiling_face: 
