### PR TITLE
Defaults to empty ASDF_DATA_DIR

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -6,6 +6,7 @@ GREP_OPTIONS="--color=never"
 GREP_COLORS=
 
 ASDF_DIR=${ASDF_DIR:-''}
+ASDF_DATA_DIR=${ASDF_DATA_DIR:-''}
 
 asdf_version() {
   local version git_rev


### PR DESCRIPTION
If ASDF_DATA_DIR variable is undefined it will assign an empty value to
it so bash instances running with set -o nounset can run the script
without error.