### PR TITLE
add installation note for Debian 10

### DIFF
--- a/docs/core-manage-asdf-vm.md
+++ b/docs/core-manage-asdf-vm.md
@@ -168,7 +168,15 @@ sudo apt install \
   libxslt-dev libffi-dev libtool unixodbc-dev \
   unzip curl
 ```
+#### ** Debian **
 
+```shell
+sudo apt install \
+  automake autoconf libreadline-dev \
+  libncurses-dev libssl-dev libyaml-dev \
+  libxslt-dev libffi-dev libtool unixodbc-dev \
+  unzip curl zlib1g-dev
+```
 #### **Fedora**
 
 ```shell


### PR DESCRIPTION
On Debian 10 it was required to add `zlib1g-dev` into installed packages, otherwise, for example, Python fails:
```
coolcold@nekobus:~$ asdf install python 3.8.1
Downloading python-build...
Cloning into '/home/coolcold/.asdf/plugins/python/pyenv'...
remote: Enumerating objects: 17591, done.
remote: Total 17591 (delta 0), reused 0 (delta 0), pack-reused 17591
Receiving objects: 100% (17591/17591), 3.43 MiB | 407.00 KiB/s, done.
Resolving deltas: 100% (11951/11951), done.
python-build 3.8.1 /home/coolcold/.asdf/installs/python/3.8.1
Downloading Python-3.8.1.tar.xz...
-> https://www.python.org/ftp/python/3.8.1/Python-3.8.1.tar.xz
Installing Python-3.8.1...

BUILD FAILED (Debian 10 using python-build 1.2.16)

Inspect or clean up the working tree at /tmp/python-build.20200107110028.17443
Results logged to /tmp/python-build.20200107110028.17443.log

Last 10 log lines:
    return _bootstrap(
  File "/tmp/python-build.20200107110028.17443/Python-3.8.1/Lib/ensurepip/__init__.py", line 119, in _bootstrap
    return _run_pip(args + [p[0] for p in _PROJECTS], additional_paths)
  File "/tmp/python-build.20200107110028.17443/Python-3.8.1/Lib/ensurepip/__init__.py", line 27, in _run_pip
    import pip._internal
  File "<frozen zipimport>", line 241, in load_module
  File "<frozen zipimport>", line 709, in _get_module_code
  File "<frozen zipimport>", line 570, in _get_data
zipimport.ZipImportError: can't decompress data; zlib not available
make: *** [Makefile:1186: install] Error 1
```

# Summary

Installation docs update to include Debian 10

Fixes: unable to install python
