### PR TITLE
Fix bash completion for `plugin-add`

### DIFF
--- a/completions/asdf.bash
+++ b/completions/asdf.bash
@@ -25,7 +25,7 @@ _asdf() {
       ;;
     plugin-add)
       local available_plugins
-      available_plugins=$( (asdf plugin-list 2>/dev/null && asdf plugin-list-all 2>/dev/null) | sort | uniq -u)
+      available_plugins=$(asdf plugin-list-all 2>/dev/null | awk '{ if ($2 !~ /^\*/) print $1}')
       # shellcheck disable=SC2207
       COMPREPLY=($(compgen -W "$available_plugins" -- "$cur"))
       ;;


### PR DESCRIPTION
# Summary

`$ asdf plugin-add <TAB>` currently yields this mess:

![image](https://user-images.githubusercontent.com/3399022/73251625-572d3080-41ca-11ea-99db-74800cedec04.png)

Fixing it to provide a clean list of available but not installed plugins (this is also what fish completion already does and somehow got overlooked in bash version):

![image](https://user-images.githubusercontent.com/3399022/73251726-8ba0ec80-41ca-11ea-9d24-acb6d6dc4a9b.png)