### PR TITLE
Fix hanging 'asdf update is a noop for non-git repos' test

### DIFF
--- a/test/update_command.bats
+++ b/test/update_command.bats
@@ -54,7 +54,7 @@ teardown() {
 }
 
 @test "asdf update is a noop for non-git repos" {
-  (cd $ASDF_DIR && rm -r .git/)
+  rm -rf $ASDF_DIR/.git/
   run asdf update
   [ "$status" -eq 1 ]
   [ "$(echo -e "Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf.")" == "$output" ]


### PR DESCRIPTION
# Summary

Don't allow the `rm` command to hang waiting for user input to confirm the deletion of the `.git` files. `rm` was causing the test to hang.

Fixes: #634