### PR TITLE
Misc. Test Improvements

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -40,10 +40,8 @@ asdf_data_dir() {
 
   if [ -n "${ASDF_DATA_DIR}" ]; then
     data_dir="${ASDF_DATA_DIR}"
-  elif [[ $EUID -ne 0 ]]; then
-    data_dir="$HOME/.asdf"
   else
-    data_dir="$(asdf_dir)"
+    data_dir="$HOME/.asdf"
   fi
 
   echo "$data_dir"

--- a/test/test_helpers.bash
+++ b/test/test_helpers.bash
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Unset ASDF_DIR because it may already be set by the users shell, and some
+# tests fail when it is set to something other than the temp dir.
+unset ASDF_DIR
+
 # shellcheck source=lib/utils.sh
 . "$(dirname "$BATS_TEST_DIRNAME")"/lib/utils.sh
 

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -143,6 +143,14 @@ teardown() {
   [ "$output" = "$ASDF_DATA_DIR" ]
 }
 
+@test "asdf_data_dir should return ~/.asdf when ASDF_DATA_DIR is not set" {
+  unset ASDF_DATA_DIR
+
+  run asdf_data_dir
+  [ "$status" -eq 0 ]
+  [ "$output" = "$HOME/.asdf" ]
+}
+
 @test "check_if_plugin_exists should work with a custom data directory" {
   ASDF_DATA_DIR=$HOME/asdf-data
 


### PR DESCRIPTION
# Summary

Unset `ASDF_DIR` before running tests to ensure tests always pass regardless of whether the user already has `ASDF_DIR` set in their shell.

Fixes: #634
