### PR TITLE
[docs] clean up: update example with maintained project url

### DIFF
--- a/docs/core-manage-plugins.md
+++ b/docs/core-manage-plugins.md
@@ -31,7 +31,7 @@ asdf plugin-list
 ```shell
 asdf plugin-list --urls
 # asdf plugin-list
-# java            https://github.com/skotchpine/asdf-java.git
+# java            https://github.com/halcyon/asdf-java.git
 # nodejs          https://github.com/asdf-vm/asdf-nodejs.git
 ```
 


### PR DESCRIPTION
# Summary
Fixes: updates example url to avoid redirect users to deprecated repository.

## Other Information

https://github.com/skotchpine/asdf-java isn't been maintained anymore.