### PR TITLE
Default ZSH_VERSION to empty string.

### DIFF
--- a/asdf.sh
+++ b/asdf.sh
@@ -32,7 +32,7 @@ PATH="${ASDF_USER_SHIMS}:$PATH"
 # Load the asdf wrapper function
 . "${ASDF_DIR}/lib/asdf.sh"
 
-if [ -n "$ZSH_VERSION" ]; then
+if [ -n "${ZSH_VERSION:-}" ]; then
   autoload -U bashcompinit
   bashcompinit
 fi


### PR DESCRIPTION
# Summary

This avoids borking when a user has `set -u` (a.k.a. the `nounset` option) enabled.

Fixes #655.