### PR TITLE
Ensure we are using installation location instead of symlink location

### DIFF
--- a/bin/asdf
+++ b/bin/asdf
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+## Courtesy of https://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
 normalized_readlink() {
   TARGET_FILE=$1
 

--- a/bin/asdf
+++ b/bin/asdf
@@ -1,8 +1,26 @@
 #!/usr/bin/env bash
 
-# Get files actual location
-SCRIPT=$(readlink -f "$0")
+normalized_readlink() {
+  TARGET_FILE=$1
 
+  cd "$(dirname "$TARGET_FILE")" || exit
+  TARGET_FILE=$(basename "$TARGET_FILE")
+
+  # Iterate down a (possible) chain of symlinks
+  while [ -L "$TARGET_FILE" ]; do
+    TARGET_FILE=$(readlink "$TARGET_FILE")
+    cd "$(dirname "$TARGET_FILE")" || exit
+    TARGET_FILE=$(basename "$TARGET_FILE")
+  done
+
+  # Compute the canonicalized name by finding the physical path
+  # for the directory we're in and appending the target file.
+  PHYS_DIR=$(pwd -P)
+  RESULT=$PHYS_DIR/$TARGET_FILE
+  echo "$RESULT"
+}
+
+SCRIPT=$(normalized_readlink "$0")
 # shellcheck source=lib/utils.bash
 source "$(dirname "$(dirname "$SCRIPT")")/lib/utils.bash"
 

--- a/bin/asdf
+++ b/bin/asdf
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 
+# Get files actual location
+SCRIPT=$(readlink -f "$0")
+
 # shellcheck source=lib/utils.bash
-source "$(dirname "$(dirname "$0")")/lib/utils.bash"
+source "$(dirname "$(dirname "$SCRIPT")")/lib/utils.bash"
 
 find_cmd() {
   local cmd_dir="$1"

--- a/bin/asdf
+++ b/bin/asdf
@@ -77,11 +77,13 @@ asdf_cmd() {
     exec "$ASDF_CMD_FILE" "${@:${args_offset}}"
   elif [ -f "$ASDF_CMD_FILE" ]; then
     set -- "${@:${args_offset}}"
+    # shellcheck source=/dev/null
     source "$ASDF_CMD_FILE"
   else
     local asdf_cmd_dir
     asdf_cmd_dir="$(asdf_dir)/lib/commands"
     echo "Unknown command: \`asdf ${*}\`" >&2
+    # shellcheck source=lib/commands/command-help.bash
     source "$asdf_cmd_dir/command-help.bash" >&2
     return 127
   fi

--- a/bin/asdf
+++ b/bin/asdf
@@ -26,23 +26,23 @@ find_asdf_cmd() {
   local asdf_cmd_dir
   asdf_cmd_dir="$(asdf_dir)/lib/commands"
   case "$1" in
-  'exec' | 'current' | 'env' | 'global' | 'install' | 'latest' | 'local' | \
-    'reshim' | 'uninstall' | 'update' | 'where' | 'which' | \
-    'export-shell-version')
-    echo "$asdf_cmd_dir/command-$1.bash" 2
-    ;;
+    'exec' | 'current' | 'env' | 'global' | 'install' | 'latest' | 'local' | \
+      'reshim' | 'uninstall' | 'update' | 'where' | 'which' | \
+      'export-shell-version')
+      echo "$asdf_cmd_dir/command-$1.bash" 2
+      ;;
 
-  '' | '--help' | '-h' | 'help')
-    echo "$asdf_cmd_dir/command-help.bash" 2
-    ;;
+    '' | '--help' | '-h' | 'help')
+      echo "$asdf_cmd_dir/command-help.bash" 2
+      ;;
 
-  '--version' | 'version')
-    echo "$asdf_cmd_dir/command-version.bash" 2
-    ;;
+    '--version' | 'version')
+      echo "$asdf_cmd_dir/command-version.bash" 2
+      ;;
 
-  *)
-    find_cmd "$asdf_cmd_dir" "$@"
-    ;;
+    *)
+      find_cmd "$asdf_cmd_dir" "$@"
+      ;;
   esac
 }
 

--- a/bin/asdf
+++ b/bin/asdf
@@ -1,29 +1,7 @@
 #!/usr/bin/env bash
 
-## Courtesy of https://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
-normalized_readlink() {
-  TARGET_FILE=$1
-
-  cd "$(dirname "$TARGET_FILE")" || exit
-  TARGET_FILE=$(basename "$TARGET_FILE")
-
-  # Iterate down a (possible) chain of symlinks
-  while [ -L "$TARGET_FILE" ]; do
-    TARGET_FILE=$(readlink "$TARGET_FILE")
-    cd "$(dirname "$TARGET_FILE")" || exit
-    TARGET_FILE=$(basename "$TARGET_FILE")
-  done
-
-  # Compute the canonicalized name by finding the physical path
-  # for the directory we're in and appending the target file.
-  PHYS_DIR=$(pwd -P)
-  RESULT=$PHYS_DIR/$TARGET_FILE
-  echo "$RESULT"
-}
-
-SCRIPT=$(normalized_readlink "$0")
 # shellcheck source=lib/utils.bash
-source "$(dirname "$(dirname "$SCRIPT")")/lib/utils.bash"
+source "$(dirname "$(dirname "$0")")/lib/utils.bash"
 
 find_cmd() {
   local cmd_dir="$1"
@@ -48,23 +26,23 @@ find_asdf_cmd() {
   local asdf_cmd_dir
   asdf_cmd_dir="$(asdf_dir)/lib/commands"
   case "$1" in
-    'exec' | 'current' | 'env' | 'global' | 'install' | 'latest' | 'local' | \
-      'reshim' | 'uninstall' | 'update' | 'where' | 'which' | \
-      'export-shell-version')
-      echo "$asdf_cmd_dir/command-$1.bash" 2
-      ;;
+  'exec' | 'current' | 'env' | 'global' | 'install' | 'latest' | 'local' | \
+    'reshim' | 'uninstall' | 'update' | 'where' | 'which' | \
+    'export-shell-version')
+    echo "$asdf_cmd_dir/command-$1.bash" 2
+    ;;
 
-    '' | '--help' | '-h' | 'help')
-      echo "$asdf_cmd_dir/command-help.bash" 2
-      ;;
+  '' | '--help' | '-h' | 'help')
+    echo "$asdf_cmd_dir/command-help.bash" 2
+    ;;
 
-    '--version' | 'version')
-      echo "$asdf_cmd_dir/command-version.bash" 2
-      ;;
+  '--version' | 'version')
+    echo "$asdf_cmd_dir/command-version.bash" 2
+    ;;
 
-    *)
-      find_cmd "$asdf_cmd_dir" "$@"
-      ;;
+  *)
+    find_cmd "$asdf_cmd_dir" "$@"
+    ;;
   esac
 }
 

--- a/test/banned_commands.bats
+++ b/test/banned_commands.bats
@@ -4,8 +4,8 @@ load test_helpers
 
 banned_commands=(
     realpath
-    # readlink on OSX behaves differently from readlink on other Unix systems
-    readlink
+    # readlink -f on OSX behaves differently from readlink -f on other Unix systems
+    "readlink -f"
     # It's best to avoid eval as it makes it easier to accidentally execute
     # arbitrary strings
     eval

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -310,18 +310,18 @@ teardown() {
   run resolve_symlink bar
   [ "$status" -eq 0 ]
   echo $status
-  [ "$output" = $(pwd)/foo ]
+  [ "$output" = "$(pwd -P)/foo" ]
   rm -f foo bar
 }
 
 @test "resolve_symlink converts relative symlink path to the real file path" {
   touch foo
   ln -s foo bar
-
   run resolve_symlink bar
+  
   [ "$status" -eq 0 ]
   echo $status
-  [ "$output" = $(pwd)/foo ]
+  [ "$output" = "$(pwd -P)/foo" ]
   rm -f foo bar
 }
 

--- a/test/version_commands.bats
+++ b/test/version_commands.bats
@@ -209,7 +209,7 @@ teardown() {
 @test "global should preserve symlinks when setting versions" {
   mkdir other-dir
   touch other-dir/.tool-versions
-  ln -s other-dir/.tool-versions $HOME/.tool-versions
+  ln -s "$(pwd)/other-dir/.tool-versions" "$HOME/.tool-versions"
 
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
@@ -220,7 +220,7 @@ teardown() {
 @test "global should preserve symlinks when updating versions" {
   mkdir other-dir
   touch other-dir/.tool-versions
-  ln -s other-dir/.tool-versions $HOME/.tool-versions
+  ln -s "$(pwd)/other-dir/.tool-versions" "$HOME/.tool-versions"
 
   run asdf global "dummy" "1.1.0"
   run asdf global "dummy" "1.1.0"


### PR DESCRIPTION
# Summary

Change to resolve actual asdf script location before sourcing anything.
Ensures that we are not using symlink location as basis for sourcing.

Fixes:
- https://github.com/asdf-vm/asdf/issues/607