### PR TITLE
Change bullet point under "Why use asdf-vm?" heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ asdf-vm is a CLI tool that can manage multiple language runtime versions on a pe
 - support for existing config files `.node-version`, `.nvmrc`, `.ruby-version` for easy migration
 - automatically switches runtime versions as you traverse your directories
 - simple plugin system to add support for your language of choice
-- completion scripts managed by the plugin, not you!
+- shell completion available for common shells (Bash, Zsh, Fish)
 
 ## Documentation
 


### PR DESCRIPTION
# Summary

Change the incorrect/confusing bullet point under the "Why use asdf-vm?" heading in the readme.

Fixes: #529 
