### PR TITLE
Use different exit code if updates are disabled

### DIFF
--- a/lib/commands/command-update.bash
+++ b/lib/commands/command-update.bash
@@ -8,7 +8,7 @@ update_command() {
 
     if [ -f asdf_updates_disabled ] || ! git rev-parse --is-inside-work-tree &>/dev/null; then
       echo "Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf."
-      exit 1
+      exit 42
     else
       do_update "$update_to_head"
     fi

--- a/test/update_command.bats
+++ b/test/update_command.bats
@@ -53,11 +53,24 @@ teardown() {
   [ "$?" -eq 0 ]
 }
 
+@test "asdf update is a noop for when updates are disabled" {
+  touch $ASDF_DIR/asdf_updates_disabled
+  run asdf update
+  [ "$status" -eq 42 ]
+  [ "$(echo -e "Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf.")" == "$output" ]
+}
+
 @test "asdf update is a noop for non-git repos" {
   rm -rf $ASDF_DIR/.git/
   run asdf update
-  [ "$status" -eq 1 ]
+  [ "$status" -eq 42 ]
   [ "$(echo -e "Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf.")" == "$output" ]
+}
+
+@test "asdf update fails with exit code 1" {
+  git --git-dir "$ASDF_DIR/.git" remote set-url origin https://this-host-does-not-exist.xyz
+  run asdf update
+  [ "$status" -eq 1 ]
 }
 
 @test "asdf update should not remove plugin versions" {


### PR DESCRIPTION
# Summary

If asdf-vm was installed with a package manager and the user doesn't have the necessary permissions to update it with `asdf update`, asdf-vm emits an informational message and exits with exit code 1.

This makes it hard to programmatically detect whether the update failed or wasn't even attempted because it's not possible.

With this change, asdf-vm would exit with the exit code 2 if updates are disabled instead of exit code 1, which signals an error during update.

Refs r-darwish/topgrade#367