### PR TITLE
fix: remove automatic compinit

### DIFF
--- a/asdf.sh
+++ b/asdf.sh
@@ -31,7 +31,3 @@ PATH="${ASDF_USER_SHIMS}:$PATH"
 # shellcheck source=lib/asdf.sh
 # Load the asdf wrapper function
 . "${ASDF_DIR}/lib/asdf.sh"
-
-if [ -n "${ZSH_VERSION:-}" ]; then
-  fpath=(${ASDF_DIR}/completions $fpath)
-fi

--- a/asdf.sh
+++ b/asdf.sh
@@ -34,6 +34,4 @@ PATH="${ASDF_USER_SHIMS}:$PATH"
 
 if [ -n "${ZSH_VERSION:-}" ]; then
   fpath=(${ASDF_DIR}/completions $fpath)
-  autoload -Uz compinit
-  compinit
 fi

--- a/docs/core-manage-asdf-vm.md
+++ b/docs/core-manage-asdf-vm.md
@@ -83,7 +83,7 @@ echo -e '\n. $HOME/.asdf/asdf.sh' >> ~/.zshrc
 ?>If you are using a framework, such as [oh-my-zsh](https://ohmyz.sh/), these lines remain _below_ the line
 where you source your framework.)
 
-!>If you are not using a framework, or if on starting your shell you get an error message like `command not found: compinit`, then add the below line before the ones above.
+!>If you are not using a framework or are using a custom `compinit` setup, ensure `compinit` is below your sourcing of `asdf.sh` as it adds completions to the `fpath`.
 
 ```shell
 autoload -Uz compinit && compinit

--- a/docs/core-manage-asdf-vm.md
+++ b/docs/core-manage-asdf-vm.md
@@ -86,7 +86,7 @@ or use a framework plugin like [asdf for oh-my-zsh](https://github.com/ohmyzsh/o
 
 ZSH Completions:
 
-asdf ships with ZSH completions, however they need to be setup. Add the following to your `.zshrc`:
+asdf ships with ZSH completions which will need to be setup if you're not using a ZSH framework plugin that does this for you. Add the following to your `.zshrc`:
 
 ```shell
 # append completions to fpath

--- a/docs/core-manage-asdf-vm.md
+++ b/docs/core-manage-asdf-vm.md
@@ -80,14 +80,13 @@ Installation via **Git**:
 echo -e '\n. $HOME/.asdf/asdf.sh' >> ~/.zshrc
 ```
 
-?>If you are using a framework, such as [oh-my-zsh](https://ohmyz.sh/), these lines remain _below_ the line
-where you source your framework.)
+?>Sourcing `asdf.sh` should occur after you source any ZSH framework such as [oh-my-zsh](https://ohmyz.sh/).
 
-!>If you are not using a framework or are using a custom `compinit` setup, ensure `compinit` is below your sourcing of `asdf.sh` as it adds completions to the `fpath`.
+Completions are automatically added to your `fpath` by `asdf.sh`, though `compinit` needs to be run.
 
-```shell
-autoload -Uz compinit && compinit
-```
+- if you are using a custom `compinit` setup, ensure `compinit` is below your sourcing of `asdf.sh`
+- if you are using a ZSH framework (which usually call `compinit` themselves) then the `asdf` plugin may require updating to support the new native ZSH completions
+- if you are not seeing completions, you can always add `autoload -Uz compinit && compinit` after your sourcing of `asdf.sh` to see if that solves your problem
 
 Installation via **Homebrew**:
 

--- a/docs/core-manage-asdf-vm.md
+++ b/docs/core-manage-asdf-vm.md
@@ -76,17 +76,28 @@ echo -e "\n. $(brew --prefix asdf)/etc/bash_completion.d/asdf.bash" >> ~/.bash_p
 
 Installation via **Git**:
 
+Source the `asdf.sh` script in your shell config:
+
 ```shell
-echo -e '\n. $HOME/.asdf/asdf.sh' >> ~/.zshrc
+echo -e "\n. $HOME/.asdf/asdf.sh" >> ~/.zshrc
 ```
 
-?>Sourcing `asdf.sh` should occur after you source any ZSH framework such as [oh-my-zsh](https://ohmyz.sh/).
+or use a framework plugin like [asdf for oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/asdf) which will source this init script and setup completions.
 
-Completions are automatically added to your `fpath` by `asdf.sh`, though `compinit` needs to be run.
+ZSH Completions:
+
+asdf ships with ZSH completions, however they need to be setup. Add the following to your `.zshrc`:
+
+```shell
+# append completions to fpath
+echo -e "\nfpath=(${ASDF_DIR}/completions $fpath)" >> ~/.zshrc
+# initialise completions with ZSH's compinit
+echo -e "\nautoload -Uz compinit && compinit" >> ~/.zshrc
+```
 
 - if you are using a custom `compinit` setup, ensure `compinit` is below your sourcing of `asdf.sh`
-- if you are using a ZSH framework (which usually call `compinit` themselves) then the `asdf` plugin may require updating to support the new native ZSH completions
-- if you are not seeing completions, you can always add `autoload -Uz compinit && compinit` after your sourcing of `asdf.sh` to see if that solves your problem
+- if you are using a custom `compinit` setup with a ZSH framework, ensure `compinit` is below your sourcing of the framework
+- if you are using a ZSH framework with an asdf plugin, then you shouldn't need to manually add `fpath`, the plugin may need to be updated to use the new ZSH completions properly
 
 Installation via **Homebrew**:
 
@@ -94,7 +105,7 @@ Installation via **Homebrew**:
 echo -e "\n. $(brew --prefix asdf)/asdf.sh" >> ~/.zshrc
 ```
 
-?> ASDF automatically adds it's completions to the function path (`$fpath`). This may clash with Homebrew's ZSH completions. See [Configuring Completions in ZSH](https://docs.brew.sh/Shell-Completion#configuring-completions-in-zsh) in the Homebrew docs.
+Shell completions should automatically be installed and available.
 
 #### ** Fish **
 


### PR DESCRIPTION
# Summary

#544 released in https://github.com/asdf-vm/asdf/releases/tag/v0.7.7 changed:

```diff
- if [ -n "$ZSH_VERSION" ]; then
-   autoload -U bashcompinit	
-   bashcompinit
+ if [ -n "${ZSH_VERSION:-}" ]; then
+   fpath=(${ASDF_DIR}/completions $fpath)
+   autoload -Uz compinit
+   compinit
+ fi
```

which results in `compinit` being executed multiple times (should people use a framework or explicitly use compinit in their own `zshrc``). `compinit` is designed to be called once, so we should not automatically run it here and double up on those already calling it.
 
This has performance implications and concerns were raised about asdf being **unexpectedly** intrusive.

Clearer documentation updates will rectify any issues with this removal. I would wager few ZSH users are relying on asdf to run `compinit` so hopefully we see minimal affect.

This was previously not a problem for ZSH users as we were:

- using `bashcompinit` and thus not interfering with `compinit`
- advising users to source the Bash completions in their `zshrc` files

Fixes: #674 
