### PR TITLE
Move sort_versions() into utils.bash

### DIFF
--- a/lib/commands/command-update.bash
+++ b/lib/commands/command-update.bash
@@ -42,10 +42,4 @@ do_update() {
   fi
 }
 
-# stolen from https://github.com/rbenv/ruby-build/pull/631/files#diff-fdcfb8a18714b33b07529b7d02b54f1dR942
-sort_versions() {
-  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
-    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
-}
-
 update_command "$@"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -760,3 +760,9 @@ with_shim_executable() {
 
   return 126
 }
+
+# stolen from https://github.com/rbenv/ruby-build/pull/631/files#diff-fdcfb8a18714b33b07529b7d02b54f1dR942
+sort_versions() {
+  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
+    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
+}


### PR DESCRIPTION
Instead of almost every asdf plugin [reinventing the wheel](https://github.com/search?q=org%3Aasdf-community+sort_versions&type=Code), the `sort_versions()` function should be made available through `utils.bash`.