### PR TITLE
Change exit code to 0 and output message to stdout

### DIFF
--- a/lib/commands/command-plugin-add.bash
+++ b/lib/commands/command-plugin-add.bash
@@ -27,8 +27,8 @@ plugin_add_command() {
   mkdir -p "$(asdf_data_dir)/plugins"
 
   if [ -d "$plugin_path" ]; then
-    display_error "Plugin named $plugin_name already added"
-    exit 2
+    echo "Plugin named $plugin_name already added"
+    exit 0
   else
     asdf_run_hook "pre_asdf_plugin_add" "$plugin_name"
     asdf_run_hook "pre_asdf_plugin_add_${plugin_name}"


### PR DESCRIPTION
# Summary

Changed exit code to 0 and message output to stdout when trying to add an already added plugin

Fixes: #659 
