### PR TITLE
Force users to use one of our predefined issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+# Force users to use one of our predefined issue templates
+blank_issues_enabled: false


### PR DESCRIPTION
# Summary

Removing the option for users to not choose one of our predefined issue templates when they click "New Issue". This is needed now that we have multiple issue templates (#694).
