### PR TITLE
Add each subcommand

### DIFF
--- a/bin/asdf
+++ b/bin/asdf
@@ -28,7 +28,7 @@ find_asdf_cmd() {
   case "$1" in
     'exec' | 'current' | 'env' | 'global' | 'install' | 'latest' | 'local' | \
       'reshim' | 'uninstall' | 'update' | 'where' | 'which' | \
-      'export-shell-version')
+      'export-shell-version' | 'each')
       echo "$asdf_cmd_dir/command-$1.bash" 2
       ;;
 

--- a/lib/commands/command-each.bash
+++ b/lib/commands/command-each.bash
@@ -1,0 +1,38 @@
+each_command() {
+  local plugin_name=$1
+  shift
+
+  if [ -z "$plugin_name" ]; then
+    display_error "You must specify a name"
+    exit 1
+  else
+    check_if_plugin_exists "$plugin_name"
+    execute_command_for_each_installed_version "$plugin_name" "$@"
+  fi
+}
+
+execute_command_for_each_installed_version() {
+  local plgugin_name=$1
+  shift
+
+  local versions=$(list_installed_versions "$plugin_name")
+
+  if [ -n "${versions}" ]; then
+    local version_envvar_name=$(version_envvar_name "$plugin_name")
+
+    for version in $versions; do
+      echo "## $plugin_name $version ##"
+      env $version_envvar_name="$version" "$@"
+    done
+  else
+    display_error 'No versions installed'
+  fi
+}
+
+version_envvar_name() {
+  local plugin_name=$1
+  local upcase_name=$(echo "${plugin_name}" | tr '[:lower:]-' '[:upper:]_')
+  echo "ASDF_${upcase_name}_VERSION"
+}
+
+each_command "$@"

--- a/lib/commands/command-each.bash
+++ b/lib/commands/command-each.bash
@@ -12,17 +12,19 @@ each_command() {
 }
 
 execute_command_for_each_installed_version() {
-  local plgugin_name=$1
+  local plugin_name=$1
   shift
 
-  local versions=$(list_installed_versions "$plugin_name")
+  local versions
+  versions=$(list_installed_versions "$plugin_name")
 
   if [ -n "${versions}" ]; then
-    local version_envvar_name=$(version_envvar_name "$plugin_name")
+    local version_envvar_name
+    version_envvar_name=$(version_envvar_name "$plugin_name")
 
     for version in $versions; do
       echo "## $plugin_name $version ##"
-      env $version_envvar_name="$version" "$@"
+      env "$version_envvar_name"="$version" "$@"
     done
   else
     display_error 'No versions installed'
@@ -31,7 +33,8 @@ execute_command_for_each_installed_version() {
 
 version_envvar_name() {
   local plugin_name=$1
-  local upcase_name=$(echo "${plugin_name}" | tr '[:lower:]-' '[:upper:]_')
+  local upcase_name
+  upcase_name=$(echo "${plugin_name}" | tr '[:lower:]-' '[:upper:]_')
   echo "ASDF_${upcase_name}_VERSION"
 }
 

--- a/test/each_command.bats
+++ b/test/each_command.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+load test_helpers
+
+setup() {
+  setup_asdf_dir
+  install_dummy_plugin
+}
+
+teardown() {
+  clean_asdf_dir
+}
+
+@test "each_command should execute given command with all installed versions" {
+  run asdf install dummy 1.0
+  run asdf install dummy 1.1
+  run asdf each dummy sh -c 'echo $ASDF_DUMMY_VERSION'
+  [ "$(echo -e "## dummy 1.0 ##\n1.0\n## dummy 1.1 ##\n1.1\n")" == "$output" ]
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
# Summary

This PR adds `each` subcommand to asdf which will run given command (after the plugin name) for all installed versions of the tool/language.

## Example usage

To run `gem update` for all installed rubies:

```
$ asdf each ruby gem update
## ruby 2.6.5 ##
Updating installed gems
:
## ruby 2.7.1 ##
Updating installed gems
:
```
