### PR TITLE
fix: remove sort --version-sort from command-latest as list is already sorted

### DIFF
--- a/lib/commands/command-latest.bash
+++ b/lib/commands/command-latest.bash
@@ -12,7 +12,6 @@ latest_command() {
   asdf list-all "$plugin_name" "$query" |
     grep -vE "(^Available versions:|-src|-dev|-latest|-stm|[-\\.]rc|-alpha|-beta|[-\\.]pre|-next|(a|b|c)[0-9]+|snapshot|master)" |
     sed 's/^\s\+//' |
-    sort --version-sort |
     tail -1
 }
 


### PR DESCRIPTION
# Summary

`sort`'s `--version-sort` flag isn't available on all OSs as reported in the linked issue and the reason for a custom `sort_versions` function in `command-update.bash` https://github.com/asdf-vm/asdf/blob/8a5c70b2dd43f918c51548a52c150c3c9ff4a547/lib/commands/command-update.bash#L46

Since the `asdf list-all "$plugin_name"` part of the command returns a sorted list, we do not need to perform any sort here. We should be able to safely remove it.

Fixes: #698 

## Other Information

I originally replaced this sort with the aforementioned custom sort_versions function and it seems that it is not idempotent. Something of note since we recommend this function for plugin authors.