### PR TITLE
Add basic CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for all the code in this repo
+* @asdf-vm/core


### PR DESCRIPTION
# Summary

Add a basic CODEOWNERS file with a rule that specifies the core team as the owner of all the files in this repository.