### PR TITLE
Documentation: Fix Fish source syntax

### DIFF
--- a/docs/core-manage-asdf-vm.md
+++ b/docs/core-manage-asdf-vm.md
@@ -169,7 +169,7 @@ echo -e "\n. $(brew --prefix asdf)/etc/bash_completion.d/asdf.bash" >> ~/.bash_p
 Add the following to `~/.config/fish/config.fish`:
 
 ```shell
-source "(brew --prefix asdf)"/asdf.fish
+source (brew --prefix asdf)/asdf.fish
 ```
 
 ?> Completions are [handled by Homebrew for the Fish shell](https://docs.brew.sh/Shell-Completion#configuring-completions-in-fish). Friendly!


### PR DESCRIPTION
# Summary

The previous instructions did not work on modern Fish (3.1.0) and lead to the following error:

> source: Error encountered while sourcing file '(brew --prefix asdf)/asdf.fish':
> source: No such file or directory