### PR TITLE
fix: remove `column` command in favor of awk

### DIFF
--- a/lib/commands/command-plugin-list-all.bash
+++ b/lib/commands/command-plugin-list-all.bash
@@ -20,7 +20,7 @@ plugin_list_all_command() {
 
         printf "%s\\t%s\\n" "$index_plugin_name" "$installed_flag$source_url"
       done
-    ) | (column -t -s $'\t' 2>/dev/null || awk '{ printf("%-28s", $1); sub(/^[^*]/, " &", $2); $1=""; print $0 }')
+    ) | awk '{ printf("%-28s", $1); sub(/^[^*]/, " &", $2); $1=""; print $0 }'
   else
     printf "%s%s\\n" "error: index of plugins not found at " "$plugins_index_path"
   fi

--- a/lib/commands/command-plugin-list-all.bash
+++ b/lib/commands/command-plugin-list-all.bash
@@ -10,17 +10,23 @@ plugin_list_all_command() {
   plugins_local_path="$(get_plugin_path)"
 
   if ls "$plugins_index_path" &>/dev/null; then
-    (
+      list=""
+      width=0
       for index_plugin in "$plugins_index_path"/*; do
         index_plugin_name=$(basename "$index_plugin")
+        l=$(echo -n "$index_plugin_name" | wc -m)
+        width=$((l > width ? l : width))
+        list="$list $index_plugin_name"
+      done
+
+      for index_plugin_name in $list; do
         source_url=$(get_plugin_source_url "$index_plugin_name")
         installed_flag=" "
 
         [[ -d "${plugins_local_path}/${index_plugin_name}" ]] && installed_flag='*'
 
-        printf "%s\\t%s\\n" "$index_plugin_name" "$installed_flag$source_url"
+        printf "%-${width}s  %s\\n" "$index_plugin_name" "$installed_flag$source_url"
       done
-    ) | column -t -s $'\t'
   else
     printf "%s%s\\n" "error: index of plugins not found at " "$plugins_index_path"
   fi

--- a/lib/commands/command-plugin-list-all.bash
+++ b/lib/commands/command-plugin-list-all.bash
@@ -9,7 +9,7 @@ plugin_list_all_command() {
   local plugins_local_path
   plugins_local_path="$(get_plugin_path)"
 
-  if ls "$plugins_index_path" &> /dev/null; then
+  if ls "$plugins_index_path" &>/dev/null; then
     (
       for index_plugin in "$plugins_index_path"/*; do
         index_plugin_name=$(basename "$index_plugin")
@@ -20,7 +20,7 @@ plugin_list_all_command() {
 
         printf "%s\\t%s\\n" "$index_plugin_name" "$installed_flag$source_url"
       done
-    ) | (column -t -s $'\t' 2> /dev/null || awk '{ printf("%-28s", $1); sub(/^[^*]/, " &", $2); $1=""; print $0 }')
+    ) | (column -t -s $'\t' 2>/dev/null || awk '{ printf("%-28s", $1); sub(/^[^*]/, " &", $2); $1=""; print $0 }')
   else
     printf "%s%s\\n" "error: index of plugins not found at " "$plugins_index_path"
   fi

--- a/lib/commands/command-plugin-list-all.bash
+++ b/lib/commands/command-plugin-list-all.bash
@@ -9,24 +9,18 @@ plugin_list_all_command() {
   local plugins_local_path
   plugins_local_path="$(get_plugin_path)"
 
-  if ls "$plugins_index_path" &>/dev/null; then
-      list=""
-      width=0
+  if ls "$plugins_index_path" &> /dev/null; then
+    (
       for index_plugin in "$plugins_index_path"/*; do
         index_plugin_name=$(basename "$index_plugin")
-        l=$(echo -n "$index_plugin_name" | wc -m)
-        width=$((l > width ? l : width))
-        list="$list $index_plugin_name"
-      done
-
-      for index_plugin_name in $list; do
         source_url=$(get_plugin_source_url "$index_plugin_name")
         installed_flag=" "
 
         [[ -d "${plugins_local_path}/${index_plugin_name}" ]] && installed_flag='*'
 
-        printf "%-${width}s  %s\\n" "$index_plugin_name" "$installed_flag$source_url"
+        printf "%s\\t%s\\n" "$index_plugin_name" "$installed_flag$source_url"
       done
+    ) | (column -t -s $'\t' 2> /dev/null || awk '{ printf("%-28s", $1); sub(/^[^*]/, " &", $2); $1=""; print $0 }')
   else
     printf "%s%s\\n" "error: index of plugins not found at " "$plugins_index_path"
   fi

--- a/lib/commands/command-plugin-list.bash
+++ b/lib/commands/command-plugin-list.bash
@@ -23,27 +23,27 @@ plugin_list_command() {
     esac
   done
 
-  if ls "$plugins_path" &> /dev/null; then
+  if ls "$plugins_path" &>/dev/null; then
     (
       for plugin_path in "$plugins_path"/*; do
         plugin_name=$(basename "$plugin_path")
         printf "%s" "$plugin_name"
 
         if [ -n "$show_repo" ]; then
-          printf "\\t%s" "$(git --git-dir "$plugin_path/.git" remote get-url origin 2> /dev/null)"
+          printf "\\t%s" "$(git --git-dir "$plugin_path/.git" remote get-url origin 2>/dev/null)"
         fi
 
         if [ -n "$show_ref" ]; then
           local branch
           local gitref
-          branch=$(git --git-dir "$plugin_path/.git" rev-parse --abbrev-ref HEAD 2> /dev/null)
-          gitref=$(git --git-dir "$plugin_path/.git" rev-parse --short HEAD 2> /dev/null)
+          branch=$(git --git-dir "$plugin_path/.git" rev-parse --abbrev-ref HEAD 2>/dev/null)
+          gitref=$(git --git-dir "$plugin_path/.git" rev-parse --short HEAD 2>/dev/null)
           printf "\\t%s\\t%s" "$branch" "$gitref"
         fi
 
         printf "\\n"
       done
-    ) | (column -t -s $'\t' 2> /dev/null || awk '{ if (NF > 1) { printf("%-28s", $1) ; $1="" }; print $0}')
+    ) | (column -t -s $'\t' 2>/dev/null || awk '{ if (NF > 1) { printf("%-28s", $1) ; $1="" }; print $0}')
   else
     display_error 'Oohes nooes ~! No plugins installed'
     exit 1

--- a/lib/commands/command-plugin-list.bash
+++ b/lib/commands/command-plugin-list.bash
@@ -43,7 +43,7 @@ plugin_list_command() {
 
         printf "\\n"
       done
-    ) | (column -t -s $'\t' 2>/dev/null || awk '{ if (NF > 1) { printf("%-28s", $1) ; $1="" }; print $0}')
+    ) | awk '{ if (NF > 1) { printf("%-28s", $1) ; $1="" }; print $0}'
   else
     display_error 'Oohes nooes ~! No plugins installed'
     exit 1

--- a/lib/commands/command-plugin-list.bash
+++ b/lib/commands/command-plugin-list.bash
@@ -43,7 +43,7 @@ plugin_list_command() {
 
         printf "\\n"
       done
-    ) | column -t -s $'\t'
+    ) | (column -t -s $'\t' 2>/dev/null || tee)
   else
     display_error 'Oohes nooes ~! No plugins installed'
     exit 1

--- a/lib/commands/command-plugin-list.bash
+++ b/lib/commands/command-plugin-list.bash
@@ -23,27 +23,27 @@ plugin_list_command() {
     esac
   done
 
-  if ls "$plugins_path" &>/dev/null; then
+  if ls "$plugins_path" &> /dev/null; then
     (
       for plugin_path in "$plugins_path"/*; do
         plugin_name=$(basename "$plugin_path")
         printf "%s" "$plugin_name"
 
         if [ -n "$show_repo" ]; then
-          printf "\\t%s" "$(git --git-dir "$plugin_path/.git" remote get-url origin 2>/dev/null)"
+          printf "\\t%s" "$(git --git-dir "$plugin_path/.git" remote get-url origin 2> /dev/null)"
         fi
 
         if [ -n "$show_ref" ]; then
           local branch
           local gitref
-          branch=$(git --git-dir "$plugin_path/.git" rev-parse --abbrev-ref HEAD 2>/dev/null)
-          gitref=$(git --git-dir "$plugin_path/.git" rev-parse --short HEAD 2>/dev/null)
+          branch=$(git --git-dir "$plugin_path/.git" rev-parse --abbrev-ref HEAD 2> /dev/null)
+          gitref=$(git --git-dir "$plugin_path/.git" rev-parse --short HEAD 2> /dev/null)
           printf "\\t%s\\t%s" "$branch" "$gitref"
         fi
 
         printf "\\n"
       done
-    ) | (column -t -s $'\t' 2>/dev/null || tee)
+    ) | (column -t -s $'\t' 2> /dev/null || awk '{ if (NF > 1) { printf("%-28s", $1) ; $1="" }; print $0}')
   else
     display_error 'Oohes nooes ~! No plugins installed'
     exit 1

--- a/test/plugin_list_all_command.bats
+++ b/test/plugin_list_all_command.bats
@@ -15,9 +15,9 @@ teardown() {
 @test "plugin_list_all list all plugins in the repository" {
   run asdf plugin-list-all
   local expected="\
-bar     http://example.com/bar
-dummy  *http://example.com/dummy
-foo     http://example.com/foo"
+bar                           http://example.com/bar
+dummy                        *http://example.com/dummy
+foo                           http://example.com/foo"
   [ "$status" -eq 0 ]
   [ "$output" = "$expected" ]
 }


### PR DESCRIPTION
- asdf plugin list
- asdf plugin list all

Avoid hard dependency on `column` command. This command
is not included in a fresh ubuntu container and not
defined in posix:

https://pubs.opengroup.org/onlinepubs/9699919799/idx/utilities.html

Also makes the output of `asdf plugin list all` line-streamed
on the second column value