### PR TITLE
Ensure consistency in indentation for message shown when no versions …

### DIFF
--- a/lib/commands/command-list.bash
+++ b/lib/commands/command-list.bash
@@ -31,7 +31,7 @@ display_installed_versions() {
       echo "  $version"
     done
   else
-    display_error 'No versions installed'
+    display_error '  No versions installed'
   fi
 }
 

--- a/test/list_command.bats
+++ b/test/list_command.bats
@@ -26,7 +26,7 @@ teardown() {
   run asdf install dummy 1.0
   run asdf install tummy 2.0
   run asdf list
-  [ "$(echo -e "dummy\n  1.0\nmummy\nNo versions installed\ntummy\n  2.0")" == "$output" ]
+  [ "$(echo -e "dummy\n  1.0\nmummy\n  No versions installed\ntummy\n  2.0")" == "$output" ]
   [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
…installed

# Summary

This is just a refinement of the fix that was peformed for https://github.com/asdf-vm/asdf/issues/330 .

When there are no versions installed for a package, the "No versions installed" message has no visual distinction from the package-name (just like the issue with version numbers before).

This PR just adds the same 2 spaces indentation for the info-string as well.

