### PR TITLE
Fix dead link by changing the extension to sh

### DIFF
--- a/docs/plugins-create.md
+++ b/docs/plugins-create.md
@@ -53,7 +53,7 @@ This script should install the version, in the path mentioned in `ASDF_INSTALL_P
 
 The install script should exit with a status of `0` when the installation is successful. If the installation fails the script should exit with any non-zero exit status.
 
-If possible the script should only place files in the `ASDF_INSTALL_PATH` directory once the build and installation of the tool is deemed successful by the install script. asdf [checks for the existence](https://github.com/asdf-vm/asdf/blob/242d132afbf710fe3c7ec23c68cec7bdd2c78ab5/lib/utils.bash#L44) of the `ASDF_INSTALL_PATH` directory in order to determine if that version of the tool is installed. If the `ASDF_INSTALL_PATH` directory is populated at the beginning of the installation process other asdf commands run in other terminals during the installation may consider that version of the tool installed, even when it is not fully installed.
+If possible the script should only place files in the `ASDF_INSTALL_PATH` directory once the build and installation of the tool is deemed successful by the install script. asdf [checks for the existence](https://github.com/asdf-vm/asdf/blob/242d132afbf710fe3c7ec23c68cec7bdd2c78ab5/lib/utils.sh#L44) of the `ASDF_INSTALL_PATH` directory in order to determine if that version of the tool is installed. If the `ASDF_INSTALL_PATH` directory is populated at the beginning of the installation process other asdf commands run in other terminals during the installation may consider that version of the tool installed, even when it is not fully installed.
 
 ## Optional Scripts
 


### PR DESCRIPTION
# Summary

Hi, I tried creating a plugin for asdf-vm. I found a dead link in the documentation and fixed it.

The reason is that [the commit changed the file extension](https://github.com/asdf-vm/asdf/commit/52cbf1165c79c7efbb1c9b2f26167a047a7335d0).

I also think there is a way to change the link to the master branch.However, that selection line number is unstable. e.g) https://github.com/asdf-vm/asdf/blob/master/lib/utils.bash#L98

This P-R keeps a commit hash to stabilize the line number. What do you think?

My plugin was easy to create. Thanks to the maintainers of the documentation.