### PR TITLE
feat: install script for logging on installation

### DIFF
--- a/docs/core-manage-asdf-vm.md
+++ b/docs/core-manage-asdf-vm.md
@@ -5,7 +5,7 @@
 
 ### --Git--
 
-Run the install script to `git clone` the latest branch:
+Run the install script to `git clone` the latest release:
 
 ```shell
 curl -o- https://raw.githubusercontent.com/asdf-vm/asdf/v0.7.8/install.bash | bash

--- a/docs/core-manage-asdf-vm.md
+++ b/docs/core-manage-asdf-vm.md
@@ -5,18 +5,12 @@
 
 ### --Git--
 
-Clone only the latest branch:
+Run the install script to `git clone` the latest branch:
 
 ```shell
-git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.7.8
-```
-
-Alternately, you can clone the whole repo and checkout the latest branch:
-
-```shell
-git clone https://github.com/asdf-vm/asdf.git ~/.asdf
-cd ~/.asdf
-git checkout "$(git describe --abbrev=0 --tags)"
+curl -o- https://raw.githubusercontent.com/asdf-vm/asdf/v0.7.8/install.bash | bash
+# or
+wget -qO- https://raw.githubusercontent.com/asdf-vm/asdf/v0.7.8/install.bash | bash
 ```
 
 ### --Homebrew--

--- a/install.bash
+++ b/install.bash
@@ -6,14 +6,15 @@ set -euo pipefail
 #ORIGINAL_IFS=$IFS
 IFS=$'\t\n' # Stricter IFS settings
 
-asdf_install_dir=${ASDF_INSTALL_DIR:-"~/.asdf"}
+asdf_install_dir=${ASDF_INSTALL_DIR:-"$HOME/.asdf"}
 
 git clone https://github.com/asdf-vm/asdf.git "${asdf_install_dir}"
-# checkout latest tag
-git --git-dir "${asdf_install_dir}" checkout "$(git --git-dir "${asdf_install_dir}" describe --abbrev=0 --tags)"
+# checkout latest tag in repo in another dir
+# credit: https://stackoverflow.com/a/6073628/7911479 and https://stackoverflow.com/a/31811385/7911479
+git --git-dir "${asdf_install_dir}/.git" --work-tree "${asdf_install_dir}" checkout "$(git describe --abbrev=0 --tags)" --quiet
 
-printf "asdf setup"
-printf "1: install asdf - completed!"
-printf "2: add asdf to your shell - https://asdf-vm.com/#/core-manage-asdf-vm"
-printf "3: add a plugin - https://asdf-vm.com/#/core-manage-plugins"
-printf "4: install a tool version - https://asdf-vm.com/#/core-manage-versions"
+printf "\n%s\n" "asdf setup"
+printf "%s\t\t\t%s\n" "1: install asdf" "completed!"
+printf "%s\t%s\n" "2: add asdf to your shell" "https://asdf-vm.com/#/core-manage-asdf-vm"
+printf "%s\t\t\t%s\n" "3: add a plugin" "https://asdf-vm.com/#/core-manage-plugins"
+printf "%s\t%s\n" "4: install a tool version" "https://asdf-vm.com/#/core-manage-versions"

--- a/install.bash
+++ b/install.bash
@@ -8,7 +8,6 @@ IFS=$'\t\n' # Stricter IFS settings
 
 asdf_install_dir=${ASDF_INSTALL_DIR:-"~/.asdf"}
 
-mkdir -p "${asdf_install_dir}"
 git clone https://github.com/asdf-vm/asdf.git "${asdf_install_dir}"
 # checkout latest tag
 git --git-dir "${asdf_install_dir}" checkout "$(git --git-dir "${asdf_install_dir}" describe --abbrev=0 --tags)"

--- a/install.bash
+++ b/install.bash
@@ -12,4 +12,8 @@ git clone https://github.com/asdf-vm/asdf.git "${asdf_install_dir}"
 # checkout latest tag
 git --git-dir "${asdf_install_dir}" checkout "$(git --git-dir "${asdf_install_dir}" describe --abbrev=0 --tags)"
 
-printf "[WARNING] asdf requires further configuration. See the documentation at https://asdf-vm.com/#/core-manage-asdf-vm"
+printf "asdf setup"
+printf "1: install asdf - completed!"
+printf "2: add asdf to your shell - https://asdf-vm.com/#/core-manage-asdf-vm"
+printf "3: add a plugin - https://asdf-vm.com/#/core-manage-plugins"
+printf "4: install a tool version - https://asdf-vm.com/#/core-manage-versions"

--- a/install.bash
+++ b/install.bash
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Unoffical Bash "strict mode"
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/
+set -euo pipefail
+#ORIGINAL_IFS=$IFS
+IFS=$'\t\n' # Stricter IFS settings
+
+asdf_install_dir=${ASDF_INSTALL_DIR:-"~/.asdf"}
+
+mkdir -p "${asdf_install_dir}"
+git clone https://github.com/asdf-vm/asdf.git "${asdf_install_dir}"
+# checkout latest tag
+git --git-dir "${asdf_install_dir}" checkout "$(git --git-dir "${asdf_install_dir}" describe --abbrev=0 --tags)"
+
+printf "[WARNING] asdf requires further configuration. See the documentation at https://asdf-vm.com/#/core-manage-asdf-vm"

--- a/release/tag.sh
+++ b/release/tag.sh
@@ -109,12 +109,12 @@ if ! git diff-index --cached --exit-code -r --ignore-submodules HEAD -- >&2; the
   exit 1
 fi
 
-# Update version in README
-sed -i.bak "s|^\\(git clone.*--branch \\).*$|\\1$new_tag_name|" README.md
-rm README.md.bak
+# Update version in install.bash
+sed -i.bak "s|^\\(git clone.*--branch \\).*$|\\1$new_tag_name|" install.bash
+rm install.bash.bak
 
 # Update version in docs/core-manage-asdf-vm.md
-sed -i.bak "s|^\\(git clone.*--branch \\).*$|\\1$new_tag_name|" docs/core-manage-asdf-vm.md
+sed -i.bak "s~\\(https://raw.githubusercontent.com/asdf-vm/asdf/\\).*/install.bash | bash~\\1${VERSION}/install.bash | bash~" docs/core-manage-asdf-vm.md
 rm docs/core-manage-asdf-vm.md.bak
 
 # Update version in the VERSION file


### PR DESCRIPTION
# Summary

Use an install script to perform the `git clone` installation process. This allows us to log on installation which is required for the Homebrew installation as outlined in #738 (Homebrew users expect `brew install asdf` to perform the complete setup of asdf and subsequently report a GitHub issue before going to the docs site to see further instructions)

Fixes: #738 

## Other Information

- [x] update tag regex (probably can be improved as I'm no `sed` expert)
- [x] we no longer have instructions in README so deprecate that tag update
- [x] change instructions to `curl`/`wget` the install script from the GitHub remote
- [x] use `--git-dir` and `--work-tree` to avoid filesystem traversal as `git` provides this functionality

## Notes

- the `git checkout` uses `--quiet` flag to supress "detached head" warning on tag checkout. Perhaps we let it log this?
- potentially could reuse `ASDF_DATA_DIR` instead of introducing another env var

---

Testing output:

with `--quiet`:

```shell
asdf on  feat/install-script [!] 
➜ ./install.bash        
Cloning into '/home/jthegedus/projects/test'...
remote: Enumerating objects: 31, done.
remote: Counting objects: 100% (31/31), done.
remote: Compressing objects: 100% (26/26), done.
remote: Total 5350 (delta 12), reused 13 (delta 5), pack-reused 5319
Receiving objects: 100% (5350/5350), 1007.11 KiB | 808.00 KiB/s, done.
Resolving deltas: 100% (3010/3010), done.

asdf setup
1: install asdf                 completed!
2: add asdf to your shell       https://asdf-vm.com/#/core-manage-asdf-vm
3: add a plugin                 https://asdf-vm.com/#/core-manage-plugins
4: install a tool version       https://asdf-vm.com/#/core-manage-versions
```

without `--quiet`:

```sell
asdf on  feat/install-script [!] 
➜ ./install.bash        
Cloning into '/home/jthegedus/projects/test'...
remote: Enumerating objects: 31, done.
remote: Counting objects: 100% (31/31), done.
remote: Compressing objects: 100% (26/26), done.
remote: Total 5350 (delta 12), reused 13 (delta 5), pack-reused 5319
Receiving objects: 100% (5350/5350), 1007.11 KiB | 808.00 KiB/s, done.
Resolving deltas: 100% (3010/3010), done.
Note: switching to 'v0.7.8'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 4a3e3d6 Update version to 0.7.8

asdf setup
1: install asdf                 completed!
2: add asdf to your shell       https://asdf-vm.com/#/core-manage-asdf-vm
3: add a plugin                 https://asdf-vm.com/#/core-manage-plugins
4: install a tool version       https://asdf-vm.com/#/core-manage-versions
```