### PR TITLE
docs: synchronize help text

### DIFF
--- a/docs/core-commands.md
+++ b/docs/core-commands.md
@@ -1,6 +1,8 @@
 <!-- 
     single source of truth.
-    import commands list from master branch or repo.
+    import commands list from master branch of repo.
     not amenable to docs for git ref. Solution to be determined.
  -->
+`asdf` or `asdf help` will list all available commands for your current asdf version.
+
 [](https://raw.githubusercontent.com/asdf-vm/asdf/master/help.txt ':include')

--- a/docs/core-commands.md
+++ b/docs/core-commands.md
@@ -1,42 +1,6 @@
-## Manage Plugins
-
-| Command                                  | Effect                                                       |
-| -----------------------------------------| ------------------------------------------------------------ |
-| `asdf plugin add <name> [<git-url>]`     | Add a plugin from the plugin repo OR, add a Git repo         |
-|                                          | ...as a plugin by specifying the name and repo url           |
-| `asdf plugin list`                       | List installed plugins                                       |
-| `asdf plugin list [--urls] [--refs]`     | List installed plugins. Optionally show git urls and git-ref |
-| `asdf plugin list all`                   | List plugins registered on asdf-plugins repository with URLs |
-| `asdf plugin remove <name>`              | Remove plugin and package versions                           |
-| `asdf plugin update <name> [<git-ref>]`  | Update plugin to latest commit or a particular git ref.      |
-| `asdf plugin update --all`               | Update all plugins                                           |
-
-## Manage Packages
-
-| Command                                  | Effect                                                                     |
-| ---------------------------------------- | -------------------------------------------------------------------------- |
-| `asdf install [<name> <version>]`        | Install a specific version of a package, or with no arguments,             |
-|                                          | ...install all the package versions listed in the .tool-versions file      |
-| `asdf install <name> latest[:<version>]` | Install the latest stable version of a package, or with optional version,  |
-|                                          | ...install the latest stable version that begins with the given string     |
-| `asdf uninstall <name> <version>`        | Remove a specific version of a package                                     |
-| `asdf current`                           | Display current version set or being used for all packages                 |
-| `asdf current <name>`                    | Display current version set or being used for package                      |
-| `asdf where <name> [<version>]`          | Display install path for an installed or current version                   |
-| `asdf which <name>`                      | Display install path for current version                                   |
-| `asdf local <name> <version>`            | Set the package local version                                              |
-| `asdf global <name> <version>`           | Set the package global version                                             |
-| `asdf latest <name> [<version>]`         | Show latest stable version of a package                                    |
-| `asdf list <name>`                       | List installed versions of a package                                       |
-| `asdf list all <name> [<version>]`       | List all versions of a package and optionally filter the returned versions |
-
-## Utils
-
-| Command                        | Effect                                                |
-| ------------------------------ | ----------------------------------------------------- |
-| `asdf exec <command> [args]`   | Runs the currently selected version of command        |
-| `asdf env <command> [util]`    | Executes util inside the environment used for command |
-| `asdf reshim <name> <version>` | Recreate shims for version of a package               |
-| `asdf shim-versions <command>` | List the plugins and versions that provide a command  |
-| `asdf update`                  | Update asdf to the latest stable release              |
-| `asdf update --head`           | Update asdf to the latest on the master branch        |
+<!-- 
+    single source of truth.
+    import commands list from master branch or repo.
+    not amenable to docs for git ref. Solution to be determined.
+ -->
+[](https://raw.githubusercontent.com/asdf-vm/asdf/master/help.txt ':include')

--- a/docs/core-manage-asdf-vm.md
+++ b/docs/core-manage-asdf-vm.md
@@ -1,4 +1,58 @@
-## Install asdf-vm
+1. [Manage asdf-vm](/core-manage-asdf-vm): install `asdf` **and** add `asdf` to your shell
+2. [Manage Plugins](/core-manage-plugins): add a plugin for your tool `asdf plugin add nodejs`
+3. [Manage Versions](/core-manage-versions): install a version of that tool `asdf install nodejs 13.14.0`
+4. [Configuration](/core-configuration): set global and project tool versions via `.tool-versions` config
+
+## Install
+
+### Dependencies
+
+<!-- select:start -->
+<!-- select-menu-labels: Operating System,Installation Method -->
+
+#### -- Linux,Aptitude --
+
+```shell
+sudo apt install curl git
+```
+
+#### -- Linux,DNF --
+
+```shell
+sudo dnf install curl git
+```
+
+#### -- Linux,Pacman --
+
+```shell
+sudo pacman -S curl git
+```
+
+#### -- Linux,Zypper --
+
+```shell
+sudo zypper install curl git
+```
+
+#### -- macOS,Homebrew --
+
+```shell
+brew install coreutils curl git
+```
+
+#### -- macOS,Spack --
+
+```shell
+spack install coreutils curl git
+```
+
+### -- Docsify Select Default --
+
+No match for _Operating System_ and _Installation Method_ selections. Please try another combination.
+
+<!-- select:end -->
+
+### asdf
 
 <!-- select:start -->
 <!-- select-menu-labels: Installation Method -->
@@ -199,52 +253,6 @@ You are ready to use asdf 🎉
 
 If you're having issues with your shell not detecting newly installed shims, it's most-likely due to the sourcing of `asdf.sh` or `asdf.fish` not being at the **BOTTOM** of your `.bash_profile`, `.zshrc`, `config.fish` config file. It needs to be sourced **AFTER** you have set your `$PATH` and **AFTER** you have sourced your framework (oh-my-zsh etc).
 
-### Dependencies
-
-<!-- select:start -->
-<!-- select-menu-labels: Operating System,Installation Method -->
-
-#### -- Linux,Aptitude --
-
-```shell
-sudo apt install curl git
-```
-
-#### -- Linux,DNF --
-
-```shell
-sudo dnf install curl git
-```
-
-#### -- Linux,Pacman --
-
-```shell
-sudo pacman -S curl git
-```
-
-#### -- Linux,Zypper --
-
-```shell
-sudo zypper install curl git
-```
-
-#### -- macOS,Homebrew --
-
-```shell
-brew install coreutils curl git
-```
-
-#### -- macOS,Spack --
-
-```shell
-spack install coreutils curl git
-```
-
-### -- Docsify Select Default --
-
-No match for _Operating System_ and _Installation Method_ selections. Please try another combination.
-
-<!-- select:end -->
 
 ### Migrating Tools
 

--- a/help.txt
+++ b/help.txt
@@ -20,6 +20,7 @@ MANAGE PACKAGES
   asdf shell <name> <version>              Set the package version in the current shell
   asdf local <name> <version>              Set the package local version
   asdf global <name> <version>             Set the package global version
+  asdf latest <name> [<version>]           Show latest stable version of a package
   asdf list <name>                         List installed versions of a package
   asdf list all <name>                     List all versions of a package
 

--- a/help.txt
+++ b/help.txt
@@ -32,8 +32,7 @@ asdf which <command>                    Display the path to an executable
 asdf local <name> <version>             Set the package local version
 asdf global <name> <version>            Set the package global version
 asdf shell <name> <version>             Set the package version to
-                                        `ASDF_${LANG}_VERSION` in the current
-                                        shell
+                                        `ASDF_${LANG}_VERSION` in the current shell
 asdf latest <name> [<version>]          Show latest stable version of a package
 asdf list <name>                        List installed versions of a package
 asdf list all <name> [<version>]        List all versions of a package and
@@ -41,15 +40,11 @@ asdf list all <name> [<version>]        List all versions of a package and
 
 
 UTILS
-asdf exec <command> [args...]           Executes the command shim for current
-                                        version
+asdf exec <command> [args...]           Executes the command shim for current version
 asdf env <command> [util]               Runs util (default: `env`) inside the
-                                        environment used for command shim
-                                        execution.
+                                        environment used for command shim execution.
 asdf reshim <name> <version>            Recreate shims for version of a package
 asdf shim-versions <command>            List the plugins and versions that
                                         provide a command
-asdf update                             Update asdf to the latest stable
-                                        release
-asdf update --head                      Update asdf to the latest on the master
-                                        branch
+asdf update                             Update asdf to the latest stable release
+asdf update --head                      Update asdf to the latest on the master branch

--- a/help.txt
+++ b/help.txt
@@ -17,7 +17,7 @@ asdf where <name> [<version>]           Display install path for an installed or
 asdf which <command>                    Display the path to an executable
 asdf local <name> <version>             Set the package local version
 asdf global <name> <version>            Set the package global version
-asdf shell <name> <version>             Set the package version in the current shell
+asdf shell <name> <version>             Set the package version to `ASDF_${LANG}_VERSION` in the current shell
 asdf latest <name> [<version>]          Show latest stable version of a package
 asdf list <name>                        List installed versions of a package
 asdf list all <name> [<version>]        List all versions of a package and optionally filter the returned versions

--- a/help.txt
+++ b/help.txt
@@ -1,32 +1,55 @@
 MANAGE PLUGINS
-asdf plugin add <name> [<git-url>]      Add a plugin from the plugin repo OR, add a Git repo as a plugin by specifying the name and repo url
-asdf plugin list [--urls] [--refs]      List installed plugins. Optionally show git urls and git-ref
-asdf plugin list all                    List plugins registered on asdf-plugins repository with URLs
+asdf plugin add <name> [<git-url>]      Add a plugin from the plugin repo OR,
+                                        add a Git repo as a plugin by
+                                        specifying the name and repo url
+asdf plugin list [--urls] [--refs]      List installed plugins. Optionally show
+                                        git urls and git-ref
+asdf plugin list all                    List plugins registered on asdf-plugins
+                                        repository with URLs
 asdf plugin remove <name>               Remove plugin and package versions
-asdf plugin update <name> [<git-ref>]   Update a plugin to latest commit or a particular git-ref
+asdf plugin update <name> [<git-ref>]   Update a plugin to latest commit or a
+                                        particular git-ref
 asdf plugin update --all                Update all plugins
 
 
 MANAGE PACKAGES
-asdf install [<name> <version>]         Install a specific version of a package or, with no arguments, install all the package versions listed in the .tool-versions file
-asdf install <name> latest[:<version>]  Install the latest stable version of a package, or with optional version, install the latest stable version that begins with the given string
+asdf install [<name> <version>]         Install a specific version of a package
+                                        or, with no arguments, install all the
+                                        package versions listed in the
+                                        .tool-versions file
+asdf install <name> latest[:<version>]  Install the latest stable version of a
+                                        package, or with optional version,
+                                        install the latest stable version that
+                                        begins with the given string
 asdf uninstall <name> <version>         Remove a specific version of a package
-asdf current                            Display current version set or being used for all packages
-asdf current <name>                     Display current version set or being used for package
-asdf where <name> [<version>]           Display install path for an installed or current version
+asdf current                            Display current version set or being
+                                        used for all packages
+asdf current <name>                     Display current version set or being
+                                        used for package
+asdf where <name> [<version>]           Display install path for an installed
+                                        or current version
 asdf which <command>                    Display the path to an executable
 asdf local <name> <version>             Set the package local version
 asdf global <name> <version>            Set the package global version
-asdf shell <name> <version>             Set the package version to `ASDF_${LANG}_VERSION` in the current shell
+asdf shell <name> <version>             Set the package version to
+                                        `ASDF_${LANG}_VERSION` in the current
+                                        shell
 asdf latest <name> [<version>]          Show latest stable version of a package
 asdf list <name>                        List installed versions of a package
-asdf list all <name> [<version>]        List all versions of a package and optionally filter the returned versions
+asdf list all <name> [<version>]        List all versions of a package and
+                                        optionally filter the returned versions
 
 
 UTILS
-asdf exec <command> [args...]           Executes the command shim for current version
-asdf env <command> [util]               Runs util (default: `env`) inside the environment used for command shim execution.
+asdf exec <command> [args...]           Executes the command shim for current
+                                        version
+asdf env <command> [util]               Runs util (default: `env`) inside the
+                                        environment used for command shim
+                                        execution.
 asdf reshim <name> <version>            Recreate shims for version of a package
-asdf shim-versions <command>            List the plugins and versions that provide a command
-asdf update                             Update asdf to the latest stable release
-asdf update --head                      Update asdf to the latest on the master branch
+asdf shim-versions <command>            List the plugins and versions that
+                                        provide a command
+asdf update                             Update asdf to the latest stable
+                                        release
+asdf update --head                      Update asdf to the latest on the master
+                                        branch

--- a/help.txt
+++ b/help.txt
@@ -1,10 +1,10 @@
 MANAGE PLUGINS
   asdf plugin add <name> [<git-url>]       Add a plugin from the plugin repo OR, add a Git repo
                                            as a plugin by specifying the name and repo url
-  asdf plugin list [--urls] [--refs]       List installed plugins. Optionally show git urls and git-ref.
+  asdf plugin list [--urls] [--refs]       List installed plugins. Optionally show git urls and git-ref
   asdf plugin list all                     List plugins registered on asdf-plugins repository with URLs
   asdf plugin remove <name>                Remove plugin and package versions
-  asdf plugin update <name> [<git-ref>]    Update a plugin to latest commit or a particular git-ref.
+  asdf plugin update <name> [<git-ref>]    Update a plugin to latest commit or a particular git-ref
   asdf plugin update --all                 Update all plugins
 
 
@@ -12,23 +12,27 @@ MANAGE PACKAGES
   asdf install [<name> <version>]          Install a specific version of a package or,
                                            with no arguments, install all the package
                                            versions listed in the .tool-versions file
+  asdf install <name> latest[:<version>]   Install the latest stable version of a package,
+                                           or with optional version, install the latest stable
+                                           version that begins with the given string
   asdf uninstall <name> <version>          Remove a specific version of a package
   asdf current                             Display current version set or being used for all packages
   asdf current <name>                      Display current version set or being used for package
   asdf where <name> [<version>]            Display install path for an installed or current version
   asdf which <command>                     Display the path to an executable
-  asdf shell <name> <version>              Set the package version in the current shell
   asdf local <name> <version>              Set the package local version
   asdf global <name> <version>             Set the package global version
+  asdf shell <name> <version>              Set the package version in the current shell
   asdf latest <name> [<version>]           Show latest stable version of a package
   asdf list <name>                         List installed versions of a package
-  asdf list all <name>                     List all versions of a package
+  asdf list all <name> [<version>]         List all versions of a package and optionally
+                                           filter the returned versions
 
 
 UTILS
-  asdf exec <command> [args..]             Executes the command shim for current version
+  asdf exec <command> [args...]            Executes the command shim for current version
   asdf env <command> [util]                Runs util (default: `env`) inside the environment used for command shim execution.
   asdf reshim <name> <version>             Recreate shims for version of a package
-  asdf shim-versions <command>             List on which plugins and versions is command available
+  asdf shim-versions <command>             List the plugins and versions that provide a command
   asdf update                              Update asdf to the latest stable release
   asdf update --head                       Update asdf to the latest on the master branch

--- a/help.txt
+++ b/help.txt
@@ -1,38 +1,32 @@
 MANAGE PLUGINS
-  asdf plugin add <name> [<git-url>]       Add a plugin from the plugin repo OR, add a Git repo
-                                           as a plugin by specifying the name and repo url
-  asdf plugin list [--urls] [--refs]       List installed plugins. Optionally show git urls and git-ref
-  asdf plugin list all                     List plugins registered on asdf-plugins repository with URLs
-  asdf plugin remove <name>                Remove plugin and package versions
-  asdf plugin update <name> [<git-ref>]    Update a plugin to latest commit or a particular git-ref
-  asdf plugin update --all                 Update all plugins
+asdf plugin add <name> [<git-url>]      Add a plugin from the plugin repo OR, add a Git repo as a plugin by specifying the name and repo url
+asdf plugin list [--urls] [--refs]      List installed plugins. Optionally show git urls and git-ref
+asdf plugin list all                    List plugins registered on asdf-plugins repository with URLs
+asdf plugin remove <name>               Remove plugin and package versions
+asdf plugin update <name> [<git-ref>]   Update a plugin to latest commit or a particular git-ref
+asdf plugin update --all                Update all plugins
 
 
 MANAGE PACKAGES
-  asdf install [<name> <version>]          Install a specific version of a package or,
-                                           with no arguments, install all the package
-                                           versions listed in the .tool-versions file
-  asdf install <name> latest[:<version>]   Install the latest stable version of a package,
-                                           or with optional version, install the latest stable
-                                           version that begins with the given string
-  asdf uninstall <name> <version>          Remove a specific version of a package
-  asdf current                             Display current version set or being used for all packages
-  asdf current <name>                      Display current version set or being used for package
-  asdf where <name> [<version>]            Display install path for an installed or current version
-  asdf which <command>                     Display the path to an executable
-  asdf local <name> <version>              Set the package local version
-  asdf global <name> <version>             Set the package global version
-  asdf shell <name> <version>              Set the package version in the current shell
-  asdf latest <name> [<version>]           Show latest stable version of a package
-  asdf list <name>                         List installed versions of a package
-  asdf list all <name> [<version>]         List all versions of a package and optionally
-                                           filter the returned versions
+asdf install [<name> <version>]         Install a specific version of a package or, with no arguments, install all the package versions listed in the .tool-versions file
+asdf install <name> latest[:<version>]  Install the latest stable version of a package, or with optional version, install the latest stable version that begins with the given string
+asdf uninstall <name> <version>         Remove a specific version of a package
+asdf current                            Display current version set or being used for all packages
+asdf current <name>                     Display current version set or being used for package
+asdf where <name> [<version>]           Display install path for an installed or current version
+asdf which <command>                    Display the path to an executable
+asdf local <name> <version>             Set the package local version
+asdf global <name> <version>            Set the package global version
+asdf shell <name> <version>             Set the package version in the current shell
+asdf latest <name> [<version>]          Show latest stable version of a package
+asdf list <name>                        List installed versions of a package
+asdf list all <name> [<version>]        List all versions of a package and optionally filter the returned versions
 
 
 UTILS
-  asdf exec <command> [args...]            Executes the command shim for current version
-  asdf env <command> [util]                Runs util (default: `env`) inside the environment used for command shim execution.
-  asdf reshim <name> <version>             Recreate shims for version of a package
-  asdf shim-versions <command>             List the plugins and versions that provide a command
-  asdf update                              Update asdf to the latest stable release
-  asdf update --head                       Update asdf to the latest on the master branch
+asdf exec <command> [args...]           Executes the command shim for current version
+asdf env <command> [util]               Runs util (default: `env`) inside the environment used for command shim execution.
+asdf reshim <name> <version>            Recreate shims for version of a package
+asdf shim-versions <command>            List the plugins and versions that provide a command
+asdf update                             Update asdf to the latest stable release
+asdf update --head                      Update asdf to the latest on the master branch


### PR DESCRIPTION
# Summary

The help text and "All Commands" doc site page have been getting updates differently. They've fallen out of sync. While crude, I would like to solve the discrepancy by directly importing the `help.txt` file into the docs.

I don't imagine that page to be heavily visited, it was only included for completeness of the documentation site. This is a better in-between.  

## Other Information

I removed the 2 space indentation of the `help.txt` for all commands. This allows for more content to be horizontally filled.

I removed the inline word wrapping. I will follow this PR up with a change to render the help text via `awk` on `asdf`/`asdf help` and perform wrapping.