### PR TITLE
fix: print tool-versions file dir on shim error

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -444,12 +444,12 @@ resolve_symlink() {
   # If it is a slash we can assume it's root and absolute. Otherwise we treat it
   # as relative
   case $resolved_path in
-  /*)
-    echo "$resolved_path"
-    ;;
-  *)
-    echo "$PWD/$resolved_path"
-    ;;
+    /*)
+      echo "$resolved_path"
+      ;;
+    *)
+      echo "$PWD/$resolved_path"
+      ;;
   esac
 }
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -706,7 +706,7 @@ with_shim_executable() {
   local shim_exec="${2}"
 
   if [ ! -f "$(asdf_data_dir)/shims/${shim_name}" ]; then
-    echo "unknown command: ${shim_name}. Perhaps you have to reshim?" >&2
+    printf "%s %s %s\\n" "unknown command:" "$shim_name" ". Perhaps you have to reshim?" >&2
     return 1
   fi
 
@@ -746,6 +746,8 @@ with_shim_executable() {
   (
     local preset_plugin_versions
     preset_plugin_versions=()
+    local closest_tool_version
+    closest_tool_version=$(find_tool_versions)
 
     local shim_plugins
     IFS=$'\n' read -rd '' -a shim_plugins <<<"$(shim_plugins "$shim_name")"
@@ -761,19 +763,16 @@ with_shim_executable() {
     done
 
     if [ -n "${preset_plugin_versions[*]}" ]; then
-      echo "asdf: No preset version installed for command ${shim_name}"
-      echo "Please install the missing version by running one of the following:"
-      echo ""
+      printf "%s %s\\n" "No preset version installed for command" "$shim_name"
+      printf "%s\\n\\n" "Please install a version by running one of the following:"
       for preset_plugin_version in "${preset_plugin_versions[@]}"; do
-        echo "asdf install ${preset_plugin_version}"
+        printf "%s %s\\n" "asdf install" "$preset_plugin_version"
       done
-      echo ""
-      echo "or add one of the following in your .tool-versions file:"
+      printf "\\n%s %s\\n" "or add one of the following versions in your config file at" "$closest_tool_version"
     else
-      echo "asdf: No version set for command ${shim_name}"
-      echo "you might want to add one of the following in your .tool-versions file:"
+      printf "%s %s\\n" "No version set for command" "$shim_name"
+      printf "%s %s\\n" "Please add one of the following versions in your config file at" "$closest_tool_version"
     fi
-    echo ""
     shim_plugin_versions "${shim_name}"
   ) >&2
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -444,12 +444,12 @@ resolve_symlink() {
   # If it is a slash we can assume it's root and absolute. Otherwise we treat it
   # as relative
   case $resolved_path in
-    /*)
-      echo "$resolved_path"
-      ;;
-    *)
-      echo "$PWD/$resolved_path"
-      ;;
+  /*)
+    echo "$resolved_path"
+    ;;
+  *)
+    echo "$PWD/$resolved_path"
+    ;;
   esac
 }
 
@@ -706,7 +706,7 @@ with_shim_executable() {
   local shim_exec="${2}"
 
   if [ ! -f "$(asdf_data_dir)/shims/${shim_name}" ]; then
-    printf "%s %s %s\\n" "unknown command:" "$shim_name" ". Perhaps you have to reshim?" >&2
+    printf "%s %s %s\\n" "unknown command:" "${shim_name}." "Perhaps you have to reshim?" >&2
     return 1
   fi
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -444,12 +444,12 @@ resolve_symlink() {
   # If it is a slash we can assume it's root and absolute. Otherwise we treat it
   # as relative
   case $resolved_path in
-    /*)
-      echo "$resolved_path"
-      ;;
-    *)
-      echo "$PWD/$resolved_path"
-      ;;
+  /*)
+    echo "$resolved_path"
+    ;;
+  *)
+    echo "$PWD/$resolved_path"
+    ;;
   esac
 }
 
@@ -771,7 +771,7 @@ with_shim_executable() {
       printf "\\n%s %s\\n" "or add one of the following versions in your config file at" "$closest_tool_version"
     else
       printf "%s %s\\n" "No version set for command" "$shim_name"
-      printf "%s %s\\n" "Please add one of the following versions in your config file at" "$closest_tool_version"
+      printf "%s %s\\n" "Consider adding one of the following versions in your config file at" "$closest_tool_version"
     fi
     shim_plugin_versions "${shim_name}"
   ) >&2

--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -90,7 +90,7 @@ teardown() {
   [ "$status" -eq 126 ]
 
   echo "$output" | grep -q "No version set for command dummy" 2>/dev/null
-  echo "$output" | grep -q "Please add one of the following versions in your config file at $PROJECT_DIR/.tool-versions" 2>/dev/null
+  echo "$output" | grep -q "Consider adding one of the following versions in your config file at $PROJECT_DIR/.tool-versions" 2>/dev/null
   echo "$output" | grep -q "dummy 1.0" 2>/dev/null
   echo "$output" | grep -q "dummy 2.0" 2>/dev/null
 }
@@ -108,7 +108,7 @@ teardown() {
   [ "$status" -eq 126 ]
 
   echo "$output" | grep -q "No version set for command dummy" 2>/dev/null
-  echo "$output" | grep -q "Please add one of the following versions in your config file at $PROJECT_DIR/.tool-versions" 2>/dev/null
+  echo "$output" | grep -q "Consider adding one of the following versions in your config file at $PROJECT_DIR/.tool-versions" 2>/dev/null
   echo "$output" | grep -q "dummy 1.0" 2>/dev/null
   echo "$output" | grep -q "mummy 3.0" 2>/dev/null
 }

--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -90,7 +90,7 @@ teardown() {
   [ "$status" -eq 126 ]
 
   echo "$output" | grep -q "No version set for command dummy" 2>/dev/null
-  echo "$output" | grep -q "you might want to add one of the following in your .tool-versions file" 2>/dev/null
+  echo "$output" | grep -q "Please add one of the following versions in your config file at $PROJECT_DIR/.tool-versions" 2>/dev/null
   echo "$output" | grep -q "dummy 1.0" 2>/dev/null
   echo "$output" | grep -q "dummy 2.0" 2>/dev/null
 }
@@ -108,7 +108,7 @@ teardown() {
   [ "$status" -eq 126 ]
 
   echo "$output" | grep -q "No version set for command dummy" 2>/dev/null
-  echo "$output" | grep -q "you might want to add one of the following in your .tool-versions file" 2>/dev/null
+  echo "$output" | grep -q "Please add one of the following versions in your config file at $PROJECT_DIR/.tool-versions" 2>/dev/null
   echo "$output" | grep -q "dummy 1.0" 2>/dev/null
   echo "$output" | grep -q "mummy 3.0" 2>/dev/null
 }
@@ -120,12 +120,12 @@ teardown() {
 
   run $ASDF_DIR/shims/dummy world hello
   [ "$status" -eq 126 ]
-  echo "$output" | grep -q "No preset version installed for command dummy"  2>/dev/null
-  echo "$output" | grep -q "Please install the missing version by running one of the following:"  2>/dev/null
-  echo "$output" | grep -q "asdf install dummy 2.0"  2>/dev/null
-  echo "$output" | grep -q "asdf install dummy 1.3"  2>/dev/null
-  echo "$output" | grep -q "or add one of the following in your .tool-versions file:"  2>/dev/null
-  echo "$output" | grep -q "dummy 1.0"  2>/dev/null
+  echo "$output" | grep -q "No preset version installed for command dummy" 2>/dev/null
+  echo "$output" | grep -q "Please install a version by running one of the following:" 2>/dev/null
+  echo "$output" | grep -q "asdf install dummy 2.0" 2>/dev/null
+  echo "$output" | grep -q "asdf install dummy 1.3" 2>/dev/null
+  echo "$output" | grep -q "or add one of the following versions in your config file at $PROJECT_DIR/.tool-versions" 2>/dev/null
+  echo "$output" | grep -q "dummy 1.0" 2>/dev/null
 }
 
 @test "shim exec should execute first plugin that is installed and set" {


### PR DESCRIPTION
# Summary

Add the path to the active `.tool-versions` file on shim errors

```shell
➜ asdf env gcloud            
No version set for command gcloud
Please add one of the following versions in your config file at /home/jthegedus/.tool-versions

gcloud 287.0.0
gcloud 288.0.0
gcloud 293.0.0

asdf-gcloud on  master 
➜ asdf env gcloud
No preset version installed for command gcloud
Please install a version by running one of the following:

asdf install gcloud 290.0.0

or add one of the following versions in your config file at /home/jthegedus/.tool-versions

gcloud 287.0.0
gcloud 288.0.0
gcloud 293.0.0
```

Fixes: #749 

## Other Information

- moved from `echo` to `printf`
- slimmed error output