### PR TITLE
fix: CI formatting use editorconfig

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -89,4 +89,4 @@ jobs:
         run: shfmt -f .
 
       - name: Run shfmt
-        run: shfmt -d -i 2 .
+        run: shfmt -d .

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -85,5 +85,8 @@ jobs:
       - name: Install shfmt
         run: brew install shfmt
 
+      - name: List file to shfmt
+        run: shfmt -f .
+
       - name: Run shfmt
-        run: shfmt -d -i 2 -ci . lib/commands/*
+        run: shfmt -d -i 2 .

--- a/bin/asdf
+++ b/bin/asdf
@@ -26,23 +26,23 @@ find_asdf_cmd() {
   local asdf_cmd_dir
   asdf_cmd_dir="$(asdf_dir)/lib/commands"
   case "$1" in
-    'exec' | 'current' | 'env' | 'global' | 'install' | 'latest' | 'local' | \
-      'reshim' | 'uninstall' | 'update' | 'where' | 'which' | \
-      'export-shell-version')
-      echo "$asdf_cmd_dir/command-$1.bash" 2
-      ;;
+  'exec' | 'current' | 'env' | 'global' | 'install' | 'latest' | 'local' | \
+    'reshim' | 'uninstall' | 'update' | 'where' | 'which' | \
+    'export-shell-version')
+    echo "$asdf_cmd_dir/command-$1.bash" 2
+    ;;
 
-    '' | '--help' | '-h' | 'help')
-      echo "$asdf_cmd_dir/command-help.bash" 2
-      ;;
+  '' | '--help' | '-h' | 'help')
+    echo "$asdf_cmd_dir/command-help.bash" 2
+    ;;
 
-    '--version' | 'version')
-      echo "$asdf_cmd_dir/command-version.bash" 2
-      ;;
+  '--version' | 'version')
+    echo "$asdf_cmd_dir/command-version.bash" 2
+    ;;
 
-    *)
-      find_cmd "$asdf_cmd_dir" "$@"
-      ;;
+  *)
+    find_cmd "$asdf_cmd_dir" "$@"
+    ;;
   esac
 }
 

--- a/completions/asdf.bash
+++ b/completions/asdf.bash
@@ -15,51 +15,51 @@ _asdf() {
   COMPREPLY=()
 
   case "$cmd" in
-    plugin-update)
+  plugin-update)
+    # shellcheck disable=SC2207
+    COMPREPLY=($(compgen -W "$plugins --all" -- "$cur"))
+    ;;
+  plugin-remove | current | list | list-all)
+    # shellcheck disable=SC2207
+    COMPREPLY=($(compgen -W "$plugins" -- "$cur"))
+    ;;
+  plugin-add)
+    local available_plugins
+    available_plugins=$(asdf plugin-list-all 2>/dev/null | awk '{ if ($2 !~ /^\*/) print $1}')
+    # shellcheck disable=SC2207
+    COMPREPLY=($(compgen -W "$available_plugins" -- "$cur"))
+    ;;
+  install)
+    if [[ "$plugins" == *"$prev"* ]]; then
+      local versions
+      versions=$(asdf list-all "$prev" 2>/dev/null)
       # shellcheck disable=SC2207
-      COMPREPLY=($(compgen -W "$plugins --all" -- "$cur"))
-      ;;
-    plugin-remove | current | list | list-all)
+      COMPREPLY=($(compgen -W "$versions" -- "$cur"))
+    else
       # shellcheck disable=SC2207
       COMPREPLY=($(compgen -W "$plugins" -- "$cur"))
-      ;;
-    plugin-add)
-      local available_plugins
-      available_plugins=$(asdf plugin-list-all 2>/dev/null | awk '{ if ($2 !~ /^\*/) print $1}')
+    fi
+    ;;
+  update)
+    # shellcheck disable=SC2207
+    COMPREPLY=($(compgen -W "--head" -- "$cur"))
+    ;;
+  uninstall | where | reshim | local | global | shell)
+    if [[ "$plugins" == *"$prev"* ]]; then
+      local versions
+      versions=$(asdf list "$prev" 2>/dev/null)
       # shellcheck disable=SC2207
-      COMPREPLY=($(compgen -W "$available_plugins" -- "$cur"))
-      ;;
-    install)
-      if [[ "$plugins" == *"$prev"* ]]; then
-        local versions
-        versions=$(asdf list-all "$prev" 2>/dev/null)
-        # shellcheck disable=SC2207
-        COMPREPLY=($(compgen -W "$versions" -- "$cur"))
-      else
-        # shellcheck disable=SC2207
-        COMPREPLY=($(compgen -W "$plugins" -- "$cur"))
-      fi
-      ;;
-    update)
+      COMPREPLY=($(compgen -W "$versions" -- "$cur"))
+    else
       # shellcheck disable=SC2207
-      COMPREPLY=($(compgen -W "--head" -- "$cur"))
-      ;;
-    uninstall | where | reshim | local | global | shell)
-      if [[ "$plugins" == *"$prev"* ]]; then
-        local versions
-        versions=$(asdf list "$prev" 2>/dev/null)
-        # shellcheck disable=SC2207
-        COMPREPLY=($(compgen -W "$versions" -- "$cur"))
-      else
-        # shellcheck disable=SC2207
-        COMPREPLY=($(compgen -W "$plugins" -- "$cur"))
-      fi
-      ;;
-    *)
-      local cmds='current global help install list list-all local plugin-add plugin-list plugin-list-all plugin-remove plugin-update reshim shell uninstall update where which '
-      # shellcheck disable=SC2207
-      COMPREPLY=($(compgen -W "$cmds" -- "$cur"))
-      ;;
+      COMPREPLY=($(compgen -W "$plugins" -- "$cur"))
+    fi
+    ;;
+  *)
+    local cmds='current global help install list list-all local plugin-add plugin-list plugin-list-all plugin-remove plugin-update reshim shell uninstall update where which '
+    # shellcheck disable=SC2207
+    COMPREPLY=($(compgen -W "$cmds" -- "$cur"))
+    ;;
   esac
 
   return 0

--- a/lib/asdf.sh
+++ b/lib/asdf.sh
@@ -7,14 +7,14 @@ asdf() {
   fi
 
   case "$command" in
-    "shell")
-      # commands that need to export variables
-      eval "$(asdf export-shell-version sh "$@")" # asdf_allow: eval
-      ;;
-    *)
-      # forward other commands to asdf script
-      command asdf "$command" "$@"
-      ;;
+  "shell")
+    # commands that need to export variables
+    eval "$(asdf export-shell-version sh "$@")" # asdf_allow: eval
+    ;;
+  *)
+    # forward other commands to asdf script
+    command asdf "$command" "$@"
+    ;;
 
   esac
 }

--- a/lib/commands/command-export-shell-version.bash
+++ b/lib/commands/command-export-shell-version.bash
@@ -20,12 +20,12 @@ shell_command() {
 
   if [ "$version" = "--unset" ]; then
     case "$asdf_shell" in
-      fish)
-        echo "set -e $version_env_var"
-        ;;
-      *)
-        echo "unset $version_env_var"
-        ;;
+    fish)
+      echo "set -e $version_env_var"
+      ;;
+    *)
+      echo "unset $version_env_var"
+      ;;
     esac
     exit 0
   fi
@@ -35,12 +35,12 @@ shell_command() {
   fi
 
   case "$asdf_shell" in
-    fish)
-      echo "set -gx $version_env_var \"$version\""
-      ;;
-    *)
-      echo "export $version_env_var=\"$version\""
-      ;;
+  fish)
+    echo "set -gx $version_env_var \"$version\""
+    ;;
+  *)
+    echo "export $version_env_var=\"$version\""
+    ;;
   esac
 }
 

--- a/lib/commands/command-install.bash
+++ b/lib/commands/command-install.bash
@@ -90,13 +90,13 @@ install_tool_version() {
 
   for flag in $flags; do
     case "$flag" in
-      "--keep-download")
-        keep_download=true
-        shift
-        ;;
-      *)
-        shift
-        ;;
+    "--keep-download")
+      keep_download=true
+      shift
+      ;;
+    *)
+      shift
+      ;;
     esac
   done
 

--- a/lib/commands/command-local.bash
+++ b/lib/commands/command-local.bash
@@ -9,14 +9,14 @@ local_command() {
 
   while [[ $# -gt 0 ]]; do
     case $1 in
-      -p | --parent)
-        parent="true"
-        shift # past value
-        ;;
-      *)
-        positional+=("$1") # save it in an array for later
-        shift              # past argument
-        ;;
+    -p | --parent)
+      parent="true"
+      shift # past value
+      ;;
+    *)
+      positional+=("$1") # save it in an array for later
+      shift              # past argument
+      ;;
     esac
   done
 

--- a/lib/commands/command-plugin-list.bash
+++ b/lib/commands/command-plugin-list.bash
@@ -9,17 +9,17 @@ plugin_list_command() {
 
   while [ -n "$*" ]; do
     case "$1" in
-      "--urls")
-        show_repo=true
-        shift
-        ;;
-      "--refs")
-        show_ref=true
-        shift
-        ;;
-      *)
-        shift
-        ;;
+    "--urls")
+      show_repo=true
+      shift
+      ;;
+    "--refs")
+      show_ref=true
+      shift
+      ;;
+    *)
+      shift
+      ;;
     esac
   done
 

--- a/lib/commands/command-plugin-test.bash
+++ b/lib/commands/command-plugin-test.bash
@@ -13,20 +13,20 @@ plugin_test_command() {
 
   while [[ $# -gt 0 ]]; do
     case $1 in
-      --asdf-plugin-gitref)
-        plugin_gitref="$2"
-        shift # past flag
-        shift # past value
-        ;;
-      --asdf-tool-version)
-        tool_version="$2"
-        shift # past flag
-        shift # past value
-        ;;
-      *)
-        plugin_command_array+=("$1") # save it in an array for later
-        shift                        # past argument
-        ;;
+    --asdf-plugin-gitref)
+      plugin_gitref="$2"
+      shift # past flag
+      shift # past value
+      ;;
+    --asdf-tool-version)
+      tool_version="$2"
+      shift # past flag
+      shift # past value
+      ;;
+    *)
+      plugin_command_array+=("$1") # save it in an array for later
+      shift                        # past argument
+      ;;
     esac
   done
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -444,12 +444,12 @@ resolve_symlink() {
   # If it is a slash we can assume it's root and absolute. Otherwise we treat it
   # as relative
   case $resolved_path in
-    /*)
-      echo "$resolved_path"
-      ;;
-    *)
-      echo "$PWD/$resolved_path"
-      ;;
+  /*)
+    echo "$resolved_path"
+    ;;
+  *)
+    echo "$PWD/$resolved_path"
+    ;;
   esac
 }
 


### PR DESCRIPTION
# Summary

Remove `shfmt` flags and rely solely on standard EditorConfig settings being inferred by `shfmt`. This requires dropping switchcase indenting (`shfmt -ci`).

## Details

`shfmt` is currently being used to perform format checking in our GitHub Actions.

`shfmt` supports using `editorconfig` files, but not when "Parser or Printer options" are set.

<details>
<summary>shfmt --help</summary>

```
➜ shfmt --help
usage: shfmt [flags] [path ...]

If the only argument is a dash ('-') or no arguments are given, standard input
will be used. If a given path is a directory, it will be recursively searched
for shell files - both by filename extension and by shebang.

  -version  show version and exit

  -l        list files whose formatting differs from shfmt's
  -w        write result to file instead of stdout
  -d        error with a diff when the formatting differs
  -s        simplify the code
  -mn       minify the code to reduce its size (implies -s)

Parser options:

  -ln str   language variant to parse (bash/posix/mksh, default "bash")
  -p        shorthand for -ln=posix

Printer options:

  -i uint   indent: 0 for tabs (default), >0 for number of spaces
  -bn       binary ops like && and | may start a line
  -ci       switch cases will be indented
  -sr       redirect operators will be followed by a space
  -kp       keep column alignment paddings
  -fn       function opening braces are placed on a separate line

Utilities:

  -f        recursively find all shell files and print the paths
  -tojson   print syntax tree to stdout as a typed JSON
```

</details>

Both `-i` and `-ci` are being used in our CI, so the `.editorconfig` is **not** being used by CI and is inconsistent with people using the `.editorconfig` file to perform formatting.

[Shfmt docs](https://github.com/mvdan/sh#shfmt) show you can configure it's other flags through EditorConfig:

```
shell_variant      = posix # like -ln=posix
binary_next_line   = true  # like -bn
switch_case_indent = true  # like -ci
space_redirects    = true  # like -sr
keep_padding       = true  # like -kp
function_next_line = true  # like -fn
```

However, these settings are not part of EditorConfig itself, and so developer's using EditorConfig to format files will have a discrepancy here too. This is inconsistent with the purpose of EditorConfig.

I have been unable to get `shfmt` to read `switch_case_indent` from my local EditorConfig so do not believe requiring contributors to install `shfmt` is a viable option.

## Solution

Do not use any flags of `shfmt`.

`-i 2` is read from EditorConfig's standard `indent_size`.

`-ci` is not supported by EditorConfig, so remove this. `-ci` is indented switch cases and is the only real formatting change here

## Other Information

- List the files to be formatted by `shfmt` in CI. I am unsure why `lib/commands/*` was added as `.` is recursive and covers these files, witnessed in the `List file to shfmt` CI job.
- I would like to open the tabs vs spaces can of worms at some point :sweat_smile: :gun: 
