### PR TITLE
Use v1 plugin-test action instead of v1.0.0 in document

### DIFF
--- a/docs/plugins-create.md
+++ b/docs/plugins-create.md
@@ -209,7 +209,7 @@ The [asdf-vm/actions](https://github.com/asdf-vm/actions) repo provides a GitHub
 ```yaml
 steps:
   - name: asdf_plugin_test
-    uses: asdf-vm/actions/plugin-test@v1.0.0
+    uses: asdf-vm/actions/plugin-test@v1
     with:
       command: "my_tool --version"
     env:


### PR DESCRIPTION
# Summary

This PR updates to use v1 plugin-test action instead of v1.0.0 in "Example Github Action" section of document.

ref https://github.com/asdf-community/.github/issues/6