### PR TITLE
Add `column` to list of banned commands for the asdf codebase

### DIFF
--- a/test/banned_commands.bats
+++ b/test/banned_commands.bats
@@ -9,7 +9,9 @@ banned_commands=(
     # It's best to avoid eval as it makes it easier to accidentally execute
     # arbitrary strings
     eval
-
+    # Command isn't included in the Ubuntu packages asdf depends on. Also not
+    # defined in POSIX
+    column
     # does not work on alpine and should be grep -i either way
     "grep -y"
 )


### PR DESCRIPTION
# Summary

Add `column` to list of banned commands for the asdf codebase. Tests now pass since https://github.com/asdf-vm/asdf/pull/721 has been merged.

Fixes: https://github.com/asdf-vm/asdf/issues/661 
Related: https://github.com/asdf-vm/asdf/pull/721
