### PR TITLE
Docs: Clarify shim creation for writing plugins

### DIFF
--- a/docs/plugins-create.md
+++ b/docs/plugins-create.md
@@ -49,7 +49,7 @@ If this script is not present asdf will assume that the `bin/install` script is 
 
 #### bin/install
 
-This script should install the version, in the path mentioned in `ASDF_INSTALL_PATH`.
+This script should install the version, in the path mentioned in `ASDF_INSTALL_PATH`. By default, asdf will create shims for any files in `$ASDF_INSTALL_PATH/bin` (this can be customized with the optional [bin/list-bin-paths](#binlist-bin-paths) script).
 
 The install script should exit with a status of `0` when the installation is successful. If the installation fails the script should exit with any non-zero exit status.
 


### PR DESCRIPTION
# Summary

Clarify that shims will be created for files in `$ASDF_INSTALL_PATH/bin` in the docs for the `bin/install` script for plugin authoring.  I got stuck for a bit wondering why my shims weren't being created for a plugin that I was writing for an internal tool. I know this is described in the `bin/list-bin-paths` docs, but I didn't look at those docs since that's an optional script.

Thanks for `asdf`, I think it is going to be very helpful for installation and version management of some of our internal tools!