### PR TITLE
Install one tool specified in .tool-versions

### DIFF
--- a/docs/core-configuration.md
+++ b/docs/core-configuration.md
@@ -28,6 +28,8 @@ python 3.7.2 2.7.15 system
 
 To install all the tools defined in a `.tool-versions` file run `asdf install` with no other arguments in the directory containing the `.tool-versions` file.
 
+To install a single tool defined in a `.tool-versions` file run `asdf install <name>` in the directory containing the `.tool-versions` file.  The tool will be installed at the version specified in the `.tool-versions` file.
+
 Edit the file directly or use `asdf local` (or `asdf global`) which updates it.
 
 ## \$HOME/.asdfrc

--- a/help.txt
+++ b/help.txt
@@ -15,9 +15,9 @@ asdf plugin update --all                Update all plugins
 MANAGE PACKAGES
 asdf install                            Install all the package versions listed
                                         in the .tool-versions file 
-asdf install [<name>]                   Install one tool at the version
+asdf install <name>                     Install one tool at the version
                                         specified in the .tool-versions file
-asdf install [<name> <version>]         Install a specific version of a package
+asdf install <name> <version>           Install a specific version of a package
 asdf install <name> latest[:<version>]  Install the latest stable version of a
                                         package, or with optional version,
                                         install the latest stable version that

--- a/help.txt
+++ b/help.txt
@@ -13,13 +13,11 @@ asdf plugin update --all                Update all plugins
 
 
 MANAGE PACKAGES
+asdf install                            Install all the package versions listed
+                                        in the .tool-versions file 
+asdf install [<name>]                   Install one tool at the version
+                                        specified in the .tool-versions file
 asdf install [<name> <version>]         Install a specific version of a package
-                                        With no arguments, install all the
-                                        package versions listed in the
-                                        .tool-versions file.  With only one
-                                        argument, install that tool at the
-                                        version specified in the .tool-versions
-                                        file.
 asdf install <name> latest[:<version>]  Install the latest stable version of a
                                         package, or with optional version,
                                         install the latest stable version that

--- a/help.txt
+++ b/help.txt
@@ -14,9 +14,12 @@ asdf plugin update --all                Update all plugins
 
 MANAGE PACKAGES
 asdf install [<name> <version>]         Install a specific version of a package
-                                        or, with no arguments, install all the
+                                        With no arguments, install all the
                                         package versions listed in the
-                                        .tool-versions file
+                                        .tool-versions file.  With only one
+                                        argument, install that tool at the
+                                        version specified in the .tool-versions
+                                        file.
 asdf install <name> latest[:<version>]  Install the latest stable version of a
                                         package, or with optional version,
                                         install the latest stable version that

--- a/lib/commands/command-install.bash
+++ b/lib/commands/command-install.bash
@@ -20,8 +20,7 @@ install_command() {
   if [ "$plugin_name" = "" ] && [ "$full_version" = "" ]; then
     install_local_tool_versions "$extra_args"
   elif [[ $# -eq 1 ]]; then
-    display_error "You must specify a name and a version to install"
-    exit 1
+    install_one_local_tool "$plugin_name"
   else
     install_tool_version "$plugin_name" "$full_version" "$extra_args"
   fi
@@ -39,6 +38,30 @@ get_concurrency() {
   fi
 }
 
+install_one_local_tool() {
+  local plugin_name=$1
+  local search_path
+  search_path=$(pwd)
+
+  local plugin_versions
+
+  local plugin_version
+
+  local plugin_version_and_path
+  plugin_version_and_path="$(find_versions "$plugin_name" "$search_path")"
+
+  if [ -n "$plugin_version_and_path" ]; then
+    local plugin_version
+    some_tools_installed='yes'
+    plugin_versions=$(cut -d '|' -f 1 <<<"$plugin_version_and_path")
+    for plugin_version in $plugin_versions; do
+      install_tool_version "$plugin_name" "$plugin_version"
+    done
+  else
+    echo "No versions specified for $plugin_name in config files or environment"
+    exit 1
+  fi
+}
 install_local_tool_versions() {
   local plugins_path
   plugins_path=$(get_plugin_path)

--- a/test/fixtures/dummy_plugin/bin/install
+++ b/test/fixtures/dummy_plugin/bin/install
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
 
+# We want certain versions to fail installation for various reasons in the tests
+check_dummy_versions() {
+  local bad_versions=" other-dummy "
+  if [[ "$bad_versions" == *" $ASDF_INSTALL_VERSION "* ]]; then
+    echo "Dummy couldn't install version: $ASDF_INSTALL_VERSION (on purpose)"
+    exit 1
+  fi
+}
+
+check_dummy_versions
 mkdir -p "$ASDF_INSTALL_PATH"
 env >"$ASDF_INSTALL_PATH/env"
 echo "$ASDF_INSTALL_VERSION" >"$ASDF_INSTALL_PATH/version"

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -133,12 +133,20 @@ teardown() {
 }
 
 @test "install_command fails when tool is specified but no version of the tool is configured in config file" {
-
   echo 'dummy 1.0' > $PROJECT_DIR/.tool-versions
   run asdf install other-dummy
   [ "$status" -eq 1 ]
   [ "$output" = "No versions specified for other-dummy in config files or environment" ]
   [ ! -f $ASDF_DIR/installs/dummy/1.0/version ]
+}
+
+@test "install_command fails when two tools are specified with no versions" {
+  printf 'dummy 1.0\nother-dummy 2.0' > $PROJECT_DIR/.tool-versions
+  run asdf install dummy other-dummy
+  [ "$status" -eq 1 ]
+  [ "$output" = "Dummy couldn't install version: other-dummy (on purpose)" ]
+  [ ! -f $ASDF_DIR/installs/dummy/1.0/version ]
+  [ ! -f $ASDF_DIR/installs/other-dummy/2.0/version ]
 }
 
 @test "install_command without arguments uses a parent directory .tool-versions file if present" {

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -35,6 +35,14 @@ teardown() {
   [ $(cat $ASDF_DIR/installs/dummy/1.2/version) = "1.2" ]
 }
 
+@test "install_command with only name installs the version in .tool-versions" {
+  cd $PROJECT_DIR
+  echo -n 'dummy 1.2' > ".tool-versions"
+  run asdf install dummy
+  [ "$status" -eq 0 ]
+  [ $(cat $ASDF_DIR/installs/dummy/1.2/version) = "1.2" ]
+}
+
 @test "install_command set ASDF_CONCURRENCY" {
   run asdf install dummy 1.0
   [ "$status" -eq 0 ]
@@ -117,16 +125,20 @@ teardown() {
   [ "$output" == "This is Dummy 1.0! hello world" ]
 }
 
-@test "install_command fails when the name or version are not specified" {
+@test "install_command fails when tool is specified but no version of the tool is configured" {
   run asdf install dummy
   [ "$status" -eq 1 ]
-  [ "$output" = "You must specify a name and a version to install" ]
+  [ "$output" = "No versions specified for dummy in config files or environment" ]
   [ ! -f $ASDF_DIR/installs/dummy/1.1/version ]
+}
 
-  run asdf install 1.1
+@test "install_command fails when tool is specified but no version of the tool is configured in config file" {
+
+  echo 'dummy 1.0' > $PROJECT_DIR/.tool-versions
+  run asdf install other-dummy
   [ "$status" -eq 1 ]
-  [ "$output" = "You must specify a name and a version to install" ]
-  [ ! -f $ASDF_DIR/installs/dummy/1.1/version ]
+  [ "$output" = "No versions specified for other-dummy in config files or environment" ]
+  [ ! -f $ASDF_DIR/installs/dummy/1.0/version ]
 }
 
 @test "install_command without arguments uses a parent directory .tool-versions file if present" {


### PR DESCRIPTION
# Summary
Install one tool specified in .tool-versions

Add a one-argument version of install command `asdf install <name>` that installs that single tool at the version specified in `.tool-versions`.  If there is no `.tool-versions` or if that tool is not in it, an error message is shown and `asdf` exits `1`.

Fixes: #759 