### PR TITLE
when listing versions, mark or flag (w asterisk *) those versions that are current/global/default

### DIFF
--- a/lib/commands/command-list.bash
+++ b/lib/commands/command-list.bash
@@ -22,16 +22,23 @@ list_command() {
   fi
 }
 
+
 display_installed_versions() {
   local versions
-  versions=$(list_installed_versions "$1")
-
+  local plugin=$1
+  versions=$(list_installed_versions "$plugin")
   if [ -n "${versions}" ]; then
+    local cver=$(eval asdf current "$plugin" | cut -f 1 -d " " )
     for version in $versions; do
-      echo "  $version"
+      local flag="  "
+      if [[ "$version" == "$cver" ]]
+        then
+        flag=" *"
+      fi
+      echo "${flag}$version"
     done
   else
-    display_error '  No versions installed'
+    display_error 'No versions installed'
   fi
 }
 


### PR DESCRIPTION
# Summary

When listing versions using eg "asdf list" or "asdf list <plugin>" , would be great if we also mark or flag (w asterisk *) those versions that are current/global/default for that plugin.

Example run:

```
$ asdf list
elixir
  1.10.2-otp-22
 *1.10.3-otp-22
erlang
 *22.3.2
nodejs
 *12.18.2
php
 *7.4.4
ruby
  2.5.8
 *2.6.6
  2.7.1

$ asdf list ruby
  2.5.8
 *2.6.6
  2.7.1

```
```

# we can check
$ asdf current
elixir         1.10.3-otp-22 (set by /home/botp/.tool-versions)
erlang         22.3.2   (set by /home/botp/.tool-versions)
nodejs         12.18.2  (set by /home/botp/.tool-versions)
php            7.4.4    (set by /home/botp/.tool-versions)
ruby           2.6.6    (set by /home/botp/.tool-versions)

```