### PR TITLE
fix: plugin test to emit error message when `latest` fails

### DIFF
--- a/lib/commands/command-plugin-test.bash
+++ b/lib/commands/command-plugin-test.bash
@@ -110,6 +110,9 @@ plugin_test_command() {
     # version from the versions list
     if [ -z "$tool_version" ] || [[ "$tool_version" == *"latest"* ]]; then
       version="$(asdf latest "$plugin_name" "$(echo "$tool_version" | sed -e 's#latest##;s#^:##')")"
+      if [ -z "$tool_version" ]; then
+        fail_test "could not get latest version"
+      fi
     else
       version="$tool_version"
     fi


### PR DESCRIPTION
# Summary

`plugin-test` currently tries to install the plugin without providing a version if `asdf latest` fails.
This emits an error message before instead.

## Other Information

Fixes #756