### PR TITLE
fix: revert to cmds to precompute brew prefix on addition to shell config

### DIFF
--- a/docs/core-manage-asdf-vm.md
+++ b/docs/core-manage-asdf-vm.md
@@ -223,7 +223,7 @@ echo -e "\n. $(brew --prefix asdf)/etc/bash_completion.d/asdf.bash" >> ~/.bash_p
 Add `asdf.fish` to your `~/.config/fish/config.fish` with:
 
 ```shell
-echo -e "\nsource (brew --prefix asdf)/asdf.fish" >> ~/.config/fish/config.fish
+echo -e "\nsource $(brew --prefix asdf)/asdf.fish" >> ~/.config/fish/config.fish
 ```
 
 ?> Completions are [handled by Homebrew for the Fish shell](https://docs.brew.sh/Shell-Completion#configuring-completions-in-fish). Friendly!

--- a/docs/core-manage-asdf-vm.md
+++ b/docs/core-manage-asdf-vm.md
@@ -206,10 +206,10 @@ compinit
 
 If using **macOS Catalina or newer**, the default shell has changed to **ZSH**. Unless changing back to Bash, follow the ZSH instructions.
 
-Add the following to `~/.bash_profile`:
+Add `asdf.sh` to your `~/.bash_profile` with:
 
 ```shell
-. $(brew --prefix asdf)/asdf.sh
+echo -e "\n. $(brew --prefix asdf)/asdf.sh" >> ~/.bash_profile
 ```
 
 ?> Completions will need to be [configured as per Homebrew's instructions](https://docs.brew.sh/Shell-Completion#configuring-completions-in-bash) or with the following:
@@ -220,20 +220,20 @@ echo -e "\n. $(brew --prefix asdf)/etc/bash_completion.d/asdf.bash" >> ~/.bash_p
 
 #### --macOS,Fish,Homebrew--
 
-Add the following to `~/.config/fish/config.fish`:
+Add `asdf.fish` to your `~/.config/fish/config.fish` with:
 
 ```shell
-source (brew --prefix asdf)/asdf.fish
+echo -e "\nsource (brew --prefix asdf)/asdf.fish" >> ~/.config/fish/config.fish
 ```
 
 ?> Completions are [handled by Homebrew for the Fish shell](https://docs.brew.sh/Shell-Completion#configuring-completions-in-fish). Friendly!
 
 #### --macOS,ZSH,Homebrew--
 
-Add the following to `~/.zshrc`:
+Add `asdf.sh` to your `~/.zshrc` with:
 
 ```shell
-. $(brew --prefix asdf)/asdf.sh
+echo -e "\n. $(brew --prefix asdf)/asdf.sh" >> ~/.zshrc
 ```
 
 ?> Completions will need to be [configured as per Homebrew's instructions](https://docs.brew.sh/Shell-Completion#configuring-completions-in-zsh).


### PR DESCRIPTION
# Summary

Revert installation instructions for Homebrew to be commands that append to shell configs instead of the contents to be added. `$(brew --prefix)` will now be computed on adding `asdf` to the shell config instead of being computed on each execution.

Fixes: #771 

## Other Information

This has potential to break when the `asdf` Homebrew package is updated and changes the installation location. The consensus is that we will deal with those issues if/when they arise.