### PR TITLE
docs: link to our community and place(s) for q&a

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,6 @@ See [CONTRIBUTING.md in the repo](https://github.com/asdf-vm/asdf/blob/master/CO
 
 ## Community & Questions
 
-- ![GitHub Discussions](https://icongram.jgog.in/simple/github.svg?color=808080&size=16)Github Discussions **TBA**: our preferred method for community Q&A and interaction
+- [![GitHub Discussions](https://icongram.jgog.in/simple/github.svg?color=808080&size=16)Github Discussions TBA](https://github.com/asdf-vm/asdf/discussions): our preferred method for community Q&A and interaction
 - [![Github Issues](https://icongram.jgog.in/simple/github.svg?color=808080&size=16)Github Issues](https://github.com/asdf-vm/asdf/issues): report a bug or raise a feature request to the `asdf` core team
 - [![StackOverflow Tag](https://icongr.am/fontawesome/stack-overflow.svg?size=16&color=808080)StackOverflow Tag](https://stackoverflow.com/questions/tagged/asdf-vm): see existing Q&A for `asdf`. Some of the core team watch this tag in addition to our helpful community

--- a/README.md
+++ b/README.md
@@ -22,9 +22,15 @@ asdf-vm is a CLI tool that can manage multiple language runtime versions on a pe
 - [Getting Started](https://asdf-vm.github.io/asdf/#/core-manage-asdf-vm)
 - [All Commands](https://asdf-vm.github.io/asdf/#/core-commands)
 - [All Plugins](https://asdf-vm.github.io/asdf/#/plugins-all)
-- [Create a Plugin](https://asdf-vm.github.io/asdf/#/plugins-create)
+- [Create a Plugin](https://asdf-vm.github.io/asdf/#/plugins-create) with our [asdf-plugin-template](https://github.com/asdf-vm/asdf-plugin-template)
 - [asdf GitHub Actions](https://github.com/asdf-vm/actions)
 
 ## Contributing
 
 See [CONTRIBUTING.md in the repo](https://github.com/asdf-vm/asdf/blob/master/CONTRIBUTING.md) or the [Contributing section on the docs site](http://asdf-vm.github.io/asdf/#/contributing-core-asdf-vm).
+
+## Community & Questions
+
+- ![GitHub Discussions](https://icongram.jgog.in/simple/github.svg?color=808080&size=16)Github Discussions **TBA**: our preferred method for community Q&A and interaction
+- [![Github Issues](https://icongram.jgog.in/simple/github.svg?color=808080&size=16)Github Issues](https://github.com/asdf-vm/asdf/issues): report a bug or raise a feature request to the `asdf` core team
+- [![StackOverflow Tag](https://icongr.am/fontawesome/stack-overflow.svg?size=16&color=808080)StackOverflow Tag](https://stackoverflow.com/questions/tagged/asdf-vm): see existing Q&A for `asdf`. Some of the core team watch this tag in addition to our helpful community

--- a/README.md
+++ b/README.md
@@ -31,6 +31,6 @@ See [CONTRIBUTING.md in the repo](https://github.com/asdf-vm/asdf/blob/master/CO
 
 ## Community & Questions
 
-- [![GitHub Discussions](https://icongram.jgog.in/simple/github.svg?color=808080&size=16)Github Discussions TBA](https://github.com/asdf-vm/asdf/discussions): our preferred method for community Q&A and interaction
+<!-- - [![GitHub Discussions](https://icongram.jgog.in/simple/github.svg?color=808080&size=16)Github Discussions TBA](https://github.com/asdf-vm/asdf/discussions): our preferred method for community Q&A and interaction -->
 - [![Github Issues](https://icongram.jgog.in/simple/github.svg?color=808080&size=16)Github Issues](https://github.com/asdf-vm/asdf/issues): report a bug or raise a feature request to the `asdf` core team
 - [![StackOverflow Tag](https://icongr.am/fontawesome/stack-overflow.svg?size=16&color=808080)StackOverflow Tag](https://stackoverflow.com/questions/tagged/asdf-vm): see existing Q&A for `asdf`. Some of the core team watch this tag in addition to our helpful community

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -15,6 +15,6 @@
 - [Documentation Site](contributing-doc-site)
 - [Thanks](thanks)
 - **Community & Questions**
-- ![GitHub Discussions](https://icongram.jgog.in/simple/github.svg?color=808080&size=16)Github Discussions TBA
+- [![GitHub Discussions](https://icongram.jgog.in/simple/github.svg?color=808080&size=16)Github Discussions TBA](https://github.com/asdf-vm/asdf/discussions)
 - [![Github Issues](https://icongram.jgog.in/simple/github.svg?color=808080&size=16)Github Issues](https://github.com/asdf-vm/asdf/issues)
 - [![StackOverflow Tag](https://icongr.am/fontawesome/stack-overflow.svg?size=16&color=808080)StackOverflow Tag](https://stackoverflow.com/questions/tagged/asdf-vm)

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -14,7 +14,7 @@
 - [Core asdf vm](contributing-core-asdf-vm)
 - [Documentation Site](contributing-doc-site)
 - [Thanks](thanks)
-- **Questions & Community**
+- **Community & Questions**
 - ![GitHub Discussions](https://icongram.jgog.in/simple/github.svg?color=808080&size=16)Github Discussions TBA
 - [![Github Issues](https://icongram.jgog.in/simple/github.svg?color=808080&size=16)Github Issues](https://github.com/asdf-vm/asdf/issues)
 - [![StackOverflow Tag](https://icongr.am/fontawesome/stack-overflow.svg?size=16&color=808080)StackOverflow Tag](https://stackoverflow.com/questions/tagged/asdf-vm)

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,22 +1,20 @@
 <!-- docs/_sidebar.md -->
 
-- Core
-
-  - [Manage asdf-vm](core-manage-asdf-vm)
-  - [Manage Plugins](core-manage-plugins)
-  - [Manage Versions](core-manage-versions)
-  - [Configuration](core-configuration)
-  - [All Commands](core-commands)
-
-- Plugins
-
-  - [Creating Plugins](plugins-create)
-  - [All Plugins](plugins-all) <!-- pulls in asdf-vm/asdf-plugins readme -->
-
-- Contributing
-
-  - [Core asdf vm](contributing-core-asdf-vm)
-  - [Documentation Site](contributing-doc-site)
-
+- **Core**
+- [Manage asdf-vm](core-manage-asdf-vm)
+- [Manage Plugins](core-manage-plugins)
+- [Manage Versions](core-manage-versions)
+- [Configuration](core-configuration)
+- [All Commands](core-commands)
 - [Changelog](changelog) <!-- pulls in changelog from repo -->
+- **Plugins**
+- [Creating Plugins](plugins-create)
+- [All Plugins](plugins-all) <!-- pulls in asdf-vm/asdf-plugins readme -->
+- **Contributing**
+- [Core asdf vm](contributing-core-asdf-vm)
+- [Documentation Site](contributing-doc-site)
 - [Thanks](thanks)
+- **Questions & Community**
+- ![GitHub Discussions](https://icongram.jgog.in/simple/github.svg?color=808080&size=16)Github Discussions TBA
+- [![Github Issues](https://icongram.jgog.in/simple/github.svg?color=808080&size=16)Github Issues](https://github.com/asdf-vm/asdf/issues)
+- [![StackOverflow Tag](https://icongr.am/fontawesome/stack-overflow.svg?size=16&color=808080)StackOverflow Tag](https://stackoverflow.com/questions/tagged/asdf-vm)

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -15,6 +15,6 @@
 - [Documentation Site](contributing-doc-site)
 - [Thanks](thanks)
 - **Community & Questions**
-- [![GitHub Discussions](https://icongram.jgog.in/simple/github.svg?color=808080&size=16)Github Discussions TBA](https://github.com/asdf-vm/asdf/discussions)
 - [![Github Issues](https://icongram.jgog.in/simple/github.svg?color=808080&size=16)Github Issues](https://github.com/asdf-vm/asdf/issues)
 - [![StackOverflow Tag](https://icongr.am/fontawesome/stack-overflow.svg?size=16&color=808080)StackOverflow Tag](https://stackoverflow.com/questions/tagged/asdf-vm)
+<!-- - [![GitHub Discussions](https://icongram.jgog.in/simple/github.svg?color=808080&size=16)Github Discussions TBA](https://github.com/asdf-vm/asdf/discussions) -->


### PR DESCRIPTION
# Summary

Add links to README and website sidebar to our preferred tools for Q&A and community. GitHub Issues and SO links, GitHub Discussions placeholder.

Fixes: #766 

## Other Information

Re community: from the members who participated in https://github.com/asdf-vm/asdf/issues/766 it seems [GitHub Discussions](https://github.blog/2020-05-06-new-from-satellite-2020-github-codespaces-github-discussions-securing-code-in-private-repositories-and-more/) will be the best place to keep community interaction as it doesn't introduce another tool (eg Discord) where conversations are hidden, not index-able by Google etc. I am open to further discussion on this, though vote for GitHub Discussions.