### PR TITLE
make sure the shims folder is appended to path only once

### DIFF
--- a/asdf.fish
+++ b/asdf.fish
@@ -1,10 +1,13 @@
 set -x ASDF_DIR (dirname (status -f))
-set -l asdf_data_dir (
-  if test -n "$ASDF_DATA_DIR"; echo $ASDF_DATA_DIR;
-  else; echo $HOME/.asdf; end)
+
+if test -n $ASDF_DATA_DIR
+  set -l asdf_user_shims $ASDF_DATA_DIR/shims
+else
+  set -l asdf_user_shims $HOME/.asdf
+end
 
 # Add asdf to PATH
-set -l asdf_bin_dirs $ASDF_DIR/bin $ASDF_DIR/shims $asdf_data_dir/shims
+set -l asdf_bin_dirs $ASDF_DIR/bin $asdf_user_shims 
 
 for x in $asdf_bin_dirs
   if test -d $x


### PR DESCRIPTION
# Summary

This makes sure the shims folder is appended to $PATH only once. Before, if the user's $HOME contained a trailing `/` two shims folders would get appended to $PATH (e.g; `/home/lucas//.asdf/shims` && `/home/lucas/.asdf/shim`), preventing the user from using the `system` version as described in #767.

Fixes #767

## Other Information

This pretty much just replicates the logic in this line [https://github.com/asdf-vm/asdf/blob/master/asdf.sh#L24](https://github.com/asdf-vm/asdf/blob/master/asdf.sh#L24
) to the fish script