### PR TITLE
fix shims folder path

### DIFF
--- a/asdf.fish
+++ b/asdf.fish
@@ -1,10 +1,12 @@
 set -x ASDF_DIR (dirname (status -f))
 
-if test -n $ASDF_DATA_DIR
-  set -l asdf_user_shims $ASDF_DATA_DIR/shims
-else
-  set -l asdf_user_shims $HOME/.asdf
-end
+set -l asdf_user_shims (
+  if test -n "$ASDF_DATA_DIR"
+    echo $ASDF_DATA_DIR/shims
+  else
+    echo $HOME/.asdf/shims
+  end
+)
 
 # Add asdf to PATH
 set -l asdf_bin_dirs $ASDF_DIR/bin $asdf_user_shims 


### PR DESCRIPTION
# Summary

Append `/shims` to `$HOME/.asdf` in $asdf_user_shims.

I also had to move the if statement inside `set`, because if you use the `-l` flag inside the scope of a if statement, the variable doesn't become available in the global scope.

Fixes: https://github.com/asdf-vm/asdf/pull/777#pullrequestreview-465867789

```
> echo $PATH | grep asdf
/home/lucas/.asdf/shims /home/lucas/.asdf/bin ...
```
