### PR TITLE
fix: typo causing plugin-test to erroneously fail

### DIFF
--- a/lib/commands/command-plugin-test.bash
+++ b/lib/commands/command-plugin-test.bash
@@ -110,7 +110,7 @@ plugin_test_command() {
     # version from the versions list
     if [ -z "$tool_version" ] || [[ "$tool_version" == *"latest"* ]]; then
       version="$(asdf latest "$plugin_name" "$(echo "$tool_version" | sed -e 's#latest##;s#^:##')")"
-      if [ -z "$tool_version" ]; then
+      if [ -z "$version" ]; then
         fail_test "could not get latest version"
       fi
     else


### PR DESCRIPTION
# Summary

Currently, `asdf plugin-test` checks to see whether the parameter `tool_version` is zero instead of whether the output of `asdf latest` is zero to determine whether or not the plugin reports a latest version number. This change fixes that typo which was likely introduced in #772.

Fixes: n/a

## Other Information
