### PR TITLE
chore: add gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,191 @@
+## GITATTRIBUTES FOR WEB PROJECTS
+#
+# These settings are for any web project.
+#
+# Details per file setting:
+#   text    These files should be normalized (i.e. convert CRLF to LF).
+#   binary  These files are binary and should be left untouched.
+#
+# Note that binary is a macro for -text -diff.
+######################################################################
+
+## AUTO-DETECT
+##   Handle line endings automatically for files detected as
+##   text and leave all files detected as binary untouched.
+##   This will handle all files NOT defined below.
+* text=auto
+
+## SOURCE CODE
+*.bat      text eol=crlf
+*.coffee   text
+*.css      text
+*.htm      text
+*.html     text
+*.inc      text
+*.ini      text
+*.js       text
+*.json     text
+*.jsx      text
+*.less     text
+*.od       text
+*.onlydata text
+*.php      text
+*.pl       text
+*.py       text
+*.rb       text
+*.sass     text
+*.scm      text
+*.scss     text
+*.sh       text eol=lf
+*.sql      text
+*.styl     text
+*.tag      text
+*.ts       text
+*.tsx      text
+*.xml      text
+*.xhtml    text
+
+## DOCKER
+*.dockerignore    text
+Dockerfile    text
+
+## DOCUMENTATION
+*.markdown   text
+*.md         text
+*.mdwn       text
+*.mdown      text
+*.mkd        text
+*.mkdn       text
+*.mdtxt      text
+*.mdtext     text
+*.txt        text
+AUTHORS      text
+CHANGELOG    text
+CHANGES      text
+CONTRIBUTING text
+COPYING      text
+copyright    text
+*COPYRIGHT*  text
+INSTALL      text
+license      text
+LICENSE      text
+NEWS         text
+readme       text
+*README*     text
+TODO         text
+
+## TEMPLATES
+*.dot        text
+*.ejs        text
+*.haml       text
+*.handlebars text
+*.hbs        text
+*.hbt        text
+*.jade       text
+*.latte      text
+*.mustache   text
+*.njk        text
+*.phtml      text
+*.tmpl       text
+*.tpl        text
+*.twig       text
+
+## LINTERS
+.csslintrc    text
+.eslintrc     text
+.htmlhintrc   text
+.jscsrc       text
+.jshintrc     text
+.jshintignore text
+.stylelintrc  text
+
+## CONFIGS
+*.bowerrc      text
+*.cnf          text
+*.conf         text
+*.config       text
+.browserslistrc    text
+.editorconfig  text
+.gitattributes text
+.gitconfig     text
+.htaccess      text
+*.npmignore    text
+*.yaml         text
+*.yml          text
+browserslist   text
+Makefile       text
+makefile       text
+
+## HEROKU
+Procfile    text
+.slugignore text
+
+## GRAPHICS
+*.ai   binary
+*.bmp  binary
+*.eps  binary
+*.gif  binary
+*.ico  binary
+*.jng  binary
+*.jp2  binary
+*.jpg  binary
+*.jpeg binary
+*.jpx  binary
+*.jxr  binary
+*.pdf  binary
+*.png  binary
+*.psb  binary
+*.psd  binary
+*.svg  text
+*.svgz binary
+*.tif  binary
+*.tiff binary
+*.wbmp binary
+*.webp binary
+
+## AUDIO
+*.kar  binary
+*.m4a  binary
+*.mid  binary
+*.midi binary
+*.mp3  binary
+*.ogg  binary
+*.ra   binary
+
+## VIDEO
+*.3gpp binary
+*.3gp  binary
+*.as   binary
+*.asf  binary
+*.asx  binary
+*.fla  binary
+*.flv  binary
+*.m4v  binary
+*.mng  binary
+*.mov  binary
+*.mp4  binary
+*.mpeg binary
+*.mpg  binary
+*.ogv  binary
+*.swc  binary
+*.swf  binary
+*.webm binary
+
+## ARCHIVES
+*.7z  binary
+*.gz  binary
+*.jar binary
+*.rar binary
+*.tar binary
+*.zip binary
+
+## FONTS
+*.ttf   binary
+*.eot   binary
+*.otf   binary
+*.woff  binary
+*.woff2 binary
+
+## EXECUTABLES
+*.exe binary
+*.pyc binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -14,14 +14,14 @@
 * text=auto
 
 ## SOURCE CODE
-*.bats     text eol=crlf
+*.bats     text
 *.css      text
 *.htm      text
 *.html     text
 *.js       text
-*.sh       text eol=lf
-*.bash     text eol=lf
-*.fish     text eol=lf
+*.sh       text
+*.bash     text
+*.fish     text
 
 ## DOCKER
 *.dockerignore    text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,4 @@
-## GITATTRIBUTES FOR WEB PROJECTS
-#
-# These settings are for any web project.
+## GITATTRIBUTES
 #
 # Details per file setting:
 #   text    These files should be normalized (i.e. convert CRLF to LF).
@@ -16,38 +14,18 @@
 * text=auto
 
 ## SOURCE CODE
-*.bat      text eol=crlf
-*.coffee   text
+*.bats     text eol=crlf
 *.css      text
 *.htm      text
 *.html     text
-*.inc      text
-*.ini      text
 *.js       text
-*.json     text
-*.jsx      text
-*.less     text
-*.od       text
-*.onlydata text
-*.php      text
-*.pl       text
-*.py       text
-*.rb       text
-*.sass     text
-*.scm      text
-*.scss     text
 *.sh       text eol=lf
-*.sql      text
-*.styl     text
-*.tag      text
-*.ts       text
-*.tsx      text
-*.xml      text
-*.xhtml    text
+*.bash     text eol=lf
+*.fish     text eol=lf
 
 ## DOCKER
 *.dockerignore    text
-Dockerfile    text
+Dockerfile        text
 
 ## DOCUMENTATION
 *.markdown   text
@@ -74,118 +52,9 @@ readme       text
 *README*     text
 TODO         text
 
-## TEMPLATES
-*.dot        text
-*.ejs        text
-*.haml       text
-*.handlebars text
-*.hbs        text
-*.hbt        text
-*.jade       text
-*.latte      text
-*.mustache   text
-*.njk        text
-*.phtml      text
-*.tmpl       text
-*.tpl        text
-*.twig       text
-
-## LINTERS
-.csslintrc    text
-.eslintrc     text
-.htmlhintrc   text
-.jscsrc       text
-.jshintrc     text
-.jshintignore text
-.stylelintrc  text
-
 ## CONFIGS
-*.bowerrc      text
-*.cnf          text
-*.conf         text
-*.config       text
-.browserslistrc    text
 .editorconfig  text
 .gitattributes text
 .gitconfig     text
-.htaccess      text
-*.npmignore    text
 *.yaml         text
 *.yml          text
-browserslist   text
-Makefile       text
-makefile       text
-
-## HEROKU
-Procfile    text
-.slugignore text
-
-## GRAPHICS
-*.ai   binary
-*.bmp  binary
-*.eps  binary
-*.gif  binary
-*.ico  binary
-*.jng  binary
-*.jp2  binary
-*.jpg  binary
-*.jpeg binary
-*.jpx  binary
-*.jxr  binary
-*.pdf  binary
-*.png  binary
-*.psb  binary
-*.psd  binary
-*.svg  text
-*.svgz binary
-*.tif  binary
-*.tiff binary
-*.wbmp binary
-*.webp binary
-
-## AUDIO
-*.kar  binary
-*.m4a  binary
-*.mid  binary
-*.midi binary
-*.mp3  binary
-*.ogg  binary
-*.ra   binary
-
-## VIDEO
-*.3gpp binary
-*.3gp  binary
-*.as   binary
-*.asf  binary
-*.asx  binary
-*.fla  binary
-*.flv  binary
-*.m4v  binary
-*.mng  binary
-*.mov  binary
-*.mp4  binary
-*.mpeg binary
-*.mpg  binary
-*.ogv  binary
-*.swc  binary
-*.swf  binary
-*.webm binary
-
-## ARCHIVES
-*.7z  binary
-*.gz  binary
-*.jar binary
-*.rar binary
-*.tar binary
-*.zip binary
-
-## FONTS
-*.ttf   binary
-*.eot   binary
-*.otf   binary
-*.woff  binary
-*.woff2 binary
-
-## EXECUTABLES
-*.exe binary
-*.pyc binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -22,6 +22,11 @@
 *.sh       text
 *.bash     text
 *.fish     text
+#### asdf/bin/* explicitly define as text
+*asdf      text
+*asdf-exec text
+*_asdf     text
+#### asdf/test/fixtures/* should be covered by * text=auto on L14
 
 ## DOCKER
 *.dockerignore    text


### PR DESCRIPTION
# Summary

This seems relevant now we have users on Windows operating systems (I am one on occasion)

---

~I happy to trim some of these items as I copied from an old project. It seems https://gitattributes.io is down now so I can't grab a new default version.~
