### PR TITLE
feat: cmd to print debug information

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -32,13 +32,12 @@ Tell us what happened instead
 
 ### Environment
 
-**OS**:
+<!-- Copy the output of `asdf info` here -->
+```shell
 
-**asdf version**:
+```
 
 **asdf plugins affected (if relevant)**:
-
-**asdf plugins installed**:
 
 **Screenshots**
 If applicable, add screenshots to help explain your problem.

--- a/completions/_asdf
+++ b/completions/_asdf
@@ -30,6 +30,7 @@ asdf_commands=( # 'asdf help' lists commands with help text
   # utils
   'exec:executes the command shim for the current version'
   'env:prints or runs an executable under a command environment'
+  'info:print os, shell and asdf debug information'
   'reshim:recreate shims for version of a package'
   'shim:shim management sub-commands'
   'shim-versions:list for given command which plugins and versions provide it'

--- a/completions/asdf.bash
+++ b/completions/asdf.bash
@@ -56,7 +56,7 @@ _asdf() {
     fi
     ;;
   *)
-    local cmds='current global help install list list-all local plugin-add plugin-list plugin-list-all plugin-remove plugin-update reshim shell uninstall update where which '
+    local cmds='current global help install list list-all local plugin-add plugin-list plugin-list-all plugin-remove plugin-update reshim shell uninstall update where which info'
     # shellcheck disable=SC2207
     COMPREPLY=($(compgen -W "$cmds" -- "$cur"))
     ;;

--- a/completions/asdf.fish
+++ b/completions/asdf.fish
@@ -132,5 +132,5 @@ complete -f -c asdf -n '__fish_asdf_using_command shell; and test (count (comman
 
 # misc
 complete -f -c asdf -n '__fish_asdf_needs_command' -l "help" -d "Displays help"
-complete -f -c asdf -n '__fish_asdf_needs_command' -l "version" -d "Displays asdf version"
 complete -f -c asdf -m '__fish_asdf_needs_command' -l "info" -d "Print OS, Shell and ASDF debug information"
+complete -f -c asdf -n '__fish_asdf_needs_command' -l "version" -d "Displays asdf version"

--- a/completions/asdf.fish
+++ b/completions/asdf.fish
@@ -133,3 +133,4 @@ complete -f -c asdf -n '__fish_asdf_using_command shell; and test (count (comman
 # misc
 complete -f -c asdf -n '__fish_asdf_needs_command' -l "help" -d "Displays help"
 complete -f -c asdf -n '__fish_asdf_needs_command' -l "version" -d "Displays asdf version"
+complete -f -c asdf -m '__fish_asdf_needs_command' -l "info" -d "Print OS, Shell and ASDF debug information"

--- a/help.txt
+++ b/help.txt
@@ -14,7 +14,7 @@ asdf plugin update --all                Update all plugins
 
 MANAGE PACKAGES
 asdf install                            Install all the package versions listed
-                                        in the .tool-versions file 
+                                        in the .tool-versions file
 asdf install <name>                     Install one tool at the version
                                         specified in the .tool-versions file
 asdf install <name> <version>           Install a specific version of a package
@@ -45,6 +45,7 @@ UTILS
 asdf exec <command> [args...]           Executes the command shim for current version
 asdf env <command> [util]               Runs util (default: `env`) inside the
                                         environment used for command shim execution.
+asdf info                               Print OS, Shell and ASDF debug information.
 asdf reshim <name> <version>            Recreate shims for version of a package
 asdf shim-versions <command>            List the plugins and versions that
                                         provide a command

--- a/lib/commands/command-info.bash
+++ b/lib/commands/command-info.bash
@@ -1,0 +1,11 @@
+# -*- sh -*-
+
+info_command() {
+    printf "%s:\n%s\n\n" "OS" "$(uname -a)"
+    printf "%s:\n%s\n\n" "SHELL" "$($SHELL --version)"
+    printf "%s:\n%s\n\n" "ASDF VERSION" "$(asdf_version)"
+    printf "%s:\n%s\n\n" "ASDF ENVIRONMENT VARIABLES" "$(env | grep -E "ASDF_DIR|ASDF_DATA_DIR|ASDF_CONFIG_FILE|ASDF_DEFAULT_TOOL_VERSIONS_FILENAME")"
+    printf "%s:\n%s\n\n" "ASDF INSTALLED PLUGINS" "$(asdf plugin list --urls)"
+}
+
+info_command "$@"

--- a/lib/commands/command-info.bash
+++ b/lib/commands/command-info.bash
@@ -1,11 +1,11 @@
 # -*- sh -*-
 
 info_command() {
-    printf "%s:\n%s\n\n" "OS" "$(uname -a)"
-    printf "%s:\n%s\n\n" "SHELL" "$($SHELL --version)"
-    printf "%s:\n%s\n\n" "ASDF VERSION" "$(asdf_version)"
-    printf "%s:\n%s\n\n" "ASDF ENVIRONMENT VARIABLES" "$(env | grep -E "ASDF_DIR|ASDF_DATA_DIR|ASDF_CONFIG_FILE|ASDF_DEFAULT_TOOL_VERSIONS_FILENAME")"
-    printf "%s:\n%s\n\n" "ASDF INSTALLED PLUGINS" "$(asdf plugin list --urls)"
+  printf "%s:\n%s\n\n" "OS" "$(uname -a)"
+  printf "%s:\n%s\n\n" "SHELL" "$($SHELL --version)"
+  printf "%s:\n%s\n\n" "ASDF VERSION" "$(asdf_version)"
+  printf "%s:\n%s\n\n" "ASDF ENVIRONMENT VARIABLES" "$(env | grep -E "ASDF_DIR|ASDF_DATA_DIR|ASDF_CONFIG_FILE|ASDF_DEFAULT_TOOL_VERSIONS_FILENAME")"
+  printf "%s:\n%s\n\n" "ASDF INSTALLED PLUGINS" "$(asdf plugin list --urls)"
 }
 
 info_command "$@"

--- a/test/info_command.bats
+++ b/test/info_command.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+
+load test_helpers
+
+setup() {
+  setup_asdf_dir
+  install_dummy_plugin
+  install_dummy_legacy_plugin
+  run asdf install dummy 1.0
+  run asdf install dummy 1.1
+
+  PROJECT_DIR=$HOME/project
+  mkdir $PROJECT_DIR
+}
+
+teardown() {
+  clean_asdf_dir
+}
+
+@test "info should show os, shell and asdf debug information" {
+  cd $PROJECT_DIR
+
+  run asdf info
+
+  [ "$status" -eq 0 ]
+  # TODO: Assert asdf info output is printed
+}


### PR DESCRIPTION
# Summary

Add `asdf info` to enable easier debug info gathering for users.

Fixes: #786 

## Other Information

On my machine this prints:

```shell
.asdf on  master [?] 
➜ asdf info
OS:
Linux win10 4.19.104-microsoft-standard #1 SMP Wed Feb 19 06:37:35 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux

SHELL:
zsh 5.8 (x86_64-ubuntu-linux-gnu)

ASDF VERSION:
v0.8.0-rc1-d37e99a

ASDF ENVIRONMENT VARIABLES:
ASDF_DIR=/home/jthegedus/.asdf

ASDF INSTALLED PLUGINS:
deno                         https://github.com/asdf-community/asdf-deno.git
firebase                     https://github.com/jthegedus/asdf-firebase.git
gcloud                       https://github.com/jthegedus/asdf-gcloud.git
golang                       https://github.com/kennyp/asdf-golang.git
gradle                       https://github.com/rfrancis/asdf-gradle.git
hadolint                     https://github.com/looztra/asdf-hadolint.git
java                         https://github.com/halcyon/asdf-java.git
nodejs                       https://github.com/asdf-vm/asdf-nodejs.git
ocaml                        https://github.com/asdf-community/asdf-ocaml.git
python                       https://github.com/danhper/asdf-python.git
shellcheck                   https://github.com/luizm/asdf-shellcheck.git
shfmt                        https://github.com/luizm/asdf-shfmt.git
terraform                    https://github.com/Banno/asdf-hashicorp.git
```

I added space between each type of info to make it more readable as this information is for sharing in GitHub Issues and not a command I believe people will (or should) script around.