### PR TITLE
fix: _where_ bug when multiple versions are selected

### DIFF
--- a/lib/commands/command-where.bash
+++ b/lib/commands/command-where.bash
@@ -9,8 +9,11 @@ where_command() {
   local install_type="version"
   if [[ -z ${full_version} ]]; then
     local version_and_path
+    local versions
     version_and_path=$(find_versions "$plugin_name" "$PWD")
-    version=$(cut -d '|' -f 1 <<<"$version_and_path")
+    versions=$(cut -d '|' -f 1 <<<"$version_and_path")
+    IFS=' ' read -r -a plugin_versions <<<"$versions"
+    version="${plugin_versions[0]}"
   else
     local -a version_info
     IFS=':' read -r -a version_info <<<"$full_version"

--- a/test/where_command.bats
+++ b/test/where_command.bats
@@ -35,6 +35,13 @@ function teardown() {
   [ "$output" = "$ASDF_DIR/installs/dummy/2.1" ]
 }
 
+@test "where shows install location of first current version if not version specified and multiple current versions" {
+  echo 'dummy 2.1 1.0' >> $HOME/.tool-versions
+  run asdf where 'dummy'
+  [ "$status" -eq 0 ]
+  [ "$output" = "$ASDF_DIR/installs/dummy/2.1" ]
+}
+
 @test "where should error when the plugin doesn't exist" {
   run asdf where "foobar"
   [ "$status" -eq 1 ]


### PR DESCRIPTION
# Summary

Fixes a bug with `where` command when multiple versions are selected. See #690 for more information  

Fixes: #690