### PR TITLE
fix: fish init command

### DIFF
--- a/docs/core-manage-asdf-vm.md
+++ b/docs/core-manage-asdf-vm.md
@@ -223,7 +223,7 @@ echo -e "\n. $(brew --prefix asdf)/etc/bash_completion.d/asdf.bash" >> ~/.bash_p
 Add `asdf.fish` to your `~/.config/fish/config.fish` with:
 
 ```shell
-echo -e "\nsource $(brew --prefix asdf)/asdf.fish" >> ~/.config/fish/config.fish
+echo -e "\nsource "(brew --prefix asdf)"/asdf.fish" >> ~/.config/fish/config.fish
 ```
 
 ?> Completions are [handled by Homebrew for the Fish shell](https://docs.brew.sh/Shell-Completion#configuring-completions-in-fish). Friendly!


### PR DESCRIPTION
This pull request fixes the fish init script.

Currently, the subcommand works when run from bash-like shells but doesn't work from a fish shell.

Now, the subcommand uses `()` instead of `$()`. Also, the interpolated subcommand is now parsed properly as quotes need to be exited from. Using `source /usr/local/opt/asdf/asdf.fish` instead of `source (brew --prefix asdf)/asdf.fish` often saves well over a second when starting a new terminal session.