### PR TITLE
feat: support for "latest" in shell, local, and global

### DIFF
--- a/lib/commands/command-export-shell-version.bash
+++ b/lib/commands/command-export-shell-version.bash
@@ -29,6 +29,9 @@ shell_command() {
     esac
     exit 0
   fi
+  if [ "$version" = "latest" ]; then
+    version=$(asdf latest "$plugin")
+  fi
   if ! (check_if_version_exists "$plugin" "$version"); then
     version_not_installed_text "$plugin" "$version" 1>&2
     echo 'false'

--- a/lib/commands/version_commands.bash
+++ b/lib/commands/version_commands.bash
@@ -32,18 +32,23 @@ version_command() {
 
   check_if_plugin_exists "$plugin_name"
 
+  declare -a resolved_versions
   local version
   for version in "${versions[@]}"; do
+    if [ "$version" = "latest" ]; then
+      version=$(asdf latest "$plugin_name")
+    fi
     if ! (check_if_version_exists "$plugin_name" "$version"); then
       version_not_installed_text "$plugin_name" "$version" 1>&2
       exit 1
     fi
+    resolved_versions+=("$version")
   done
 
   if [ -f "$file" ] && grep "^$plugin_name " "$file" >/dev/null; then
-    sed -i.bak -e "s|^$plugin_name .*$|$plugin_name ${versions[*]}|" "$file"
+    sed -i.bak -e "s|^$plugin_name .*$|$plugin_name ${resolved_versions[*]}|" "$file"
     rm "$file".bak
   else
-    echo "$plugin_name ${versions[*]}" >>"$file"
+    echo "$plugin_name ${resolved_versions[*]}" >>"$file"
   fi
 }

--- a/test/fixtures/dummy_plugin/bin/list-all
+++ b/test/fixtures/dummy_plugin/bin/list-all
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-versions_list=(1.0 1.1 2.0)
+versions_list=(1.0.0 1.1.0 2.0.0)
 echo "${versions_list[@]}"

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -16,38 +16,38 @@ teardown() {
 }
 
 @test "install_command installs the correct version" {
-  run asdf install dummy 1.1
+  run asdf install dummy 1.1.0
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.1/version) = "1.1" ]
+  [ $(cat $ASDF_DIR/installs/dummy/1.1.0/version) = "1.1.0" ]
 }
 
 @test "install_command installs the correct version for plugins without download script" {
-  run asdf install legacy-dummy 1.1
+  run asdf install legacy-dummy 1.1.0
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/legacy-dummy/1.1/version) = "1.1" ]
+  [ $(cat $ASDF_DIR/installs/legacy-dummy/1.1.0/version) = "1.1.0" ]
 }
 
 @test "install_command without arguments installs even if the user is terrible and does not use newlines" {
   cd $PROJECT_DIR
-  echo -n 'dummy 1.2' > ".tool-versions"
+  echo -n 'dummy 1.2.0' > ".tool-versions"
   run asdf install
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.2/version) = "1.2" ]
+  [ $(cat $ASDF_DIR/installs/dummy/1.2.0/version) = "1.2.0" ]
 }
 
 @test "install_command with only name installs the version in .tool-versions" {
   cd $PROJECT_DIR
-  echo -n 'dummy 1.2' > ".tool-versions"
+  echo -n 'dummy 1.2.0' > ".tool-versions"
   run asdf install dummy
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.2/version) = "1.2" ]
+  [ $(cat $ASDF_DIR/installs/dummy/1.2.0/version) = "1.2.0" ]
 }
 
 @test "install_command set ASDF_CONCURRENCY" {
-  run asdf install dummy 1.0
+  run asdf install dummy 1.0.0
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/installs/dummy/1.0/env ]
-  run grep ASDF_CONCURRENCY $ASDF_DIR/installs/dummy/1.0/env
+  [ -f $ASDF_DIR/installs/dummy/1.0.0/env ]
+  run grep ASDF_CONCURRENCY $ASDF_DIR/installs/dummy/1.0.0/env
   [ "$status" -eq 0 ]
 }
 
@@ -55,55 +55,55 @@ teardown() {
   WHITESPACE_DIR="$PROJECT_DIR/whitespace\ dir"
   mkdir -p "$WHITESPACE_DIR"
   cd "$WHITESPACE_DIR"
-  echo 'dummy 1.2' >> "$WHITESPACE_DIR/.tool-versions"
+  echo 'dummy 1.2.0' >> "$WHITESPACE_DIR/.tool-versions"
 
   run asdf install
 
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.2/version) = "1.2" ]
+  [ $(cat $ASDF_DIR/installs/dummy/1.2.0/version) = "1.2.0" ]
 }
 
 @test "install_command should create a shim with asdf-plugin metadata" {
-  run asdf install dummy 1.0
+  run asdf install dummy 1.0.0
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/installs/dummy/1.0/env ]
-  run grep "asdf-plugin: dummy 1.0" $ASDF_DIR/shims/dummy
+  [ -f $ASDF_DIR/installs/dummy/1.0.0/env ]
+  run grep "asdf-plugin: dummy 1.0.0" $ASDF_DIR/shims/dummy
   [ "$status" -eq 0 ]
 }
 
 @test "install_command should create a shim with asdf-plugin metadata for plugins without download script" {
-  run asdf install legacy-dummy 1.0
+  run asdf install legacy-dummy 1.0.0
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/installs/legacy-dummy/1.0/env ]
-  run grep "asdf-plugin: legacy-dummy 1.0" $ASDF_DIR/shims/dummy
+  [ -f $ASDF_DIR/installs/legacy-dummy/1.0.0/env ]
+  run grep "asdf-plugin: legacy-dummy 1.0.0" $ASDF_DIR/shims/dummy
   [ "$status" -eq 0 ]
 }
 
 @test "install_command on two versions should create a shim with asdf-plugin metadata" {
-  run asdf install dummy 1.1
+  run asdf install dummy 1.1.0
   [ "$status" -eq 0 ]
 
-  run grep "asdf-plugin: dummy 1.1" $ASDF_DIR/shims/dummy
+  run grep "asdf-plugin: dummy 1.1.0" $ASDF_DIR/shims/dummy
   [ "$status" -eq 0 ]
 
-  run grep "asdf-plugin: dummy 1.0" $ASDF_DIR/shims/dummy
+  run grep "asdf-plugin: dummy 1.0.0" $ASDF_DIR/shims/dummy
   [ "$status" -eq 1 ]
 
-  run asdf install dummy 1.0
+  run asdf install dummy 1.0.0
   [ "$status" -eq 0 ]
-  run grep "asdf-plugin: dummy 1.0" $ASDF_DIR/shims/dummy
-  [ "$status" -eq 0 ]
-
-  run grep "# asdf-plugin: dummy 1.0"$'\n'"# asdf-plugin: dummy 1.1" $ASDF_DIR/shims/dummy
+  run grep "asdf-plugin: dummy 1.0.0" $ASDF_DIR/shims/dummy
   [ "$status" -eq 0 ]
 
-  lines_count=$(grep "asdf-plugin: dummy 1.1" $ASDF_DIR/shims/dummy | wc -l)
+  run grep "# asdf-plugin: dummy 1.0.0"$'\n'"# asdf-plugin: dummy 1.1.0" $ASDF_DIR/shims/dummy
+  [ "$status" -eq 0 ]
+
+  lines_count=$(grep "asdf-plugin: dummy 1.1.0" $ASDF_DIR/shims/dummy | wc -l)
   [ "$lines_count" -eq "1" ]
 }
 
 @test "install_command without arguments should not generate shim for subdir" {
   cd $PROJECT_DIR
-  echo 'dummy 1.0' > $PROJECT_DIR/.tool-versions
+  echo 'dummy 1.0.0' > $PROJECT_DIR/.tool-versions
 
   run asdf install
   [ "$status" -eq 0 ]
@@ -116,44 +116,44 @@ teardown() {
   cp -rf $BATS_TEST_DIRNAME/../{bin,lib} $ASDF_DIR/
 
   cd $PROJECT_DIR
-  echo 'dummy 1.0' > $PROJECT_DIR/.tool-versions
+  echo 'dummy 1.0.0' > $PROJECT_DIR/.tool-versions
   run asdf install
 
   # execute the generated shim
   run $ASDF_DIR/shims/dummy world hello
   [ "$status" -eq 0 ]
-  [ "$output" == "This is Dummy 1.0! hello world" ]
+  [ "$output" == "This is Dummy 1.0.0! hello world" ]
 }
 
 @test "install_command fails when tool is specified but no version of the tool is configured" {
   run asdf install dummy
   [ "$status" -eq 1 ]
   [ "$output" = "No versions specified for dummy in config files or environment" ]
-  [ ! -f $ASDF_DIR/installs/dummy/1.1/version ]
+  [ ! -f $ASDF_DIR/installs/dummy/1.1.0/version ]
 }
 
 @test "install_command fails when tool is specified but no version of the tool is configured in config file" {
-  echo 'dummy 1.0' > $PROJECT_DIR/.tool-versions
+  echo 'dummy 1.0.0' > $PROJECT_DIR/.tool-versions
   run asdf install other-dummy
   [ "$status" -eq 1 ]
   [ "$output" = "No versions specified for other-dummy in config files or environment" ]
-  [ ! -f $ASDF_DIR/installs/dummy/1.0/version ]
+  [ ! -f $ASDF_DIR/installs/dummy/1.0.0/version ]
 }
 
 @test "install_command fails when two tools are specified with no versions" {
-  printf 'dummy 1.0\nother-dummy 2.0' > $PROJECT_DIR/.tool-versions
+  printf 'dummy 1.0.0\nother-dummy 2.0.0' > $PROJECT_DIR/.tool-versions
   run asdf install dummy other-dummy
   [ "$status" -eq 1 ]
   [ "$output" = "Dummy couldn't install version: other-dummy (on purpose)" ]
-  [ ! -f $ASDF_DIR/installs/dummy/1.0/version ]
-  [ ! -f $ASDF_DIR/installs/other-dummy/2.0/version ]
+  [ ! -f $ASDF_DIR/installs/dummy/1.0.0/version ]
+  [ ! -f $ASDF_DIR/installs/other-dummy/2.0.0/version ]
 }
 
 @test "install_command without arguments uses a parent directory .tool-versions file if present" {
   # asdf lib needed to run generated shims
   cp -rf $BATS_TEST_DIRNAME/../{bin,lib} $ASDF_DIR/
 
-  echo 'dummy 1.0' > $PROJECT_DIR/.tool-versions
+  echo 'dummy 1.0.0' > $PROJECT_DIR/.tool-versions
   mkdir -p $PROJECT_DIR/child
 
   cd $PROJECT_DIR/child
@@ -161,20 +161,20 @@ teardown() {
   run asdf install
 
   # execute the generated shim
-  [ "$($ASDF_DIR/shims/dummy world hello)" == "This is Dummy 1.0! hello world" ]
+  [ "$($ASDF_DIR/shims/dummy world hello)" == "This is Dummy 1.0.0! hello world" ]
   [ "$status" -eq 0 ]
 }
 
 @test "install_command installs multiple tool versions when they are specified in a .tool-versions file" {
-  echo 'dummy 1.0 1.2' > $PROJECT_DIR/.tool-versions
+  echo 'dummy 1.0.0 1.2.0' > $PROJECT_DIR/.tool-versions
   cd $PROJECT_DIR
 
   run asdf install
   echo $output
   [ "$status" -eq 0 ]
 
-  [ $(cat $ASDF_DIR/installs/dummy/1.0/version) = "1.0" ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.2/version) = "1.2" ]
+  [ $(cat $ASDF_DIR/installs/dummy/1.0.0/version) = "1.0.0" ]
+  [ $(cat $ASDF_DIR/installs/dummy/1.2.0/version) = "1.2.0" ]
 }
 
 @test "install_command doesn't install system version" {
@@ -188,8 +188,8 @@ teardown() {
 pre_asdf_install_dummy = echo will install dummy $1
 EOM
 
-  run asdf install dummy 1.0
-  [ "$output" == "will install dummy 1.0" ]
+  run asdf install dummy 1.0.0
+  [ "$output" == "will install dummy 1.0.0" ]
 }
 
 @test "install command executes configured post plugin install hook" {
@@ -197,23 +197,23 @@ EOM
 post_asdf_install_dummy = echo HEY $version FROM $plugin_name
 EOM
 
-  run asdf install dummy 1.0
-  [ "$output" == "HEY 1.0 FROM dummy" ]
+  run asdf install dummy 1.0.0
+  [ "$output" == "HEY 1.0.0 FROM dummy" ]
 }
 
 @test "install command without arguments installs versions from legacy files" {
   echo 'legacy_version_file = yes' > $HOME/.asdfrc
-  echo '1.2' >> $PROJECT_DIR/.dummy-version
+  echo '1.2.0' >> $PROJECT_DIR/.dummy-version
   cd $PROJECT_DIR
   run asdf install
   [ "$status" -eq 0 ]
   [ "$output" == "" ]
-  [ -f $ASDF_DIR/installs/dummy/1.2/version ]
+  [ -f $ASDF_DIR/installs/dummy/1.2.0/version ]
 }
 
 @test "install command without arguments installs versions from legacy files in parent directories" {
   echo 'legacy_version_file = yes' > $HOME/.asdfrc
-  echo '1.2' >> $PROJECT_DIR/.dummy-version
+  echo '1.2.0' >> $PROJECT_DIR/.dummy-version
 
   mkdir -p $PROJECT_DIR/child
   cd $PROJECT_DIR/child
@@ -221,40 +221,40 @@ EOM
   run asdf install
   [ "$status" -eq 0 ]
   [ "$output" == "" ]
-  [ -f $ASDF_DIR/installs/dummy/1.2/version ]
+  [ -f $ASDF_DIR/installs/dummy/1.2.0/version ]
 }
 
 @test "install_command latest installs latest stable version" {
   run asdf install dummy latest
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/2.0/version) = "2.0" ]
+  [ $(cat $ASDF_DIR/installs/dummy/2.0.0/version) = "2.0.0" ]
 }
 
 @test "install_command latest:version installs latest stable version that matches the given string" {
   run asdf install dummy latest:1
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.1/version) = "1.1" ]
+  [ $(cat $ASDF_DIR/installs/dummy/1.1.0/version) = "1.1.0" ]
 }
 
 @test "install_command deletes the download directory" {
-  run asdf install dummy 1.1
+  run asdf install dummy 1.1.0
   [ "$status" -eq 0 ]
-  [ ! -d $ASDF_DIR/downloads/dummy/1.1 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.1/version) = "1.1" ]
+  [ ! -d $ASDF_DIR/downloads/dummy/1.1.0 ]
+  [ $(cat $ASDF_DIR/installs/dummy/1.1.0/version) = "1.1.0" ]
 }
 
 @test "install_command keeps the download directory when --keep-download flag is provided" {
-  run asdf install dummy 1.1 --keep-download
+  run asdf install dummy 1.1.0 --keep-download
   [ "$status" -eq 0 ]
-  [ -d $ASDF_DIR/downloads/dummy/1.1 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.1/version) = "1.1" ]
+  [ -d $ASDF_DIR/downloads/dummy/1.1.0 ]
+  [ $(cat $ASDF_DIR/installs/dummy/1.1.0/version) = "1.1.0" ]
 }
 
 @test "install_command keeps the download directory when always_keep_download setting is true" {
   echo 'always_keep_download = yes' > $HOME/.asdfrc
-  run asdf install dummy 1.1
+  run asdf install dummy 1.1.0
   echo $output
   [ "$status" -eq 0 ]
-  [ -d $ASDF_DIR/downloads/dummy/1.1 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.1/version) = "1.1" ]
+  [ -d $ASDF_DIR/downloads/dummy/1.1.0 ]
+  [ $(cat $ASDF_DIR/installs/dummy/1.1.0/version) = "1.1.0" ]
 }

--- a/test/latest_command.bats
+++ b/test/latest_command.bats
@@ -13,12 +13,12 @@ teardown() {
 
 @test "latest_command shows latest stable version" {
   run asdf latest dummy
-  [ "$(echo -e "2.0")" == "$output" ]
+  [ "$(echo -e "2.0.0")" == "$output" ]
   [ "$status" -eq 0 ]
 }
 
 @test "latest_command with version shows latest stable version that matches the given string" {
   run asdf latest dummy 1
-  [ "$(echo -e "1.1")" == "$output" ]
+  [ "$(echo -e "1.1.0")" == "$output" ]
   [ "$status" -eq 0 ]
 }

--- a/test/list_command.bats
+++ b/test/list_command.bats
@@ -12,10 +12,10 @@ teardown() {
 }
 
 @test "list_command should list plugins with installed versions" {
-  run asdf install dummy 1.0
-  run asdf install dummy 1.1
+  run asdf install dummy 1.0.0
+  run asdf install dummy 1.1.0
   run asdf list
-  [ "$(echo -e "dummy\n  1.0\n  1.1")" == "$output" ]
+  [ "$(echo -e "dummy\n  1.0.0\n  1.1.0")" == "$output" ]
   [ "$status" -eq 0 ]
 }
 
@@ -23,29 +23,29 @@ teardown() {
   run install_mock_plugin "dummy"
   run install_mock_plugin "mummy"
   run install_mock_plugin "tummy"
-  run asdf install dummy 1.0
-  run asdf install tummy 2.0
+  run asdf install dummy 1.0.0
+  run asdf install tummy 2.0.0
   run asdf list
-  [ "$(echo -e "dummy\n  1.0\nmummy\n  No versions installed\ntummy\n  2.0")" == "$output" ]
+  [ "$(echo -e "dummy\n  1.0.0\nmummy\n  No versions installed\ntummy\n  2.0.0")" == "$output" ]
   [ "$status" -eq 0 ]
 }
 
 @test "list_command with plugin should list installed versions" {
-  run asdf install dummy 1.0
-  run asdf install dummy 1.1
+  run asdf install dummy 1.0.0
+  run asdf install dummy 1.1.0
   run asdf list dummy
-  [ "$(echo -e "  1.0\n  1.1")" == "$output" ]
+  [ "$(echo -e "  1.0.0\n  1.1.0")" == "$output" ]
   [ "$status" -eq 0 ]
 }
 
 @test "list_all_command lists available versions" {
   run asdf list-all dummy
-  [ "$(echo -e "1.0\n1.1\n2.0")" == "$output" ]
+  [ "$(echo -e "1.0.0\n1.1.0\n2.0.0")" == "$output" ]
   [ "$status" -eq 0 ]
 }
 
 @test "list_all_command with version filters available versions" {
   run asdf list-all dummy 1
-  [ "$(echo -e "1.0\n1.1")" == "$output" ]
+  [ "$(echo -e "1.0.0\n1.1.0")" == "$output" ]
   [ "$status" -eq 0 ]
 }

--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -82,7 +82,7 @@ teardown() {
 
 @test "shim exec should suggest which plugin to use when no version is selected" {
   run asdf install dummy 1.0
-  run asdf install dummy 2.0
+  run asdf install dummy 2.0.0
 
   touch $PROJECT_DIR/.tool-versions
 
@@ -92,7 +92,7 @@ teardown() {
   echo "$output" | grep -q "No version set for command dummy" 2>/dev/null
   echo "$output" | grep -q "Consider adding one of the following versions in your config file at $PROJECT_DIR/.tool-versions" 2>/dev/null
   echo "$output" | grep -q "dummy 1.0" 2>/dev/null
-  echo "$output" | grep -q "dummy 2.0" 2>/dev/null
+  echo "$output" | grep -q "dummy 2.0.0" 2>/dev/null
 }
 
 @test "shim exec should suggest different plugins providing same tool when no version is selected" {
@@ -116,23 +116,23 @@ teardown() {
 @test "shim exec should suggest to install missing version" {
   run asdf install dummy 1.0
 
-  echo "dummy 2.0 1.3" > $PROJECT_DIR/.tool-versions
+  echo "dummy 2.0.0 1.3" > $PROJECT_DIR/.tool-versions
 
   run $ASDF_DIR/shims/dummy world hello
   [ "$status" -eq 126 ]
   echo "$output" | grep -q "No preset version installed for command dummy" 2>/dev/null
   echo "$output" | grep -q "Please install a version by running one of the following:" 2>/dev/null
-  echo "$output" | grep -q "asdf install dummy 2.0" 2>/dev/null
+  echo "$output" | grep -q "asdf install dummy 2.0.0" 2>/dev/null
   echo "$output" | grep -q "asdf install dummy 1.3" 2>/dev/null
   echo "$output" | grep -q "or add one of the following versions in your config file at $PROJECT_DIR/.tool-versions" 2>/dev/null
   echo "$output" | grep -q "dummy 1.0" 2>/dev/null
 }
 
 @test "shim exec should execute first plugin that is installed and set" {
-  run asdf install dummy 2.0
+  run asdf install dummy 2.0.0
   run asdf install dummy 3.0
 
-  echo "dummy 1.0 3.0 2.0" > $PROJECT_DIR/.tool-versions
+  echo "dummy 1.0 3.0 2.0.0" > $PROJECT_DIR/.tool-versions
 
   run $ASDF_DIR/shims/dummy world hello
   [ "$status" -eq 0 ]
@@ -183,7 +183,7 @@ teardown() {
   run asdf install dummy 1.0
   run asdf install mummy 3.0
 
-  echo "dummy 2.0" > $PROJECT_DIR/.tool-versions
+  echo "dummy 2.0.0" > $PROJECT_DIR/.tool-versions
   echo "mummy 3.0" >> $PROJECT_DIR/.tool-versions
   echo "dummy 1.0" >> $PROJECT_DIR/.tool-versions
 
@@ -221,10 +221,10 @@ teardown() {
 }
 
 @test "shim exec should execute system if set first" {
-  run asdf install dummy 2.0
+  run asdf install dummy 2.0.0
 
   echo "dummy system" > $PROJECT_DIR/.tool-versions
-  echo "dummy 2.0" >> $PROJECT_DIR/.tool-versions
+  echo "dummy 2.0.0" >> $PROJECT_DIR/.tool-versions
 
   mkdir $PROJECT_DIR/foo/
   echo "echo System" > $PROJECT_DIR/foo/dummy
@@ -235,38 +235,38 @@ teardown() {
 }
 
 @test "shim exec should use custom exec-env for tool" {
-  run asdf install dummy 2.0
+  run asdf install dummy 2.0.0
   echo "export FOO=sourced" > $ASDF_DIR/plugins/dummy/bin/exec-env
   mkdir $ASDF_DIR/plugins/dummy/shims
   echo 'echo $FOO custom' > $ASDF_DIR/plugins/dummy/shims/foo
   chmod +x $ASDF_DIR/plugins/dummy/shims/foo
-  run asdf reshim dummy 2.0
+  run asdf reshim dummy 2.0.0
 
-  echo "dummy 2.0" > $PROJECT_DIR/.tool-versions
+  echo "dummy 2.0.0" > $PROJECT_DIR/.tool-versions
   run $ASDF_DIR/shims/foo
   [ "$output" == "sourced custom" ]
 }
 
 @test "shim exec with custom exec-env using ASDF_INSTALL_PATH" {
-  run asdf install dummy 2.0
+  run asdf install dummy 2.0.0
   echo 'export FOO=$ASDF_INSTALL_PATH/foo' > $ASDF_DIR/plugins/dummy/bin/exec-env
   mkdir $ASDF_DIR/plugins/dummy/shims
   echo 'echo $FOO custom' > $ASDF_DIR/plugins/dummy/shims/foo
   chmod +x $ASDF_DIR/plugins/dummy/shims/foo
-  run asdf reshim dummy 2.0
+  run asdf reshim dummy 2.0.0
 
-  echo "dummy 2.0" > $PROJECT_DIR/.tool-versions
+  echo "dummy 2.0.0" > $PROJECT_DIR/.tool-versions
   run $ASDF_DIR/shims/foo
-  [ "$output" == "$ASDF_DIR/installs/dummy/2.0/foo custom" ]
+  [ "$output" == "$ASDF_DIR/installs/dummy/2.0.0/foo custom" ]
 }
 
 @test "shim exec doest not use custom exec-env for system version" {
-  run asdf install dummy 2.0
+  run asdf install dummy 2.0.0
   echo "export FOO=sourced" > $ASDF_DIR/plugins/dummy/bin/exec-env
   mkdir $ASDF_DIR/plugins/dummy/shims
   echo 'echo $FOO custom' > $ASDF_DIR/plugins/dummy/shims/foo
   chmod +x $ASDF_DIR/plugins/dummy/shims/foo
-  run asdf reshim dummy 2.0
+  run asdf reshim dummy 2.0.0
 
   echo "dummy system" > $PROJECT_DIR/.tool-versions
 
@@ -279,24 +279,24 @@ teardown() {
 }
 
 @test "shim exec should prepend the plugin paths on execution" {
-  run asdf install dummy 2.0
+  run asdf install dummy 2.0.0
 
   mkdir $ASDF_DIR/plugins/dummy/shims
   echo 'which dummy' > $ASDF_DIR/plugins/dummy/shims/foo
   chmod +x $ASDF_DIR/plugins/dummy/shims/foo
-  run asdf reshim dummy 2.0
+  run asdf reshim dummy 2.0.0
 
-  echo "dummy 2.0" > $PROJECT_DIR/.tool-versions
+  echo "dummy 2.0.0" > $PROJECT_DIR/.tool-versions
 
   run $ASDF_DIR/shims/foo
-  [ "$output" == "$ASDF_DIR/installs/dummy/2.0/bin/dummy" ]
+  [ "$output" == "$ASDF_DIR/installs/dummy/2.0.0/bin/dummy" ]
 }
 
 @test "shim exec should be able to find other shims in path" {
   cp -rf $ASDF_DIR/plugins/dummy $ASDF_DIR/plugins/gummy
 
-  echo "dummy 2.0" > $PROJECT_DIR/.tool-versions
-  echo "gummy 2.0" >> $PROJECT_DIR/.tool-versions
+  echo "dummy 2.0.0" > $PROJECT_DIR/.tool-versions
+  echo "gummy 2.0.0" >> $PROJECT_DIR/.tool-versions
 
   run asdf install
 
@@ -314,14 +314,14 @@ teardown() {
   run asdf reshim
 
   run $ASDF_DIR/shims/foo
-  [ "$output" == "$ASDF_DIR/installs/dummy/2.0/bin/dummy" ]
+  [ "$output" == "$ASDF_DIR/installs/dummy/2.0.0/bin/dummy" ]
 
   run $ASDF_DIR/shims/bar
   [ "$output" == "$ASDF_DIR/shims/gummy" ]
 }
 
 @test "shim exec should remove shim_path from path on system version execution" {
-  run asdf install dummy 2.0
+  run asdf install dummy 2.0.0
 
   echo "dummy system" > $PROJECT_DIR/.tool-versions
 
@@ -336,19 +336,19 @@ teardown() {
 
 
 @test "shim exec can take version from legacy file if configured" {
-  run asdf install dummy 2.0
+  run asdf install dummy 2.0.0
 
   echo "legacy_version_file = yes" > $HOME/.asdfrc
-  echo "2.0" > $PROJECT_DIR/.dummy-version
+  echo "2.0.0" > $PROJECT_DIR/.dummy-version
 
   run $ASDF_DIR/shims/dummy world hello
-  [ "$output" == "This is Dummy 2.0! hello world" ]
+  [ "$output" == "This is Dummy 2.0.0! hello world" ]
 }
 
 @test "shim exec can take version from environment variable" {
-  run asdf install dummy 2.0
-  run env ASDF_DUMMY_VERSION=2.0 $ASDF_DIR/shims/dummy world hello
-  [ "$output" == "This is Dummy 2.0! hello world" ]
+  run asdf install dummy 2.0.0
+  run env ASDF_DUMMY_VERSION=2.0.0 $ASDF_DIR/shims/dummy world hello
+  [ "$output" == "This is Dummy 2.0.0! hello world" ]
 }
 
 @test "shim exec uses plugin list-bin-paths" {

--- a/test/uninstall_command.bats
+++ b/test/uninstall_command.bats
@@ -21,65 +21,65 @@ teardown() {
 }
 
 @test "uninstall_command should remove the plugin with that version from asdf" {
-  run asdf install dummy 1.1
+  run asdf install dummy 1.1.0
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.1/version) = "1.1" ]
-  run asdf uninstall dummy 1.1
-  [ ! -f  $ASDF_DIR/installs/dummy/1.1/version ]
+  [ $(cat $ASDF_DIR/installs/dummy/1.1.0/version) = "1.1.0" ]
+  run asdf uninstall dummy 1.1.0
+  [ ! -f  $ASDF_DIR/installs/dummy/1.1.0/version ]
 }
 
 @test "uninstall_command should invoke the plugin bin/uninstall if available" {
-  run asdf install dummy 1.1
+  run asdf install dummy 1.1.0
   [ "$status" -eq 0 ]
   mkdir -p $ASDF_DIR/plugins/dummy/bin
   echo "echo custom uninstall" > $ASDF_DIR/plugins/dummy/bin/uninstall
   chmod 755 $ASDF_DIR/plugins/dummy/bin/uninstall
-  run asdf uninstall dummy 1.1
+  run asdf uninstall dummy 1.1.0
   [ "$output" == "custom uninstall" ]
   [ "$status" -eq 0 ]
 }
 
 @test "uninstall_command should remove the plugin shims if no other version is installed" {
-  run asdf install dummy 1.1
+  run asdf install dummy 1.1.0
   [ -f $ASDF_DIR/shims/dummy ]
-  run asdf uninstall dummy 1.1
+  run asdf uninstall dummy 1.1.0
   [ ! -f $ASDF_DIR/shims/dummy ]
 }
 
 @test "uninstall_command should leave the plugin shims if other version is installed" {
-  run asdf install dummy 1.0
-  [ -f $ASDF_DIR/installs/dummy/1.0/bin/dummy ]
+  run asdf install dummy 1.0.0
+  [ -f $ASDF_DIR/installs/dummy/1.0.0/bin/dummy ]
 
-  run asdf install dummy 1.1
-  [ -f $ASDF_DIR/installs/dummy/1.1/bin/dummy ]
+  run asdf install dummy 1.1.0
+  [ -f $ASDF_DIR/installs/dummy/1.1.0/bin/dummy ]
 
   [ -f $ASDF_DIR/shims/dummy ]
-  run asdf uninstall dummy 1.0
+  run asdf uninstall dummy 1.0.0
   [ -f $ASDF_DIR/shims/dummy ]
 }
 
 @test "uninstall_command should remove relevant asdf-plugin metadata" {
-  run asdf install dummy 1.0
-  [ -f $ASDF_DIR/installs/dummy/1.0/bin/dummy ]
+  run asdf install dummy 1.0.0
+  [ -f $ASDF_DIR/installs/dummy/1.0.0/bin/dummy ]
 
-  run asdf install dummy 1.1
-  [ -f $ASDF_DIR/installs/dummy/1.1/bin/dummy ]
+  run asdf install dummy 1.1.0
+  [ -f $ASDF_DIR/installs/dummy/1.1.0/bin/dummy ]
 
-  run asdf uninstall dummy 1.0
-  run grep "asdf-plugin: dummy 1.1" $ASDF_DIR/shims/dummy
+  run asdf uninstall dummy 1.0.0
+  run grep "asdf-plugin: dummy 1.1.0" $ASDF_DIR/shims/dummy
   [ "$status" -eq 0 ]
-  run grep "asdf-plugin: dummy 1.0" $ASDF_DIR/shims/dummy
+  run grep "asdf-plugin: dummy 1.0.0" $ASDF_DIR/shims/dummy
   [ "$status" -eq 1 ]
 }
 
 @test "uninstall_command should not remove other unrelated shims" {
-  run asdf install dummy 1.0
+  run asdf install dummy 1.0.0
   [ -f $ASDF_DIR/shims/dummy ]
 
   touch $ASDF_DIR/shims/gummy
   [ -f $ASDF_DIR/shims/gummy ]
 
-  run asdf uninstall dummy 1.0
+  run asdf uninstall dummy 1.0.0
   [ -f $ASDF_DIR/shims/gummy ]
 }
 
@@ -88,9 +88,9 @@ teardown() {
 pre_asdf_uninstall_dummy = echo will uninstall dummy $1
 EOM
 
-  run asdf install dummy 1.0
-  run asdf uninstall dummy 1.0
-  [ "$output" == "will uninstall dummy 1.0" ]
+  run asdf install dummy 1.0.0
+  run asdf uninstall dummy 1.0.0
+  [ "$output" == "will uninstall dummy 1.0.0" ]
 }
 
 @test "uninstall command executes configured post hook" {
@@ -98,8 +98,8 @@ EOM
 post_asdf_uninstall_dummy = echo removed dummy $1
 EOM
 
-  run asdf install dummy 1.0
-  run asdf uninstall dummy 1.0
+  run asdf install dummy 1.0.0
+  run asdf uninstall dummy 1.0.0
   echo $output
-  [ "$output" == "removed dummy 1.0" ]
+  [ "$output" == "removed dummy 1.0.0" ]
 }

--- a/test/update_command.bats
+++ b/test/update_command.bats
@@ -74,15 +74,15 @@ teardown() {
 }
 
 @test "asdf update should not remove plugin versions" {
-  run asdf install dummy 1.1
+  run asdf install dummy 1.1.0
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.1/version) = "1.1" ]
+  [ $(cat $ASDF_DIR/installs/dummy/1.1.0/version) = "1.1.0" ]
   run asdf update
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/installs/dummy/1.1/version ]
+  [ -f $ASDF_DIR/installs/dummy/1.1.0/version ]
   run asdf update --head
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/installs/dummy/1.1/version ]
+  [ -f $ASDF_DIR/installs/dummy/1.1.0/version ]
 }
 
 @test "asdf update should not remove plugins" {
@@ -96,7 +96,7 @@ teardown() {
 }
 
 @test "asdf update should not remove shims" {
-  run asdf install dummy 1.1
+  run asdf install dummy 1.1.0
   [ -f $ASDF_DIR/shims/dummy ]
   run asdf update
   [ "$status" -eq 0 ]

--- a/test/version_commands.bats
+++ b/test/version_commands.bats
@@ -5,8 +5,9 @@ load test_helpers
 setup() {
   setup_asdf_dir
   install_dummy_plugin
-  install_dummy_version "1.0.0"
-  install_dummy_version "1.1.0"
+  install_dummy_version "1.0"
+  install_dummy_version "1.1"
+  install_dummy_version "2.0"
 
   PROJECT_DIR=$HOME/project
   mkdir -p $PROJECT_DIR
@@ -29,7 +30,7 @@ teardown() {
 }
 
 @test "local should emit an error when plugin does not exist" {
-  run asdf local "inexistent" "1.0.0"
+  run asdf local "inexistent" "1.0"
   [ "$status" -eq 1 ]
   [ "$output" = "No such plugin: inexistent" ]
 }
@@ -41,15 +42,15 @@ teardown() {
 }
 
 @test "local should create a local .tool-versions file if it doesn't exist" {
-  run asdf local "dummy" "1.1.0"
+  run asdf local "dummy" "1.1"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0" ]
+  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1" ]
 }
 
 @test "local should allow multiple versions" {
-  run asdf local "dummy" "1.1.0" "1.0.0"
+  run asdf local "dummy" "1.1" "1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0 1.0.0" ]
+  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1 1.0" ]
 }
 
 @test "local should create a local .tool-versions file if it doesn't exist when the directory name contains whitespace" {
@@ -57,26 +58,26 @@ teardown() {
   mkdir -p "$WHITESPACE_DIR"
   cd "$WHITESPACE_DIR"
 
-  run asdf local "dummy" "1.1.0"
+  run asdf local "dummy" "1.1"
 
   tool_version_contents=$(cat "$WHITESPACE_DIR/.tool-versions")
   [ "$status" -eq 0 ]
-  [ "$tool_version_contents" = "dummy 1.1.0" ]
+  [ "$tool_version_contents" = "dummy 1.1" ]
 }
 
 @test "local should not create a duplicate .tool-versions file if such file exists" {
-  echo 'dummy 1.0.0' >> $PROJECT_DIR/.tool-versions
+  echo 'dummy 1.0' >> $PROJECT_DIR/.tool-versions
 
-  run asdf local "dummy" "1.1.0"
+  run asdf local "dummy" "1.1"
   [ "$status" -eq 0 ]
   [ "$(ls $PROJECT_DIR/.tool-versions* | wc -l)" -eq 1 ]
 }
 
 @test "local should overwrite the existing version if it's set" {
-  echo 'dummy 1.0.0' >> $PROJECT_DIR/.tool-versions
-  run asdf local "dummy" "1.1.0"
+  echo 'dummy 1.0' >> $PROJECT_DIR/.tool-versions
+  run asdf local "dummy" "1.1"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0" ]
+  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1" ]
 }
 
 @test "local should fail to set a path:dir if dir does not exists " {
@@ -99,7 +100,7 @@ teardown() {
 }
 
 @test "local -p/--parent should emit an error when plugin does not exist" {
-  run asdf local -p "inexistent" "1.0.0"
+  run asdf local -p "inexistent" "1.0"
   [ "$status" -eq 1 ]
   [ "$output" = "No such plugin: inexistent" ]
 }
@@ -113,44 +114,44 @@ teardown() {
 @test "local -p/--parent should allow multiple versions" {
   cd $CHILD_DIR
   touch $PROJECT_DIR/.tool-versions
-  run asdf local -p "dummy" "1.1.0" "1.0.0"
+  run asdf local -p "dummy" "1.1" "1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0 1.0.0" ]
+  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1 1.0" ]
 }
 
 @test "local -p/--parent should overwrite the existing version if it's set" {
   cd $CHILD_DIR
-  echo 'dummy 1.0.0' >> $PROJECT_DIR/.tool-versions
-  run asdf local -p "dummy" "1.1.0"
+  echo 'dummy 1.0' >> $PROJECT_DIR/.tool-versions
+  run asdf local -p "dummy" "1.1"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0" ]
+  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1" ]
 }
 
 @test "local -p/--parent should set the version if it's unset" {
   cd $CHILD_DIR
   touch $PROJECT_DIR/.tool-versions
-  run asdf local -p "dummy" "1.1.0"
+  run asdf local -p "dummy" "1.1"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0" ]
+  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1" ]
 }
 
 @test "global should create a global .tool-versions file if it doesn't exist" {
-  run asdf global "dummy" "1.1.0"
+  run asdf global "dummy" "1.1"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "dummy 1.1.0" ]
+  [ "$(cat $HOME/.tool-versions)" = "dummy 1.1" ]
 }
 
 @test "global should accept multiple versions" {
-  run asdf global "dummy" "1.1.0" "1.0.0"
+  run asdf global "dummy" "1.1" "1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "dummy 1.1.0 1.0.0" ]
+  [ "$(cat $HOME/.tool-versions)" = "dummy 1.1 1.0" ]
 }
 
 @test "global should overwrite the existing version if it's set" {
-  echo 'dummy 1.0.0' >> $HOME/.tool-versions
-  run asdf global "dummy" "1.1.0"
+  echo 'dummy 1.0' >> $HOME/.tool-versions
+  run asdf global "dummy" "1.1"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "dummy 1.1.0" ]
+  [ "$(cat $HOME/.tool-versions)" = "dummy 1.1" ]
 }
 
 @test "global should fail to set a path:dir if dir does not exists " {
@@ -168,19 +169,19 @@ teardown() {
 
 @test "global should write to ASDF_DEFAULT_TOOL_VERSIONS_FILENAME" {
   export ASDF_DEFAULT_TOOL_VERSIONS_FILENAME="$PROJECT_DIR/global-tool-versions"
-  run asdf global "dummy" "1.1.0"
+  run asdf global "dummy" "1.1"
   [ "$status" -eq 0 ]
-  [ "$(cat $ASDF_DEFAULT_TOOL_VERSIONS_FILENAME)" = "dummy 1.1.0" ]
+  [ "$(cat $ASDF_DEFAULT_TOOL_VERSIONS_FILENAME)" = "dummy 1.1" ]
   [ "$(cat $HOME/.tool-versions)" = "" ]
   unset ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
 }
 
 @test "global should overwrite contents of ASDF_DEFAULT_TOOL_VERSIONS_FILENAME if set" {
   export ASDF_DEFAULT_TOOL_VERSIONS_FILENAME="$PROJECT_DIR/global-tool-versions"
-  echo 'dummy 1.0.0' >> "$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME"
-  run asdf global "dummy" "1.1.0"
+  echo 'dummy 1.0' >> "$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME"
+  run asdf global "dummy" "1.1"
   [ "$status" -eq 0 ]
-  [ "$(cat $ASDF_DEFAULT_TOOL_VERSIONS_FILENAME)" = "dummy 1.1.0" ]
+  [ "$(cat $ASDF_DEFAULT_TOOL_VERSIONS_FILENAME)" = "dummy 1.1" ]
   [ "$(cat $HOME/.tool-versions)" = "" ]
   unset ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
 }
@@ -189,21 +190,21 @@ teardown() {
   mkdir other-dir
   touch other-dir/.tool-versions
   ln -s other-dir/.tool-versions .tool-versions
-  run asdf local "dummy" "1.1.0"
+  run asdf local "dummy" "1.1"
   [ "$status" -eq 0 ]
   [ -L .tool-versions ]
-  [ "$(cat other-dir/.tool-versions)" = "dummy 1.1.0" ]
+  [ "$(cat other-dir/.tool-versions)" = "dummy 1.1" ]
 }
 
 @test "local should preserve symlinks when updating versions" {
   mkdir other-dir
   touch other-dir/.tool-versions
   ln -s other-dir/.tool-versions .tool-versions
-  run asdf local "dummy" "1.1.0"
-  run asdf local "dummy" "1.1.0"
+  run asdf local "dummy" "1.1"
+  run asdf local "dummy" "1.1"
   [ "$status" -eq 0 ]
   [ -L .tool-versions ]
-  [ "$(cat other-dir/.tool-versions)" = "dummy 1.1.0" ]
+  [ "$(cat other-dir/.tool-versions)" = "dummy 1.1" ]
 }
 
 @test "global should preserve symlinks when setting versions" {
@@ -211,10 +212,10 @@ teardown() {
   touch other-dir/.tool-versions
   ln -s other-dir/.tool-versions $HOME/.tool-versions
 
-  run asdf global "dummy" "1.1.0"
+  run asdf global "dummy" "1.1"
   [ "$status" -eq 0 ]
   [ -L $HOME/.tool-versions ]
-  [ "$(cat other-dir/.tool-versions)" = "dummy 1.1.0" ]
+  [ "$(cat other-dir/.tool-versions)" = "dummy 1.1" ]
 }
 
 @test "global should preserve symlinks when updating versions" {
@@ -222,24 +223,24 @@ teardown() {
   touch other-dir/.tool-versions
   ln -s other-dir/.tool-versions $HOME/.tool-versions
 
-  run asdf global "dummy" "1.1.0"
-  run asdf global "dummy" "1.1.0"
+  run asdf global "dummy" "1.1"
+  run asdf global "dummy" "1.1"
   [ "$status" -eq 0 ]
   [ -L $HOME/.tool-versions ]
-  [ "$(cat other-dir/.tool-versions)" = "dummy 1.1.0" ]
+  [ "$(cat other-dir/.tool-versions)" = "dummy 1.1" ]
 }
 
 @test "shell wrapper function should export ENV var" {
   source $(dirname "$BATS_TEST_DIRNAME")/asdf.sh
-  asdf shell "dummy" "1.1.0"
-  [ $(echo $ASDF_DUMMY_VERSION) = "1.1.0" ]
+  asdf shell "dummy" "1.1"
+  [ $(echo $ASDF_DUMMY_VERSION) = "1.1" ]
   unset ASDF_DUMMY_VERSION
 }
 
 @test "shell wrapper function with --unset should unset ENV var" {
   source $(dirname "$BATS_TEST_DIRNAME")/asdf.sh
-  asdf shell "dummy" "1.1.0"
-  [ $(echo $ASDF_DUMMY_VERSION) = "1.1.0" ]
+  asdf shell "dummy" "1.1"
+  [ $(echo $ASDF_DUMMY_VERSION) = "1.1" ]
   asdf shell "dummy" --unset
   [ -z "$(echo $ASDF_DUMMY_VERSION)" ]
   unset ASDF_DUMMY_VERSION
@@ -248,25 +249,25 @@ teardown() {
 @test "shell wrapper function should return an error for missing plugins" {
   source $(dirname "$BATS_TEST_DIRNAME")/asdf.sh
   expected="No such plugin: nonexistent
-version 1.0.0 is not installed for nonexistent"
+version 1.0 is not installed for nonexistent"
 
-  run asdf shell "nonexistent" "1.0.0"
+  run asdf shell "nonexistent" "1.0"
   [ "$status" -eq 1 ]
   [ "$output" = "$expected" ]
 }
 
 @test "shell should emit an error when wrapper function is not loaded" {
-  run asdf shell "dummy" "1.1.0"
+  run asdf shell "dummy" "1.1"
   [ "$status" -eq 1 ]
   [ "$output" = "Shell integration is not enabled. Please ensure you source asdf in your shell setup." ]
 }
 
 @test "export-shell-version should emit an error when plugin does not exist" {
   expected="No such plugin: nonexistent
-version 1.0.0 is not installed for nonexistent
+version 1.0 is not installed for nonexistent
 false"
 
-  run asdf export-shell-version sh "nonexistent" "1.0.0"
+  run asdf export-shell-version sh "nonexistent" "1.0"
   [ "$status" -eq 1 ]
   [ "$output" = "$expected" ]
 }
@@ -281,15 +282,15 @@ false"
 }
 
 @test "export-shell-version should export version if it exists" {
-  run asdf export-shell-version sh "dummy" "1.1.0"
+  run asdf export-shell-version sh "dummy" "1.1"
   [ "$status" -eq 0 ]
-  [ "$output" = "export ASDF_DUMMY_VERSION=\"1.1.0\"" ]
+  [ "$output" = "export ASDF_DUMMY_VERSION=\"1.1\"" ]
 }
 
 @test "export-shell-version should use set when shell is fish" {
-  run asdf export-shell-version fish "dummy" "1.1.0"
+  run asdf export-shell-version fish "dummy" "1.1"
   [ "$status" -eq 0 ]
-  [ "$output" = "set -gx ASDF_DUMMY_VERSION \"1.1.0\"" ]
+  [ "$output" = "set -gx ASDF_DUMMY_VERSION \"1.1\"" ]
 }
 
 @test "export-shell-version should unset when --unset flag is passed" {
@@ -302,4 +303,25 @@ false"
   run asdf export-shell-version fish "dummy" "--unset"
   [ "$status" -eq 0 ]
   [ "$output" = "set -e ASDF_DUMMY_VERSION" ]
+}
+
+@test "shell wrapper function should support latest" {
+  source $(dirname "$BATS_TEST_DIRNAME")/asdf.sh
+  asdf shell "dummy" "latest"
+  [ $(echo $ASDF_DUMMY_VERSION) = "2.0" ]
+  unset ASDF_DUMMY_VERSION
+}
+
+@test "global should support latest" {
+  echo 'dummy 1.0' >> $HOME/.tool-versions
+  run asdf global "dummy" "1.0" "latest"
+  [ "$status" -eq 0 ]
+  [ "$(cat $HOME/.tool-versions)" = "dummy 1.0 2.0" ]
+}
+
+@test "local should support latest" {
+  echo 'dummy 1.0' >> $PROJECT_DIR/.tool-versions
+  run asdf local "dummy" "1.0" "latest"
+  [ "$status" -eq 0 ]
+  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.0 2.0" ]
 }

--- a/test/version_commands.bats
+++ b/test/version_commands.bats
@@ -5,9 +5,9 @@ load test_helpers
 setup() {
   setup_asdf_dir
   install_dummy_plugin
-  install_dummy_version "1.0"
-  install_dummy_version "1.1"
-  install_dummy_version "2.0"
+  install_dummy_version "1.0.0"
+  install_dummy_version "1.1.0"
+  install_dummy_version "2.0.0"
 
   PROJECT_DIR=$HOME/project
   mkdir -p $PROJECT_DIR
@@ -30,7 +30,7 @@ teardown() {
 }
 
 @test "local should emit an error when plugin does not exist" {
-  run asdf local "inexistent" "1.0"
+  run asdf local "inexistent" "1.0.0"
   [ "$status" -eq 1 ]
   [ "$output" = "No such plugin: inexistent" ]
 }
@@ -42,15 +42,15 @@ teardown() {
 }
 
 @test "local should create a local .tool-versions file if it doesn't exist" {
-  run asdf local "dummy" "1.1"
+  run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1" ]
+  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0" ]
 }
 
 @test "local should allow multiple versions" {
-  run asdf local "dummy" "1.1" "1.0"
+  run asdf local "dummy" "1.1.0" "1.0.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1 1.0" ]
+  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0 1.0.0" ]
 }
 
 @test "local should create a local .tool-versions file if it doesn't exist when the directory name contains whitespace" {
@@ -58,26 +58,26 @@ teardown() {
   mkdir -p "$WHITESPACE_DIR"
   cd "$WHITESPACE_DIR"
 
-  run asdf local "dummy" "1.1"
+  run asdf local "dummy" "1.1.0"
 
   tool_version_contents=$(cat "$WHITESPACE_DIR/.tool-versions")
   [ "$status" -eq 0 ]
-  [ "$tool_version_contents" = "dummy 1.1" ]
+  [ "$tool_version_contents" = "dummy 1.1.0" ]
 }
 
 @test "local should not create a duplicate .tool-versions file if such file exists" {
-  echo 'dummy 1.0' >> $PROJECT_DIR/.tool-versions
+  echo 'dummy 1.0.0' >> $PROJECT_DIR/.tool-versions
 
-  run asdf local "dummy" "1.1"
+  run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
   [ "$(ls $PROJECT_DIR/.tool-versions* | wc -l)" -eq 1 ]
 }
 
 @test "local should overwrite the existing version if it's set" {
-  echo 'dummy 1.0' >> $PROJECT_DIR/.tool-versions
-  run asdf local "dummy" "1.1"
+  echo 'dummy 1.0.0' >> $PROJECT_DIR/.tool-versions
+  run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1" ]
+  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0" ]
 }
 
 @test "local should fail to set a path:dir if dir does not exists " {
@@ -100,7 +100,7 @@ teardown() {
 }
 
 @test "local -p/--parent should emit an error when plugin does not exist" {
-  run asdf local -p "inexistent" "1.0"
+  run asdf local -p "inexistent" "1.0.0"
   [ "$status" -eq 1 ]
   [ "$output" = "No such plugin: inexistent" ]
 }
@@ -114,44 +114,44 @@ teardown() {
 @test "local -p/--parent should allow multiple versions" {
   cd $CHILD_DIR
   touch $PROJECT_DIR/.tool-versions
-  run asdf local -p "dummy" "1.1" "1.0"
+  run asdf local -p "dummy" "1.1.0" "1.0.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1 1.0" ]
+  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0 1.0.0" ]
 }
 
 @test "local -p/--parent should overwrite the existing version if it's set" {
   cd $CHILD_DIR
-  echo 'dummy 1.0' >> $PROJECT_DIR/.tool-versions
-  run asdf local -p "dummy" "1.1"
+  echo 'dummy 1.0.0' >> $PROJECT_DIR/.tool-versions
+  run asdf local -p "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1" ]
+  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0" ]
 }
 
 @test "local -p/--parent should set the version if it's unset" {
   cd $CHILD_DIR
   touch $PROJECT_DIR/.tool-versions
-  run asdf local -p "dummy" "1.1"
+  run asdf local -p "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1" ]
+  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0" ]
 }
 
 @test "global should create a global .tool-versions file if it doesn't exist" {
-  run asdf global "dummy" "1.1"
+  run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "dummy 1.1" ]
+  [ "$(cat $HOME/.tool-versions)" = "dummy 1.1.0" ]
 }
 
 @test "global should accept multiple versions" {
-  run asdf global "dummy" "1.1" "1.0"
+  run asdf global "dummy" "1.1.0" "1.0.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "dummy 1.1 1.0" ]
+  [ "$(cat $HOME/.tool-versions)" = "dummy 1.1.0 1.0.0" ]
 }
 
 @test "global should overwrite the existing version if it's set" {
-  echo 'dummy 1.0' >> $HOME/.tool-versions
-  run asdf global "dummy" "1.1"
+  echo 'dummy 1.0.0' >> $HOME/.tool-versions
+  run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "dummy 1.1" ]
+  [ "$(cat $HOME/.tool-versions)" = "dummy 1.1.0" ]
 }
 
 @test "global should fail to set a path:dir if dir does not exists " {
@@ -169,19 +169,19 @@ teardown() {
 
 @test "global should write to ASDF_DEFAULT_TOOL_VERSIONS_FILENAME" {
   export ASDF_DEFAULT_TOOL_VERSIONS_FILENAME="$PROJECT_DIR/global-tool-versions"
-  run asdf global "dummy" "1.1"
+  run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $ASDF_DEFAULT_TOOL_VERSIONS_FILENAME)" = "dummy 1.1" ]
+  [ "$(cat $ASDF_DEFAULT_TOOL_VERSIONS_FILENAME)" = "dummy 1.1.0" ]
   [ "$(cat $HOME/.tool-versions)" = "" ]
   unset ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
 }
 
 @test "global should overwrite contents of ASDF_DEFAULT_TOOL_VERSIONS_FILENAME if set" {
   export ASDF_DEFAULT_TOOL_VERSIONS_FILENAME="$PROJECT_DIR/global-tool-versions"
-  echo 'dummy 1.0' >> "$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME"
-  run asdf global "dummy" "1.1"
+  echo 'dummy 1.0.0' >> "$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME"
+  run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $ASDF_DEFAULT_TOOL_VERSIONS_FILENAME)" = "dummy 1.1" ]
+  [ "$(cat $ASDF_DEFAULT_TOOL_VERSIONS_FILENAME)" = "dummy 1.1.0" ]
   [ "$(cat $HOME/.tool-versions)" = "" ]
   unset ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
 }
@@ -190,21 +190,21 @@ teardown() {
   mkdir other-dir
   touch other-dir/.tool-versions
   ln -s other-dir/.tool-versions .tool-versions
-  run asdf local "dummy" "1.1"
+  run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
   [ -L .tool-versions ]
-  [ "$(cat other-dir/.tool-versions)" = "dummy 1.1" ]
+  [ "$(cat other-dir/.tool-versions)" = "dummy 1.1.0" ]
 }
 
 @test "local should preserve symlinks when updating versions" {
   mkdir other-dir
   touch other-dir/.tool-versions
   ln -s other-dir/.tool-versions .tool-versions
-  run asdf local "dummy" "1.1"
-  run asdf local "dummy" "1.1"
+  run asdf local "dummy" "1.1.0"
+  run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
   [ -L .tool-versions ]
-  [ "$(cat other-dir/.tool-versions)" = "dummy 1.1" ]
+  [ "$(cat other-dir/.tool-versions)" = "dummy 1.1.0" ]
 }
 
 @test "global should preserve symlinks when setting versions" {
@@ -212,10 +212,10 @@ teardown() {
   touch other-dir/.tool-versions
   ln -s other-dir/.tool-versions $HOME/.tool-versions
 
-  run asdf global "dummy" "1.1"
+  run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
   [ -L $HOME/.tool-versions ]
-  [ "$(cat other-dir/.tool-versions)" = "dummy 1.1" ]
+  [ "$(cat other-dir/.tool-versions)" = "dummy 1.1.0" ]
 }
 
 @test "global should preserve symlinks when updating versions" {
@@ -223,24 +223,24 @@ teardown() {
   touch other-dir/.tool-versions
   ln -s other-dir/.tool-versions $HOME/.tool-versions
 
-  run asdf global "dummy" "1.1"
-  run asdf global "dummy" "1.1"
+  run asdf global "dummy" "1.1.0"
+  run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
   [ -L $HOME/.tool-versions ]
-  [ "$(cat other-dir/.tool-versions)" = "dummy 1.1" ]
+  [ "$(cat other-dir/.tool-versions)" = "dummy 1.1.0" ]
 }
 
 @test "shell wrapper function should export ENV var" {
   source $(dirname "$BATS_TEST_DIRNAME")/asdf.sh
-  asdf shell "dummy" "1.1"
-  [ $(echo $ASDF_DUMMY_VERSION) = "1.1" ]
+  asdf shell "dummy" "1.1.0"
+  [ $(echo $ASDF_DUMMY_VERSION) = "1.1.0" ]
   unset ASDF_DUMMY_VERSION
 }
 
 @test "shell wrapper function with --unset should unset ENV var" {
   source $(dirname "$BATS_TEST_DIRNAME")/asdf.sh
-  asdf shell "dummy" "1.1"
-  [ $(echo $ASDF_DUMMY_VERSION) = "1.1" ]
+  asdf shell "dummy" "1.1.0"
+  [ $(echo $ASDF_DUMMY_VERSION) = "1.1.0" ]
   asdf shell "dummy" --unset
   [ -z "$(echo $ASDF_DUMMY_VERSION)" ]
   unset ASDF_DUMMY_VERSION
@@ -249,25 +249,25 @@ teardown() {
 @test "shell wrapper function should return an error for missing plugins" {
   source $(dirname "$BATS_TEST_DIRNAME")/asdf.sh
   expected="No such plugin: nonexistent
-version 1.0 is not installed for nonexistent"
+version 1.0.0 is not installed for nonexistent"
 
-  run asdf shell "nonexistent" "1.0"
+  run asdf shell "nonexistent" "1.0.0"
   [ "$status" -eq 1 ]
   [ "$output" = "$expected" ]
 }
 
 @test "shell should emit an error when wrapper function is not loaded" {
-  run asdf shell "dummy" "1.1"
+  run asdf shell "dummy" "1.1.0"
   [ "$status" -eq 1 ]
   [ "$output" = "Shell integration is not enabled. Please ensure you source asdf in your shell setup." ]
 }
 
 @test "export-shell-version should emit an error when plugin does not exist" {
   expected="No such plugin: nonexistent
-version 1.0 is not installed for nonexistent
+version 1.0.0 is not installed for nonexistent
 false"
 
-  run asdf export-shell-version sh "nonexistent" "1.0"
+  run asdf export-shell-version sh "nonexistent" "1.0.0"
   [ "$status" -eq 1 ]
   [ "$output" = "$expected" ]
 }
@@ -282,15 +282,15 @@ false"
 }
 
 @test "export-shell-version should export version if it exists" {
-  run asdf export-shell-version sh "dummy" "1.1"
+  run asdf export-shell-version sh "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$output" = "export ASDF_DUMMY_VERSION=\"1.1\"" ]
+  [ "$output" = "export ASDF_DUMMY_VERSION=\"1.1.0\"" ]
 }
 
 @test "export-shell-version should use set when shell is fish" {
-  run asdf export-shell-version fish "dummy" "1.1"
+  run asdf export-shell-version fish "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$output" = "set -gx ASDF_DUMMY_VERSION \"1.1\"" ]
+  [ "$output" = "set -gx ASDF_DUMMY_VERSION \"1.1.0\"" ]
 }
 
 @test "export-shell-version should unset when --unset flag is passed" {
@@ -308,20 +308,20 @@ false"
 @test "shell wrapper function should support latest" {
   source $(dirname "$BATS_TEST_DIRNAME")/asdf.sh
   asdf shell "dummy" "latest"
-  [ $(echo $ASDF_DUMMY_VERSION) = "2.0" ]
+  [ $(echo $ASDF_DUMMY_VERSION) = "2.0.0" ]
   unset ASDF_DUMMY_VERSION
 }
 
 @test "global should support latest" {
-  echo 'dummy 1.0' >> $HOME/.tool-versions
-  run asdf global "dummy" "1.0" "latest"
+  echo 'dummy 1.0.0' >> $HOME/.tool-versions
+  run asdf global "dummy" "1.0.0" "latest"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "dummy 1.0 2.0" ]
+  [ "$(cat $HOME/.tool-versions)" = "dummy 1.0.0 2.0.0" ]
 }
 
 @test "local should support latest" {
-  echo 'dummy 1.0' >> $PROJECT_DIR/.tool-versions
-  run asdf local "dummy" "1.0" "latest"
+  echo 'dummy 1.0.0' >> $PROJECT_DIR/.tool-versions
+  run asdf local "dummy" "1.0.0" "latest"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.0 2.0" ]
+  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.0.0 2.0.0" ]
 }


### PR DESCRIPTION
# Summary

Support the version "latest" in the `shell`, `local`, and `global` commands.

This allows running `asdf shell <plugin> latest` to use the latest version of the program installed with the mentioned plugin.

Example:

```
# asdf plugin add jbang
# asdf install jbang latest
# asdf shell latest
# jbang version
0.45.0
```

Fixes: #801