### PR TITLE
Fix plugin-update --all when there are no plugins

### DIFF
--- a/lib/commands/command-plugin-update.bash
+++ b/lib/commands/command-plugin-update.bash
@@ -9,10 +9,12 @@ plugin_update_command() {
   local plugin_name="$1"
   local gitref="${2:-master}"
   if [ "$plugin_name" = "--all" ]; then
-    for dir in "$(asdf_data_dir)"/plugins/*; do
-      echo "Updating $(basename "$dir")..."
-      (cd "$dir" && git fetch -p -u origin "$gitref:$gitref" && git checkout -f "$gitref")
-    done
+    if [ -d "$(asdf_data_dir)"/plugins ]; then
+      for dir in $(find "$(asdf_data_dir)"/plugins -type d -mindepth 1 -maxdepth 1);
+        echo "Updating $(basename "$dir")..."
+        (cd "$dir" && git fetch -p -u origin "$gitref:$gitref" && git checkout -f "$gitref")
+      done
+    fi
   else
     local plugin_path
     plugin_path="$(get_plugin_path "$plugin_name")"


### PR DESCRIPTION
Issue: when asdf is first installed, there are no plugins, and running `asdf plugin-update --all` crashes because the plugin directory doesn't exist; similarly, the command crashes if the plugins directory exists yet doesn't contain any subdirectories.

Solution: This patch changes the directory loop from using a wildcard `plugins/*` to a more robust approach: first verify the plugins directory exists, then use the`find` command to list subdirectories and correctly handle the corner case of no subdirectories.

Future: Consider printing an error message and/or advice message. Consider automatically creating the plugins directory as needed. Consider prompting the user to install some popular plugins.

# Summary

Provide a general description of the code changes in your pull request.

Fixes: List issue numbers here

## Other Information

If there is anything else that is relevant to your pull request include that
information here.

Thank you for contributing to asdf!
