### PR TITLE
chore: ban echo command

### DIFF
--- a/bin/asdf
+++ b/bin/asdf
@@ -9,10 +9,10 @@ find_cmd() {
 
   local cmd_name
   local args_offset="$#"
-  cmd_name="command-$(tr ' ' '-' <<< "${@:1:${args_offset}}").bash"
+  cmd_name="command-$(tr ' ' '-' <<<"${@:1:${args_offset}}").bash"
   while [ ! -f "$cmd_dir/$cmd_name" ] && [ "$args_offset" -gt 0 ]; do
     args_offset=$((args_offset - 1))
-    cmd_name="command-$(tr ' ' '-' <<< "${@:1:${args_offset}}").bash"
+    cmd_name="command-$(tr ' ' '-' <<<"${@:1:${args_offset}}").bash"
   done
 
   if [ -f "$cmd_dir/$cmd_name" ]; then

--- a/bin/asdf
+++ b/bin/asdf
@@ -9,16 +9,16 @@ find_cmd() {
 
   local cmd_name
   local args_offset="$#"
-  cmd_name="command-$(echo "${@:1:${args_offset}}" | tr ' ' '-').bash"
+  cmd_name="command-$(tr ' ' '-' <<< "${@:1:${args_offset}}").bash"
   while [ ! -f "$cmd_dir/$cmd_name" ] && [ "$args_offset" -gt 0 ]; do
     args_offset=$((args_offset - 1))
-    cmd_name="command-$(echo "${@:1:${args_offset}}" | tr ' ' '-').bash"
+    cmd_name="command-$(tr ' ' '-' <<< "${@:1:${args_offset}}").bash"
   done
 
   if [ -f "$cmd_dir/$cmd_name" ]; then
-    echo "$cmd_dir/$cmd_name" "$((args_offset + 1))"
+    printf "%s %s\\n" "$cmd_dir/$cmd_name" "$((args_offset + 1))"
   elif [ -f "$cmd_dir/command.bash" ]; then
-    echo "$cmd_dir/command.bash" 1
+    printf "%s %s\\n" "$cmd_dir/command.bash" 1
   fi
 }
 
@@ -29,15 +29,15 @@ find_asdf_cmd() {
   'exec' | 'current' | 'env' | 'global' | 'install' | 'latest' | 'local' | \
     'reshim' | 'uninstall' | 'update' | 'where' | 'which' | \
     'export-shell-version')
-    echo "$asdf_cmd_dir/command-$1.bash" 2
+    printf "%s %s\\n" "$asdf_cmd_dir/command-$1.bash" 2
     ;;
 
   '' | '--help' | '-h' | 'help')
-    echo "$asdf_cmd_dir/command-help.bash" 2
+    printf "%s %s\\n" "$asdf_cmd_dir/command-help.bash" 2
     ;;
 
   '--version' | 'version')
-    echo "$asdf_cmd_dir/command-version.bash" 2
+    printf "%s %s\\n" "$asdf_cmd_dir/command-version.bash" 2
     ;;
 
   *)
@@ -52,7 +52,7 @@ find_plugin_cmd() {
     IFS=' ' read -r ASDF_CMD_FILE args_offset <<<"$(find_cmd "$(get_plugin_path "$1")/lib/commands" "${@:2}")"
     if [ -n "$ASDF_CMD_FILE" ]; then
       args_offset=$((args_offset + 1)) # since the first argument is the plugin name
-      echo "$ASDF_CMD_FILE" "$args_offset"
+      printf "%s %s\\n" "$ASDF_CMD_FILE" "$args_offset"
     fi
   fi
 }
@@ -61,7 +61,7 @@ asdf_cmd() {
   local ASDF_CMD_FILE args_offset
 
   if [ "shell" == "$1" ]; then
-    echo "Shell integration is not enabled. Please ensure you source asdf in your shell setup." >&2
+    printf "Shell integration is not enabled. Please ensure you source asdf in your shell setup." >&2
     exit 1
   fi
 
@@ -78,7 +78,7 @@ asdf_cmd() {
   else
     local asdf_cmd_dir
     asdf_cmd_dir="$(asdf_dir)/lib/commands"
-    echo "Unknown command: \`asdf ${*}\`" >&2
+    printf "%s\\n" "Unknown command: \`asdf ${*}\`" >&2
     source "$asdf_cmd_dir/command-help.bash" >&2
     return 127
   fi

--- a/bin/private/asdf-exec
+++ b/bin/private/asdf-exec
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # remove this asdf-exec file when releasing >=0.6.5
-echo "asdf is self upgrading shims to new asdf exec ..."
+printf "asdf is self upgrading shims to new asdf exec ...\\n"
 
 asdf_dir="$(dirname "$(dirname "$(dirname "$0")")")"
 # shellcheck source=lib/utils.bash
@@ -10,6 +10,6 @@ rm "$(asdf_data_dir)"/shims/*
 "$asdf_dir"/bin/asdf reshim
 shim_name=$(basename "$2")
 
-echo "asdf: now running $shim_name"
+printf "asdf: now running %s\\n" "$shim_name"
 
 exec "$shim_name" "${@:3}"

--- a/lib/commands/command-current.bash
+++ b/lib/commands/command-current.bash
@@ -71,10 +71,8 @@ check_for_deprecated_plugin() {
   local new_script="${plugin_path}/bin/list-legacy-filenames"
 
   if [ "$legacy_config" = "yes" ] && [ -f "$deprecated_script" ] && [ ! -f "$new_script" ]; then
-    echo "Heads up! It looks like your $plugin_name plugin is out of date. You can update it with:"
-    echo ""
-    echo "  asdf plugin-update $plugin_name"
-    echo ""
+    printf "Heads up! It looks like your %s plugin is out of date. You can update it with:\\n\\n" "$plugin_name"
+    printf "  asdf plugin-update %s\\n\\n" "$plugin_name"
   fi
 }
 

--- a/lib/commands/command-env.bash
+++ b/lib/commands/command-env.bash
@@ -6,7 +6,7 @@ shim_env_command() {
   local env_args=("${@:3}")
 
   if [ -z "$shim_name" ]; then
-    echo "usage: asdf env <command>"
+    printf "usage: asdf env <command>\\n"
     exit 1
   fi
 

--- a/lib/commands/command-exec.bash
+++ b/lib/commands/command-exec.bash
@@ -6,7 +6,7 @@ shim_exec_command() {
   local shim_args=("${@:2}")
 
   if [ -z "$shim_name" ]; then
-    echo "usage: asdf exec <command>"
+    printf "usage: asdf exec <command>\\n"
     exit 1
   fi
 
@@ -16,7 +16,7 @@ shim_exec_command() {
     local executable_path="$3"
 
     if [ ! -x "$executable_path" ]; then
-      echo "No ${shim_name} executable found for ${plugin_name} ${version}" >&2
+      printf "No %s executable found for %s %s\\n" "$shim_name" "$plugin_name" "$version" >&2
       exit 2
     fi
 

--- a/lib/commands/command-export-shell-version.bash
+++ b/lib/commands/command-export-shell-version.bash
@@ -6,8 +6,8 @@ shell_command() {
   shift
 
   if [ "$#" -lt "2" ]; then
-    echo "Usage: asdf shell <name> {<version>|--unset}" >&2
-    echo 'false'
+    printf "Usage: asdf shell <name> {<version>|--unset}\\n" >&2
+    printf "false\\n"
     exit 1
   fi
 
@@ -15,16 +15,16 @@ shell_command() {
   local version=$2
 
   local upcase_name
-  upcase_name=$(echo "$plugin" | tr '[:lower:]-' '[:upper:]_')
+  upcase_name=$(tr '[:lower:]-' '[:upper:]_' <<< "$plugin")
   local version_env_var="ASDF_${upcase_name}_VERSION"
 
   if [ "$version" = "--unset" ]; then
     case "$asdf_shell" in
     fish)
-      echo "set -e $version_env_var"
+      printf "set -e %s\\n" "$version_env_var"
       ;;
     *)
-      echo "unset $version_env_var"
+      printf "unset %s\\n" "$version_env_var"
       ;;
     esac
     exit 0
@@ -34,16 +34,16 @@ shell_command() {
   fi
   if ! (check_if_version_exists "$plugin" "$version"); then
     version_not_installed_text "$plugin" "$version" 1>&2
-    echo 'false'
+    printf "false\\n"
     exit 1
   fi
 
   case "$asdf_shell" in
   fish)
-    echo "set -gx $version_env_var \"$version\""
+    printf "set -gx %s \"%s\"\\n" "$version_env_var" "$version"
     ;;
   *)
-    echo "export $version_env_var=\"$version\""
+    printf "export %s=\"%s\"\\n" "$version_env_var" "$version"
     ;;
   esac
 }

--- a/lib/commands/command-export-shell-version.bash
+++ b/lib/commands/command-export-shell-version.bash
@@ -15,7 +15,7 @@ shell_command() {
   local version=$2
 
   local upcase_name
-  upcase_name=$(tr '[:lower:]-' '[:upper:]_' <<< "$plugin")
+  upcase_name=$(tr '[:lower:]-' '[:upper:]_' <<<"$plugin")
   local version_env_var="ASDF_${upcase_name}_VERSION"
 
   if [ "$version" = "--unset" ]; then

--- a/lib/commands/command-help.bash
+++ b/lib/commands/command-help.bash
@@ -1,8 +1,7 @@
 # -*- sh -*-
 
 asdf_help() {
-  echo "version: $(asdf_version)"
-  echo ""
+  printf "version: %s\\n\\n" "$(asdf_version)"
   cat "$(asdf_dir)/help.txt"
 }
 
@@ -22,10 +21,9 @@ asdf_extension_cmds() {
   ext_cmds="$(ls -1 "$plugins_path"/*/lib/commands/command*.bash 2>/dev/null |
     sed "s#^$plugins_path/##;s#lib/commands/command##;s/.bash//;s/^-//;s/-/ /g")"
   if test -n "$ext_cmds"; then
-    echo "$ext_cmds" | cut -d'/' -f 1 | uniq | while read -r plugin; do
-      echo
-      echo "PLUGIN $plugin"
-      echo "$ext_cmds" | grep "$plugin/" | sed "s#^$plugin/#  asdf $plugin#" | sort
+    cut -d'/' -f 1 <<< "$ext_cmds" | uniq | while read -r plugin; do
+      printf "\\nPLUGIN %s\\n" "$plugin"
+      grep "$plugin/" <<< "$ext_cmds" | sed "s#^$plugin/#  asdf $plugin#" | sort
     done
   fi
 }
@@ -76,11 +74,11 @@ help_command() {
           (print_plugin_help "$plugin_path")
         fi
       else
-        echo "No documentation for plugin $plugin_name" >&2
+        printf "No documentation for plugin %s\\n" "$plugin_name" >&2
         exit 1
       fi
     else
-      echo "No plugin named $plugin_name" >&2
+      printf "No plugin named %s\\n" "$plugin_name" >&2
       exit 1
     fi
   else

--- a/lib/commands/command-help.bash
+++ b/lib/commands/command-help.bash
@@ -21,9 +21,9 @@ asdf_extension_cmds() {
   ext_cmds="$(ls -1 "$plugins_path"/*/lib/commands/command*.bash 2>/dev/null |
     sed "s#^$plugins_path/##;s#lib/commands/command##;s/.bash//;s/^-//;s/-/ /g")"
   if test -n "$ext_cmds"; then
-    cut -d'/' -f 1 <<< "$ext_cmds" | uniq | while read -r plugin; do
+    cut -d'/' -f 1 <<<"$ext_cmds" | uniq | while read -r plugin; do
       printf "\\nPLUGIN %s\\n" "$plugin"
-      grep "$plugin/" <<< "$ext_cmds" | sed "s#^$plugin/#  asdf $plugin#" | sort
+      grep "$plugin/" <<<"$ext_cmds" | sed "s#^$plugin/#  asdf $plugin#" | sort
     done
   fi
 }

--- a/lib/commands/command-info.bash
+++ b/lib/commands/command-info.bash
@@ -1,11 +1,11 @@
 # -*- sh -*-
 
 info_command() {
-  printf "%s:\n%s\n\n" "OS" "$(uname -a)"
-  printf "%s:\n%s\n\n" "SHELL" "$($SHELL --version)"
-  printf "%s:\n%s\n\n" "ASDF VERSION" "$(asdf_version)"
-  printf "%s:\n%s\n\n" "ASDF ENVIRONMENT VARIABLES" "$(env | grep -E "ASDF_DIR|ASDF_DATA_DIR|ASDF_CONFIG_FILE|ASDF_DEFAULT_TOOL_VERSIONS_FILENAME")"
-  printf "%s:\n%s\n\n" "ASDF INSTALLED PLUGINS" "$(asdf plugin list --urls)"
+  printf "%s:\\n%s\\n\\n" "OS" "$(uname -a)"
+  printf "%s:\\n%s\\n\\n" "SHELL" "$($SHELL --version)"
+  printf "%s:\\n%s\\n\\n" "ASDF VERSION" "$(asdf_version)"
+  printf "%s:\\n%s\\n\\n" "ASDF ENVIRONMENT VARIABLES" "$(env | grep -E "ASDF_DIR|ASDF_DATA_DIR|ASDF_CONFIG_FILE|ASDF_DEFAULT_TOOL_VERSIONS_FILENAME")"
+  printf "%s:\\n%s\\n\\n" "ASDF INSTALLED PLUGINS" "$(asdf plugin list --urls)"
 }
 
 info_command "$@"

--- a/lib/commands/command-install.bash
+++ b/lib/commands/command-install.bash
@@ -8,7 +8,7 @@ handle_failure() {
 
 handle_cancel() {
   local install_path="$1"
-  echo -e "\\nreceived sigint, cleaning up"
+  printf "\\nreceived sigint, cleaning up"
   handle_failure "$install_path"
 }
 
@@ -34,7 +34,7 @@ get_concurrency() {
   elif [ -f /proc/cpuinfo ]; then
     grep -c processor /proc/cpuinfo
   else
-    echo "1"
+    printf "1\\n"
   fi
 }
 
@@ -58,7 +58,7 @@ install_one_local_tool() {
       install_tool_version "$plugin_name" "$plugin_version"
     done
   else
-    echo "No versions specified for $plugin_name in config files or environment"
+    printf "No versions specified for %s in config files or environment\\n" "$plugin_name"
     exit 1
   fi
 }
@@ -89,14 +89,14 @@ install_local_tool_versions() {
       fi
     done
   else
-    echo "Install plugins first to be able to install tools"
+    printf "Install plugins first to be able to install tools\\n"
     exit 1
   fi
 
   if [ -z "$some_tools_installed" ]; then
-    echo "Either specify a tool & version in the command"
-    echo "OR add .tool-versions file in this directory"
-    echo "or in a parent directory"
+    printf "Either specify a tool & version in the command\\n"
+    printf "OR add .tool-versions file in this directory\\n"
+    printf "or in a parent directory\\n"
     exit 1
   fi
 }
@@ -152,7 +152,7 @@ install_tool_version() {
   trap 'handle_cancel $install_path' INT
 
   if [ -d "$install_path" ]; then
-    echo "$plugin_name $full_version is already installed"
+    printf "%s %s is already installed\\n" "$plugin_name" "$full_version"
   else
 
     if [ -f "${plugin_path}/bin/download" ]; then

--- a/lib/commands/command-list-all.bash
+++ b/lib/commands/command-list-all.bash
@@ -11,8 +11,7 @@ list_all_command() {
   versions=$(bash "${plugin_path}/bin/list-all")
 
   if [[ $query ]]; then
-    versions=$(echo "$versions" |
-      tr ' ' '\n' |
+    versions=$(tr ' ' '\n' <<< "$versions" |
       grep -E "^\\s*$query" |
       tr '\n' ' ')
   fi
@@ -20,7 +19,7 @@ list_all_command() {
   IFS=' ' read -r -a versions_list <<<"$versions"
 
   for version in "${versions_list[@]}"; do
-    echo "${version}"
+    printf "%s\\n" "${version}"
   done
 }
 

--- a/lib/commands/command-list-all.bash
+++ b/lib/commands/command-list-all.bash
@@ -11,7 +11,7 @@ list_all_command() {
   versions=$(bash "${plugin_path}/bin/list-all")
 
   if [[ $query ]]; then
-    versions=$(tr ' ' '\n' <<< "$versions" |
+    versions=$(tr ' ' '\n' <<<"$versions" |
       grep -E "^\\s*$query" |
       tr '\n' ' ')
   fi

--- a/lib/commands/command-list.bash
+++ b/lib/commands/command-list.bash
@@ -10,7 +10,7 @@ list_command() {
     if ls "$plugins_path" &>/dev/null; then
       for plugin_path in "$plugins_path"/*; do
         plugin_name=$(basename "$plugin_path")
-        echo "$plugin_name"
+        printf "%s\\n" "$plugin_name"
         display_installed_versions "$plugin_name"
       done
     else
@@ -28,7 +28,7 @@ display_installed_versions() {
 
   if [ -n "${versions}" ]; then
     for version in $versions; do
-      echo "  $version"
+      printf "  %s\\n" "$version"
     done
   else
     display_error '  No versions installed'

--- a/lib/commands/command-plugin-push.bash
+++ b/lib/commands/command-plugin-push.bash
@@ -4,14 +4,14 @@ plugin_push_command() {
   local plugin_name=$1
   if [ "$plugin_name" = "--all" ]; then
     for dir in "$(asdf_data_dir)"/plugins/*; do
-      echo "Pushing $(basename "$dir")..."
+      printf "Pushing %s...\\n" "$(basename "$dir")"
       (cd "$dir" && git push)
     done
   else
     local plugin_path
     plugin_path=$(get_plugin_path "$plugin_name")
     check_if_plugin_exists "$plugin_name"
-    echo "Pushing $plugin_name..."
+    printf "Pushing %s...\\n" "$plugin_name"
     (cd "$plugin_path" && git push)
   fi
 }

--- a/lib/commands/command-plugin-test.bash
+++ b/lib/commands/command-plugin-test.bash
@@ -36,7 +36,7 @@ plugin_test_command() {
   local TEST_DIR
 
   fail_test() {
-    echo "FAILED: $1"
+    printf "FAILED: %s\\n" "$1"
     rm -rf "$TEST_DIR"
     exit 1
   }
@@ -74,23 +74,20 @@ plugin_test_command() {
     local list_all="$plugin_path/bin/list-all"
     if grep api.github.com "$list_all" >/dev/null; then
       if ! grep Authorization "$list_all" >/dev/null; then
-        echo
-        echo "Looks like ${plugin_name}/bin/list-all relies on GitHub releases"
-        echo "but it does not properly sets an Authorization header to prevent"
-        echo "GitHub API rate limiting."
-        echo
-        echo "See https://github.com/asdf-vm/asdf/blob/master/docs/creating-plugins.md#github-api-rate-limiting"
+        printf "\\nLooks like %s/bin/list-all relies on GitHub releases\\n" "$plugin_name"
+        printf "but it does not properly sets an Authorization header to prevent\\n"
+        printf "GitHub API rate limiting.\\n\\n"
+        printf "See https://github.com/asdf-vm/asdf/blob/master/docs/creating-plugins.md#github-api-rate-limiting\\n"
 
         fail_test "$plugin_name/bin/list-all does not set GitHub Authorization token"
       fi
 
       # test for most common token names we have on plugins. If both are empty show this warning
       if [ -z "$OAUTH_TOKEN" ] && [ -z "$GITHUB_API_TOKEN" ]; then
-        echo "$plugin_name/bin/list-all is using GitHub API, just be sure you provide an API Authorization token"
-        echo "via your CI env GITHUB_API_TOKEN. This is the current rate_limit:"
-        echo
+        printf "%s/bin/list-all is using GitHub API, just be sure you provide an API Authorization token\\n" "$plugin_name"
+        printf "via your CI env GITHUB_API_TOKEN. This is the current rate_limit:\\n\\n"
         curl -s https://api.github.com/rate_limit
-        echo
+        printf "\\n"
       fi
     fi
 
@@ -109,7 +106,7 @@ plugin_test_command() {
     # Use the version passed in if it was set. Otherwise grab the latest
     # version from the versions list
     if [ -z "$tool_version" ] || [[ "$tool_version" == *"latest"* ]]; then
-      version="$(asdf latest "$plugin_name" "$(echo "$tool_version" | sed -e 's#latest##;s#^:##')")"
+      version="$(asdf latest "$plugin_name" "$(sed -e 's#latest##;s#^:##' <<< "$tool_version")")"
       if [ -z "$version" ]; then
         fail_test "could not get latest version"
       fi

--- a/lib/commands/command-plugin-test.bash
+++ b/lib/commands/command-plugin-test.bash
@@ -106,7 +106,7 @@ plugin_test_command() {
     # Use the version passed in if it was set. Otherwise grab the latest
     # version from the versions list
     if [ -z "$tool_version" ] || [[ "$tool_version" == *"latest"* ]]; then
-      version="$(asdf latest "$plugin_name" "$(sed -e 's#latest##;s#^:##' <<< "$tool_version")")"
+      version="$(asdf latest "$plugin_name" "$(sed -e 's#latest##;s#^:##' <<<"$tool_version")")"
       if [ -z "$version" ]; then
         fail_test "could not get latest version"
       fi

--- a/lib/commands/command-plugin-update.bash
+++ b/lib/commands/command-plugin-update.bash
@@ -11,7 +11,7 @@ plugin_update_command() {
   if [ "$plugin_name" = "--all" ]; then
     if [ -d "$(asdf_data_dir)"/plugins ]; then
       while IFS= read -r -d '' dir; do
-        echo "Updating $(basename "$dir")..."
+        printf "Updating %s...\\n" "$(basename "$dir")"
         (cd "$dir" && git fetch -p -u origin "$gitref:$gitref" && git checkout -f "$gitref")
       done < <(find "$(asdf_data_dir)"/plugins -type d -mindepth 1 -maxdepth 1)
     fi
@@ -19,7 +19,7 @@ plugin_update_command() {
     local plugin_path
     plugin_path="$(get_plugin_path "$plugin_name")"
     check_if_plugin_exists "$plugin_name"
-    echo "Updating $plugin_name..."
+    printf "Updating %s...\\n" "$plugin_name"
     (cd "$plugin_path" && git fetch -p -u origin "$gitref:$gitref" && git checkout -f "$gitref")
   fi
 }

--- a/lib/commands/command-reshim.bash
+++ b/lib/commands/command-reshim.bash
@@ -119,7 +119,7 @@ remove_obsolete_shims() {
   exec_names=$(plugin_executables "$plugin_name" "$full_version" | xargs -IX basename X | sort)
 
   local obsolete_shims
-  obsolete_shims=$(comm -23 <(echo "$shims") <(echo "$exec_names"))
+  obsolete_shims=$(comm -23 <(printf "%s\\n" "$shims") <(printf "%s\\n" "$exec_names"))
 
   for shim_name in $obsolete_shims; do
     remove_shim_for_version "$plugin_name" "$full_version" "$shim_name"

--- a/lib/commands/command-update.bash
+++ b/lib/commands/command-update.bash
@@ -7,7 +7,7 @@ update_command() {
     cd "$(asdf_dir)" || exit 1
 
     if [ -f asdf_updates_disabled ] || ! git rev-parse --is-inside-work-tree &>/dev/null; then
-      echo "Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf."
+      printf "Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf.\\n"
       exit 42
     else
       do_update "$update_to_head"
@@ -23,7 +23,7 @@ do_update() {
     git fetch origin master
     git checkout master
     git reset --hard origin/master
-    echo "Updated asdf to latest on the master branch"
+    printf "Updated asdf to latest on the master branch\\n"
   else
     # Update to latest release
     git fetch origin --tags || exit 1
@@ -38,7 +38,7 @@ do_update() {
 
     # Update
     git checkout "$tag" || exit 1
-    echo "Updated asdf to release $tag"
+    printf "Updated asdf to release %s\\n" "$tag"
   fi
 }
 

--- a/lib/commands/command-where.bash
+++ b/lib/commands/command-where.bash
@@ -34,14 +34,14 @@ where_command() {
   install_path=$(get_install_path "$plugin_name" "$install_type" "$version")
 
   if [ -d "$install_path" ]; then
-    echo "$install_path"
+    printf "%s\\n" "$install_path"
     exit 0
   else
     if [ "$version" = "system" ]; then
-      echo "System version is selected"
+      printf "System version is selected\\n"
       exit 1
     else
-      echo "Version not installed"
+      printf "Version not installed\\n"
       exit 1
     fi
   fi

--- a/lib/commands/command-which.bash
+++ b/lib/commands/command-which.bash
@@ -5,7 +5,7 @@ which_command() {
   shim_name=$(basename "$1")
 
   if [ -z "$shim_name" ]; then
-    echo "usage: asdf which <command>"
+    printf "usage: asdf which <command>\\n"
     exit 1
   fi
 
@@ -15,11 +15,11 @@ which_command() {
     local executable_path="$3"
 
     if [ ! -x "$executable_path" ]; then
-      echo "No ${shim_name} executable found for ${plugin_name} ${version}" >&2
+      printf "No %s executable found for %s %s\\n" "$shim_name" "$plugin_name" "$version" >&2
       exit 1
     fi
 
-    echo "$executable_path"
+    printf "%s\\n" "$executable_path"
     exit 0
   }
 

--- a/lib/commands/version_commands.bash
+++ b/lib/commands/version_commands.bash
@@ -6,9 +6,9 @@ version_command() {
 
   if [ "$#" -lt "3" ]; then
     if [ "$cmd" = "global" ]; then
-      echo "Usage: asdf global <name> <version>"
+      printf "Usage: asdf global <name> <version>\\n"
     else
-      echo "Usage: asdf local <name> <version>"
+      printf "Usage: asdf local <name> <version>\\n"
     fi
     exit 1
   fi
@@ -49,6 +49,6 @@ version_command() {
     sed -i.bak -e "s|^$plugin_name .*$|$plugin_name ${resolved_versions[*]}|" "$file"
     rm "$file".bak
   else
-    echo "$plugin_name ${resolved_versions[*]}" >>"$file"
+    printf "%s %s\\n" "$plugin_name" "${resolved_versions[*]}" >>"$file"
   fi
 }

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -13,9 +13,9 @@ asdf_version() {
   version="$(cat "$(asdf_dir)/VERSION")"
   if [ -d "$(asdf_dir)/.git" ]; then
     git_rev="$(git --git-dir "$(asdf_dir)/.git" rev-parse --short HEAD)"
-    echo "${version}-${git_rev}"
+    printf "%s-%s\\n" "$version" "$git_rev"
   else
-    echo "${version}"
+    printf "%s\\n" "$version"
   fi
 }
 
@@ -29,11 +29,11 @@ asdf_dir() {
     )
   fi
 
-  echo "$ASDF_DIR"
+  printf "%s\\n" "$ASDF_DIR"
 }
 
 asdf_repository_url() {
-  echo "https://github.com/asdf-vm/asdf-plugins.git"
+  printf "https://github.com/asdf-vm/asdf-plugins.git\\n"
 }
 
 asdf_data_dir() {
@@ -45,7 +45,7 @@ asdf_data_dir() {
     data_dir="$HOME/.asdf"
   fi
 
-  echo "$data_dir"
+  printf "%s\\n" "$data_dir"
 }
 
 get_install_path() {
@@ -59,11 +59,11 @@ get_install_path() {
   mkdir -p "${install_dir}/${plugin}"
 
   if [ "$install_type" = "version" ]; then
-    echo "${install_dir}/${plugin}/${version}"
+    printf "%s/%s/%s\\n" "$install_dir" "$plugin" "$version"
   elif [ "$install_type" = "path" ]; then
-    echo "$version"
+    printf "%s\\n" "$version"
   else
-    echo "${install_dir}/${plugin}/${install_type}-${version}"
+    printf "%s/%s/%s-%s\\n" "$install_dir" "$plugin" "$install_type" "$version"
   fi
 }
 
@@ -78,11 +78,11 @@ get_download_path() {
   mkdir -p "${download_dir}/${plugin}"
 
   if [ "$install_type" = "version" ]; then
-    echo "${download_dir}/${plugin}/${version}"
+    printf "%s/%s/%s\\n" "$download_dir" "$plugin" "$version"
   elif [ "$install_type" = "path" ]; then
     return
   else
-    echo "${download_dir}/${plugin}/${install_type}-${version}"
+    printf "%s/%s/%s-%s\\n" "$download_dir" "$plugin" "$install_type" "$version"
   fi
 }
 
@@ -140,14 +140,14 @@ version_not_installed_text() {
 
 get_plugin_path() {
   if test -n "$1"; then
-    echo "$(asdf_data_dir)/plugins/$1"
+    printf "%s\\n" "$(asdf_data_dir)/plugins/$1"
   else
-    echo "$(asdf_data_dir)/plugins"
+    printf "%s\\n" "$(asdf_data_dir)/plugins"
   fi
 }
 
 display_error() {
-  echo >&2 "$1"
+  printf "%s\\n" "$1" >&2
 }
 
 get_version_in_dir() {
@@ -159,7 +159,7 @@ get_version_in_dir() {
   asdf_version=$(parse_asdf_version_file "$search_path/.tool-versions" "$plugin_name")
 
   if [ -n "$asdf_version" ]; then
-    echo "$asdf_version|$search_path/.tool-versions"
+    printf "%s\\n" "$asdf_version|$search_path/.tool-versions"
     return 0
   fi
 
@@ -168,7 +168,7 @@ get_version_in_dir() {
     legacy_version=$(parse_legacy_version_file "$search_path/$filename" "$plugin_name")
 
     if [ -n "$legacy_version" ]; then
-      echo "$legacy_version|$search_path/$filename"
+      printf "%s\\n" "$legacy_version|$search_path/$filename"
       return 0
     fi
   done
@@ -182,10 +182,10 @@ find_versions() {
   version=$(get_version_from_env "$plugin_name")
   if [ -n "$version" ]; then
     local upcase_name
-    upcase_name=$(echo "$plugin_name" | tr '[:lower:]-' '[:upper:]_')
+    upcase_name=$(printf "%s\\n" "$plugin_name" | tr '[:lower:]-' '[:upper:]_')
     local version_env_var="ASDF_${upcase_name}_VERSION"
 
-    echo "$version|$version_env_var environment variable"
+    printf "%s\\n" "$version|$version_env_var environment variable"
     return 0
   fi
 
@@ -204,7 +204,7 @@ find_versions() {
   while [ "$search_path" != "/" ]; do
     version=$(get_version_in_dir "$plugin_name" "$search_path" "$legacy_filenames")
     if [ -n "$version" ]; then
-      echo "$version"
+      printf "%s\\n" "$version"
       return 0
     fi
     search_path=$(dirname "$search_path")
@@ -215,7 +215,7 @@ find_versions() {
   if [ -f "$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME" ]; then
     versions=$(parse_asdf_version_file "$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME" "$plugin_name")
     if [ -n "$versions" ]; then
-      echo "$versions|$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME"
+      printf "%s\\n" "$versions|$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME"
       return 0
     fi
   fi
@@ -223,16 +223,16 @@ find_versions() {
 
 display_no_version_set() {
   local plugin_name=$1
-  echo "No version set for ${plugin_name}; please run \`asdf <global | shell | local> ${plugin_name} <version>\`"
+  printf "No version set for %s; please run \`asdf <global | shell | local> %s <version>\`\\n" "$plugin_name" "$plugin_name"
 }
 
 get_version_from_env() {
   local plugin_name=$1
   local upcase_name
-  upcase_name=$(echo "$plugin_name" | tr '[:lower:]-' '[:upper:]_')
+  upcase_name=$(printf "%s\\n" "$plugin_name" | tr '[:lower:]-' '[:upper:]_')
   local version_env_var="ASDF_${upcase_name}_VERSION"
   local version=${!version_env_var:-}
-  echo "$version"
+  printf "%s\\n" "$version"
 }
 
 find_install_path() {
@@ -243,7 +243,7 @@ find_install_path() {
   IFS=':' read -a version_info <<<"$version"
 
   if [ "$version" = "system" ]; then
-    echo ""
+    printf "\\n"
   elif [ "${version_info[0]}" = "ref" ]; then
     local install_type="${version_info[0]}"
     local version="${version_info[1]}"
@@ -255,7 +255,7 @@ find_install_path() {
     # And then use the binaries there
     local install_type="path"
     local version="path"
-    echo "${version_info[1]}"
+    printf "%s\\n" "${version_info[1]}"
   else
     local install_type="version"
     local version="${version_info[0]}"
@@ -273,12 +273,12 @@ get_custom_executable_path() {
     cmd=$(basename "$executable_path")
     local relative_path
     # shellcheck disable=SC2001
-    relative_path=$(echo "$executable_path" | sed -e "s|${install_path}/||")
+    relative_path=$(printf "%s\\n" "$executable_path" | sed -e "s|${install_path}/||")
     relative_path="$("${plugin_path}/bin/exec-path" "$install_path" "$cmd" "$relative_path")"
     executable_path="$install_path/$relative_path"
   fi
 
-  echo "$executable_path"
+  printf "%s\\n" "$executable_path"
 }
 
 get_executable_path() {
@@ -289,18 +289,18 @@ get_executable_path() {
   check_if_version_exists "$plugin_name" "$version"
 
   if [ "$version" = "system" ]; then
-    path=$(echo "$PATH" | sed -e "s|$(asdf_data_dir)/shims||g; s|::|:|g")
+    path=$(sed -e "s|$(asdf_data_dir)/shims||g; s|::|:|g" <<< "$PATH")
     cmd=$(basename "$executable_path")
     cmd_path=$(PATH=$path command -v "$cmd" 2>&1)
     # shellcheck disable=SC2181
     if [ $? -ne 0 ]; then
       return 1
     fi
-    echo "$cmd_path"
+    printf "%s\\n" "$cmd_path"
   else
     local install_path
     install_path=$(find_install_path "$plugin_name" "$version")
-    echo "${install_path}"/"${executable_path}"
+    printf "%s\\n" "${install_path}"/"${executable_path}"
   fi
 }
 
@@ -312,7 +312,7 @@ parse_asdf_version_file() {
     local version
     version=$(strip_tool_version_comments "$file_path" | grep "^${plugin_name} " | sed -e "s/^${plugin_name} //")
     if [ -n "$version" ]; then
-      echo "$version"
+      printf "%s\\n" "$version"
       return 0
     fi
   fi
@@ -345,7 +345,7 @@ get_preset_version_for() {
   local version
   version=$(cut -d '|' -f 1 <<<"$version_and_path")
 
-  echo "$version"
+  printf "%s\\n" "$version"
 }
 
 get_asdf_config_value_from_file() {
@@ -359,7 +359,7 @@ get_asdf_config_value_from_file() {
   local result
   result=$(grep -E "^\\s*$key\\s*=\\s*" "$config_path" | head | awk -F '=' '{print $2}' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
   if [ -n "$result" ]; then
-    echo "$result"
+    printf "%s\\n" "$result"
     return 0
   fi
 
@@ -398,10 +398,10 @@ initialize_or_update_repository() {
   repository_path=$(asdf_data_dir)/repository
 
   if [ ! -d "$repository_path" ]; then
-    echo "initializing plugin repository..."
+    printf "initializing plugin repository..."
     git clone "$repository_url" "$repository_path"
   elif repository_needs_update; then
-    echo "updating plugin repository..."
+    printf "updating plugin repository..."
     (cd "$repository_path" && git fetch && git reset --hard origin/master)
   fi
 
@@ -430,7 +430,7 @@ find_file_upwards() {
   search_path=$(pwd)
   while [ "$search_path" != "/" ]; do
     if [ -f "$search_path/$name" ]; then
-      echo "${search_path}/$name"
+      printf "%s\\n" "${search_path}/$name"
       return 0
     fi
     search_path=$(dirname "$search_path")
@@ -451,10 +451,10 @@ resolve_symlink() {
   # as relative
   case $resolved_path in
   /*)
-    echo "$resolved_path"
+    printf "%s\\n" "$resolved_path"
     ;;
   *)
-    echo "$PWD/$resolved_path"
+    printf "%s\\n" "$PWD/$resolved_path"
     ;;
   esac
 }
@@ -481,7 +481,7 @@ list_plugin_bin_paths() {
   else
     local space_separated_list_of_bin_paths="bin"
   fi
-  echo "$space_separated_list_of_bin_paths"
+  printf "%s\\n" "$space_separated_list_of_bin_paths"
 }
 
 list_plugin_exec_paths() {
@@ -504,7 +504,7 @@ list_plugin_exec_paths() {
   local plugin_shims_path
   plugin_shims_path=$(get_plugin_path "$plugin_name")/shims
   if [ -d "$plugin_shims_path" ]; then
-    echo "$plugin_shims_path"
+    printf "%s\\n" "$plugin_shims_path"
   fi
 
   space_separated_list_of_bin_paths="$(list_plugin_bin_paths "$plugin_name" "$version" "$install_type")"
@@ -514,7 +514,7 @@ list_plugin_exec_paths() {
   install_path=$(get_install_path "$plugin_name" "$install_type" "$version")
 
   for bin_path in "${all_bin_paths[@]}"; do
-    echo "$install_path/$bin_path"
+    printf "%s\\n" "$install_path/$bin_path"
   done
 }
 
@@ -547,7 +547,7 @@ with_plugin_env() {
 
   # exec_paths contains a trailing newline which is converted to a colon, so no
   # colon is needed between the subshell and the PATH variable in this string
-  path="$(echo "$exec_paths" | tr '\n' ':')$PATH"
+  path="$(tr '\n' ':' <<< "$exec_paths")$PATH"
 
   # If no custom exec-env transform, just execute callback
   if [ ! -f "${plugin_path}/bin/exec-env" ]; then
@@ -574,7 +574,7 @@ plugin_executables() {
   for bin_path in $(list_plugin_exec_paths "$plugin_name" "$full_version"); do
     for executable_file in "$bin_path"/*; do
       if is_executable "$executable_file"; then
-        echo "$executable_file"
+        printf "%s\\n" "$executable_file"
       fi
     done
   done
@@ -602,7 +602,7 @@ shim_plugin_versions() {
   if [ -x "$shim_path" ]; then
     grep "# asdf-plugin: " "$shim_path" 2>/dev/null | sed -e "s/# asdf-plugin: //" | uniq
   else
-    echo "asdf: unknown shim $executable_name"
+    printf "asdf: unknown shim %s\\n" "$executable_name"
     return 1
   fi
 }
@@ -615,7 +615,7 @@ shim_plugins() {
   if [ -x "$shim_path" ]; then
     grep "# asdf-plugin: " "$shim_path" 2>/dev/null | sed -e "s/# asdf-plugin: //" | cut -d' ' -f 1 | uniq
   else
-    echo "asdf: unknown shim $executable_name"
+    printf "asdf: unknown shim %s\\n" "$executable_name"
     return 1
   fi
 }
@@ -625,11 +625,11 @@ strip_tool_version_comments() {
 
   while IFS= read -r tool_line || [ -n "$tool_line" ]; do
     # Remove whitespace before pound sign, the pound sign, and everything after it
-    new_line="$(echo "$tool_line" | cut -f1 -d"#" | sed -e 's/[[:space:]]*$//')"
+    new_line="$(cut -f1 -d"#" <<< "$tool_line" | sed -e 's/[[:space:]]*$//')"
 
     # Only print the line if it is not empty
     if [[ -n "$new_line" ]]; then
-      echo "$new_line"
+      printf "%s\\n" "$new_line"
     fi
   done <"$tool_version_path"
 }
@@ -655,12 +655,12 @@ get_shim_versions() {
 
 preset_versions() {
   shim_name=$1
-  shim_plugin_versions "${shim_name}" | cut -d' ' -f 1 | uniq | xargs -IPLUGIN bash -c "source $(asdf_dir)/lib/utils.bash; echo PLUGIN \$(get_preset_version_for PLUGIN)"
+  shim_plugin_versions "${shim_name}" | cut -d' ' -f 1 | uniq | xargs -IPLUGIN bash -c "source $(asdf_dir)/lib/utils.bash; printf \"%s %s\\n\" PLUGIN \$(get_preset_version_for PLUGIN)"
 }
 
 select_from_preset_version() {
   shim_name=$1
-  grep -f <(get_shim_versions "$shim_name") <(preset_versions "$shim_name") | head -n 1 | xargs echo
+  grep -f <(get_shim_versions "$shim_name") <(preset_versions "$shim_name") | head -n 1 | xargs -IVERSION printf "%s\\n" VERSION
 }
 
 select_version() {
@@ -694,10 +694,10 @@ select_version() {
         IFS=' ' read -r plugin_shim_name plugin_shim_version <<<"$plugin_and_version"
         if [[ "$plugin_name" == "$plugin_shim_name" ]]; then
           if [[ "$plugin_version" == "$plugin_shim_version" ]]; then
-            echo "$plugin_name $plugin_version"
+            printf "%s\\n" "$plugin_name $plugin_version"
             return
           elif [[ "$plugin_version" == "path:"* ]]; then
-            echo "$plugin_name $plugin_version"
+            printf "%s\\n" "$plugin_name $plugin_version"
             return
           fi
         fi
@@ -733,7 +733,7 @@ with_shim_executable() {
 
     run_within_env() {
       local path
-      path=$(echo "$PATH" | sed -e "s|$(asdf_data_dir)/shims||g; s|::|:|g")
+      path=$(sed -e "s|$(asdf_data_dir)/shims||g; s|::|:|g" <<< "$PATH")
 
       executable_path=$(PATH=$path command -v "$shim_name")
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -289,7 +289,7 @@ get_executable_path() {
   check_if_version_exists "$plugin_name" "$version"
 
   if [ "$version" = "system" ]; then
-    path=$(sed -e "s|$(asdf_data_dir)/shims||g; s|::|:|g" <<< "$PATH")
+    path=$(sed -e "s|$(asdf_data_dir)/shims||g; s|::|:|g" <<<"$PATH")
     cmd=$(basename "$executable_path")
     cmd_path=$(PATH=$path command -v "$cmd" 2>&1)
     # shellcheck disable=SC2181
@@ -547,7 +547,7 @@ with_plugin_env() {
 
   # exec_paths contains a trailing newline which is converted to a colon, so no
   # colon is needed between the subshell and the PATH variable in this string
-  path="$(tr '\n' ':' <<< "$exec_paths")$PATH"
+  path="$(tr '\n' ':' <<<"$exec_paths")$PATH"
 
   # If no custom exec-env transform, just execute callback
   if [ ! -f "${plugin_path}/bin/exec-env" ]; then
@@ -625,7 +625,7 @@ strip_tool_version_comments() {
 
   while IFS= read -r tool_line || [ -n "$tool_line" ]; do
     # Remove whitespace before pound sign, the pound sign, and everything after it
-    new_line="$(cut -f1 -d"#" <<< "$tool_line" | sed -e 's/[[:space:]]*$//')"
+    new_line="$(cut -f1 -d"#" <<<"$tool_line" | sed -e 's/[[:space:]]*$//')"
 
     # Only print the line if it is not empty
     if [[ -n "$new_line" ]]; then
@@ -733,7 +733,7 @@ with_shim_executable() {
 
     run_within_env() {
       local path
-      path=$(sed -e "s|$(asdf_data_dir)/shims||g; s|::|:|g" <<< "$PATH")
+      path=$(sed -e "s|$(asdf_data_dir)/shims||g; s|::|:|g" <<<"$PATH")
 
       executable_path=$(PATH=$path command -v "$shim_name")
 

--- a/test/banned_commands.bats
+++ b/test/banned_commands.bats
@@ -16,6 +16,9 @@ banned_commands=(
     "grep.* -y"
     # sort -V isn't supported everywhere
     "sort.*-V"
+    # echo isn't consistent across operating systems, and sometimes output can
+    # be confused with echo flags. printf does everything echo does and more.
+    echo
 )
 
 setup() {


### PR DESCRIPTION
# Summary

* Add `echo` to list of banned commands.
* Replace `echo` calls with calls to `printf`.
* Correct existing `printf` calls that were generating ShellCheck warnings.

Fixes: #781
