### PR TITLE
fix: docs file rename

### DIFF
--- a/release/tag.sh
+++ b/release/tag.sh
@@ -113,9 +113,9 @@ fi
 sed -i.bak "s|^\\(git clone.*--branch \\).*$|\\1$new_tag_name|" README.md
 rm README.md.bak
 
-# Update version in docs/core-manage-asdf-vm.md
-sed -i.bak "s|^\\(git clone.*--branch \\).*$|\\1$new_tag_name|" docs/core-manage-asdf-vm.md
-rm docs/core-manage-asdf-vm.md.bak
+# Update version in docs/core-manage-asdf.md
+sed -i.bak "s|^\\(git clone.*--branch \\).*$|\\1$new_tag_name|" docs/core-manage-asdf.md
+rm docs/core-manage-asdf.md.bak
 
 # Update version in the VERSION file
 echo "$new_tag_name" >VERSION
@@ -124,7 +124,7 @@ echo "INFO: Committing and tagging new version"
 
 # Commit the changed files before tagging the new release
 git add README.md
-git add docs/core-manage-asdf-vm.md
+git add docs/core-manage-asdf.md
 git add VERSION
 git commit -m "Update version to $new_version"
 


### PR DESCRIPTION
# Summary

We renamed the documentation to refer to `asdf` the tool itself instead of `asdf-vm`. We forgot to update the release script.
