### PR TITLE
Update no plugin installed error message

### DIFF
--- a/lib/commands/command-list.bash
+++ b/lib/commands/command-list.bash
@@ -14,7 +14,7 @@ list_command() {
         display_installed_versions "$plugin_name"
       done
     else
-      printf "%s\\n" 'Oohes nooes ~! No plugins installed'
+      printf "%s\\n" 'No plugins installed'
     fi
   else
     check_if_plugin_exists "$plugin_name"

--- a/lib/commands/command-plugin-list.bash
+++ b/lib/commands/command-plugin-list.bash
@@ -45,7 +45,7 @@ plugin_list_command() {
       done
     ) | awk '{ if (NF > 1) { printf("%-28s", $1) ; $1="" }; print $0}'
   else
-    display_error 'Oohes nooes ~! No plugins installed'
+    display_error 'No plugins installed'
     exit 1
   fi
 }

--- a/test/current_command.bats
+++ b/test/current_command.bats
@@ -127,7 +127,7 @@ foobar          1.0.0           $PROJECT_DIR/.tool-versions"
 
 @test "with no plugins prints an error" {
   clean_asdf_dir
-  expected="Oohes nooes ~! No plugins installed"
+  expected="No plugins installed"
 
   run asdf current
   [ "$status" -eq 0 ]


### PR DESCRIPTION
# Summary

Fixes: Updates error message when no plugins are installed

## Other Information

The previous error message was overly informal
