### PR TITLE
docs: print docs and github URLs in help cmd

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -51,3 +51,7 @@ asdf shim-versions <command>            List the plugins and versions that
                                         provide a command
 asdf update                             Update asdf to the latest stable release
 asdf update --head                      Update asdf to the latest on the master branch
+
+RESOURCES
+GitHub: https://github.com/asdf-vm/asdf
+Docs:   https://asdf-vm.com


### PR DESCRIPTION
# Summary

I was using some other tools earlier this week and found links to the repo and documentation in their `help` command output very useful to discover the separate documentation site without resorting to searching or browsing the repo.

I suggest we add it here to improve the visibility of our own documentation site

