### PR TITLE
Update documentation references to icongram svg files

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ See [CONTRIBUTING.md in the repo](https://github.com/asdf-vm/asdf/blob/master/CO
 
 ## Community & Questions
 
-<!-- - [![GitHub Discussions](https://icongram.jgog.in/simple/github.svg?color=808080&size=16)Github Discussions TBA](https://github.com/asdf-vm/asdf/discussions): our preferred method for community Q&A and interaction -->
+<!-- - [![GitHub Discussions](https://icongr.am/simple/github.svg?color=808080&size=16)Github Discussions TBA](https://github.com/asdf-vm/asdf/discussions): our preferred method for community Q&A and interaction -->
 
-- [![Github Issues](https://icongram.jgog.in/simple/github.svg?color=808080&size=16) Github Issues](https://github.com/asdf-vm/asdf/issues): report a bug or raise a feature request to the `asdf` core team
+- [![Github Issues](https://icongr.am/simple/github.svg?color=808080&size=16) Github Issues](https://github.com/asdf-vm/asdf/issues): report a bug or raise a feature request to the `asdf` core team
 - [![StackOverflow Tag](https://icongr.am/fontawesome/stack-overflow.svg?size=16&color=808080) StackOverflow Tag](https://stackoverflow.com/questions/tagged/asdf-vm): see existing Q&A for `asdf`. Some of the core team watch this tag in addition to our helpful community

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -15,6 +15,6 @@
 - [Documentation Site](contributing-doc-site)
 - [Thanks](thanks)
 - **Community & Questions**
-- [![Github Issues](https://icongram.jgog.in/simple/github.svg?color=808080&size=16)Github Issues](https://github.com/asdf-vm/asdf/issues)
+- [![Github Issues](https://icongr.am/simple/github.svg?color=808080&size=16)Github Issues](https://github.com/asdf-vm/asdf/issues)
 - [![StackOverflow Tag](https://icongr.am/fontawesome/stack-overflow.svg?size=16&color=808080)StackOverflow Tag](https://stackoverflow.com/questions/tagged/asdf-vm)
-<!-- - [![GitHub Discussions](https://icongram.jgog.in/simple/github.svg?color=808080&size=16)Github Discussions TBA](https://github.com/asdf-vm/asdf/discussions) -->
+<!-- - [![GitHub Discussions](https://icongr.am/simple/github.svg?color=808080&size=16)Github Discussions TBA](https://github.com/asdf-vm/asdf/discussions) -->


### PR DESCRIPTION
# Summary

Updates image references from `icongram.jgog.in` to `icongr.am` URLs

## Other Information

I noticed the broken image in the documentation site sidebar:
<img width="266" alt="Screen Shot 2020-11-17 at 10 43 17 PM" src="https://user-images.githubusercontent.com/483223/99495396-70ed5f00-2927-11eb-9f1f-8acc13635f5e.png">

As far as I can tell, `icongram.jgog.in` became `icongr.am` (partly based on [this tweet](https://twitter.com/GeekGogari/status/912689871818457090)).

I did a search for references to the old domain and updated them to the new one.