### PR TITLE
docs: github dicsussions link

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,8 @@ asdf is a CLI tool that can manage multiple language runtime versions on a per-p
 
 See [CONTRIBUTING.md in the repo](https://github.com/asdf-vm/asdf/blob/master/CONTRIBUTING.md) or the [Contributing section on the docs site](http://asdf-vm.github.io/asdf/#/contributing-core-asdf).
 
-
-
 ## Community & Questions
 
-<!-- - [![GitHub Discussions](https://icongr.am/simple/github.svg?color=808080&size=16)Github Discussions TBA](https://github.com/asdf-vm/asdf/discussions): our preferred method for community Q&A and interaction -->
-
 - [![Github Issues](https://icongr.am/simple/github.svg?color=808080&size=16) Github Issues](https://github.com/asdf-vm/asdf/issues): report a bug or raise a feature request to the `asdf` core team
+- [![GitHub Discussions](https://icongr.am/simple/github.svg?color=808080&size=16) Github Discussions](https://github.com/asdf-vm/asdf/discussions): our preferred method for community Q&A and interaction
 - [![StackOverflow Tag](https://icongr.am/fontawesome/stack-overflow.svg?size=16&color=808080) StackOverflow Tag](https://stackoverflow.com/questions/tagged/asdf-vm): see existing Q&A for `asdf`. Some of the core team watch this tag in addition to our helpful community

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -15,6 +15,6 @@
 - [Documentation Site](contributing-doc-site)
 - [Thanks](thanks)
 - **Community & Questions**
-- [![Github Issues](https://icongr.am/simple/github.svg?color=808080&size=16)Github Issues](https://github.com/asdf-vm/asdf/issues)
-- [![StackOverflow Tag](https://icongr.am/fontawesome/stack-overflow.svg?size=16&color=808080)StackOverflow Tag](https://stackoverflow.com/questions/tagged/asdf-vm)
-<!-- - [![GitHub Discussions](https://icongr.am/simple/github.svg?color=808080&size=16)Github Discussions TBA](https://github.com/asdf-vm/asdf/discussions) -->
+- [![Github Issues](https://icongr.am/simple/github.svg?color=808080&size=16) Github Issues](https://github.com/asdf-vm/asdf/issues)
+- [![GitHub Discussions](https://icongr.am/simple/github.svg?color=808080&size=16) Github Discussions](https://github.com/asdf-vm/asdf/discussions)
+- [![StackOverflow Tag](https://icongr.am/fontawesome/stack-overflow.svg?size=16&color=808080) StackOverflow Tag](https://stackoverflow.com/questions/tagged/asdf-vm)


### PR DESCRIPTION
# Summary

Adds links to GitHub Discussions in the *Community & Questions* section of README and Sidepane of docs site
