### PR TITLE
docs: improve zsh completion directions for macOS,ZSH,Homebrew

### DIFF
--- a/docs/core-manage-asdf.md
+++ b/docs/core-manage-asdf.md
@@ -239,7 +239,7 @@ echo -e "\n. $(brew --prefix asdf)/asdf.sh" >> ~/.zshrc
 ```
 **OR** use a ZSH Framework plugin like [asdf for oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/asdf) which will source this script and setup completions.
 
-?> Completions are configured by either a ZSH Framework `asdf` or  will need to be [configured as per Homebrew's instructions](https://docs.brew.sh/Shell-Completion#configuring-completions-in-zsh).
+?> Completions are configured by either a ZSH Framework `asdf` or  will need to be [configured as per Homebrew's instructions](https://docs.brew.sh/Shell-Completion#configuring-completions-in-zsh). If you are using a ZSH Framework the associated asdf plugin may need to be updated to use the new ZSH completions properly via fpath. The Oh-My-ZSH asdf plugin is yet to be updated, see [ohmyzsh/ohmyzsh#8837](https://github.com/ohmyzsh/ohmyzsh/pull/8837).
 
 
 ### --Docsify Select Default--

--- a/docs/core-manage-asdf.md
+++ b/docs/core-manage-asdf.md
@@ -237,8 +237,10 @@ Add `asdf.sh` to your `~/.zshrc` with:
 ```shell
 echo -e "\n. $(brew --prefix asdf)/asdf.sh" >> ~/.zshrc
 ```
+**OR** use a ZSH Framework plugin like [asdf for oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/asdf) which will source this script and setup completions.
 
-?> Completions will need to be [configured as per Homebrew's instructions](https://docs.brew.sh/Shell-Completion#configuring-completions-in-zsh).
+?> Completions are configured by either a ZSH Framework `asdf` or  will need to be [configured as per Homebrew's instructions](https://docs.brew.sh/Shell-Completion#configuring-completions-in-zsh).
+
 
 ### --Docsify Select Default--
 


### PR DESCRIPTION
# Summary

Changed install directions as the ohmyzsh asdf plugin has been updated to support Homebrew and completion from ohmyzsh/ohmyzsh#6749.

