### PR TITLE
fix: shims break when POSIXLY_CORRECT=1

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -663,7 +663,10 @@ preset_versions() {
 
 select_from_preset_version() {
   shim_name=$1
-  grep -f <(get_shim_versions "$shim_name") <(preset_versions "$shim_name") | head -n 1 | xargs -IVERSION printf "%s\\n" VERSION
+  shim_versions=$(get_shim_versions "$shim_name")
+  if [ -n "$shim_versions" ]; then
+    preset_versions "$shim_name" | grep -F "$shim_versions" | head -n 1 | xargs -IVERSION printf "%s\\n" VERSION
+  fi
 }
 
 select_version() {

--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -436,3 +436,15 @@ EOM
   [ "$status" -eq 1 ]
 }
 
+# From @tejanium in https://github.com/asdf-vm/asdf/issues/581#issuecomment-635337727
+@test "asdf exec should not crash when POSIXLY_CORRECT=1" {
+  export POSIXLY_CORRECT=1
+
+  echo "dummy 1.0" > $PROJECT_DIR/.tool-versions
+  run asdf install
+
+  run asdf exec dummy world hello
+  echo $output
+  [ "$output" == "This is Dummy 1.0! hello world" ]
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
# Summary

Process substitution isn't specified by POSIX and makes shims break when called by a script that `export POSIXLY_CORRECT=1` (like gitflow [here](https://github.com/nvie/gitflow/blob/develop/git-flow#L78)).

Here we replace `grep -f <(cmd1) <(cmd2)` with `cmd2 | grep -F "$(cmd1)"` so that we can provide a string instead of a file descriptor and get the same result as before.

(Note: We also check if the result of `cmd1` is empty before running `grep` to get the same behavior as with `-f`. This also prevent crashes if null results are piped to `xargs` and fits nicely with the `with_shim_executable` function that already check the result of `$selected_version` [here](https://github.com/asdf-vm/asdf/blob/master/lib/utils.bash#L729) before going on).

Fixes: #581

## Other Information

The test case is from @tejanium in #581.

From the man page of `grep`:

```
-f FILE, --file=FILE
      Obtain  patterns  from  FILE, one per line.  The empty file contains zero patterns,
      and therefore matches nothing.  (-f is specified by POSIX.)

-F, --fixed-strings
      Interpret  PATTERN  as a list of fixed strings, separated by newlines, any of which
      is to be matched.  (-F is specified by POSIX.)
```
