### PR TITLE
Fix find global options warning

### DIFF
--- a/lib/commands/command-plugin-update.bash
+++ b/lib/commands/command-plugin-update.bash
@@ -14,7 +14,7 @@ plugin_update_command() {
         local plugin_name
         plugin_name=$(basename "$dir")
         update_plugin "$plugin_name" "$dir" "$gitref" &
-      done < <(find "$(asdf_data_dir)"/plugins -type d -mindepth 1 -maxdepth 1)
+      done < <(find "$(asdf_data_dir)"/plugins -mindepth 1 -maxdepth 1 -type d)
       wait
     fi
   else


### PR DESCRIPTION
When updating plugins, I've gotten this warning:

```
find: warning: you have specified the global option -mindepth after the argument
-type, but global options are not positional, i.e., -mindepth affects tests
specified before it as well as those specified after it.  Please specify global
options before other arguments.

find: warning: you have specified the global option -maxdepth after the argument
-type, but global options are not positional, i.e., -maxdepth affects tests
specified before it as well as those specified after it.  Please specify global
options before other arguments.
```

# Summary

Change find options position on `lib/commands/command-plugin-update.bash`

## Other Information

If there is anything else that is relevant to your pull request include that
information here.

Thank you for contributing to asdf!
