### PR TITLE
docs: fish symlink completions rather than copying

### DIFF
--- a/docs/core-manage-asdf.md
+++ b/docs/core-manage-asdf.md
@@ -121,7 +121,7 @@ source ~/.asdf/asdf.fish
 ?> Completions must be configured manually with the following command:
 
 ```shell
-mkdir -p ~/.config/fish/completions; and cp ~/.asdf/completions/asdf.fish ~/.config/fish/completions
+mkdir -p ~/.config/fish/completions; and ln -s ~/.asdf/completions/asdf.fish ~/.config/fish/completions
 ```
 
 #### --Linux,ZSH,Git--


### PR DESCRIPTION
# Summary

At the moment, the fish installation instructions copy the completions to the ~/.config/fish/completions directory.

Having tried this locally, a symlink works just as well.

Could it be worth symlinking to bring along any future updates to the completions file?