### PR TITLE
Ban process substitution from asdf codebase

### DIFF
--- a/lib/commands/command-plugin-update.bash
+++ b/lib/commands/command-plugin-update.bash
@@ -10,11 +10,12 @@ plugin_update_command() {
   local gitref="${2:-master}"
   if [ "$plugin_name" = "--all" ]; then
     if [ -d "$(asdf_data_dir)"/plugins ]; then
+      plugins=(find "$(asdf_data_dir)"/plugins -type d -mindepth 1 -maxdepth 1)
       while IFS= read -r -d '' dir; do
         local plugin_name
         plugin_name=$(basename "$dir")
         update_plugin "$plugin_name" "$dir" "$gitref" &
-      done < <(find "$(asdf_data_dir)"/plugins -type d -mindepth 1 -maxdepth 1)
+      done <<< "$plugins"
       wait
     fi
   else

--- a/lib/commands/command-reshim.bash
+++ b/lib/commands/command-reshim.bash
@@ -119,7 +119,19 @@ remove_obsolete_shims() {
   exec_names=$(plugin_executables "$plugin_name" "$full_version" | xargs -IX basename X | sort)
 
   local obsolete_shims
-  obsolete_shims=$(comm -23 <(printf "%s\\n" "$shims") <(printf "%s\\n" "$exec_names"))
+  local formatted_shims
+  local formatted_exec_names
+
+  # comm only takes to files, so we write this data to temp files so we can
+  # pass it to comm.
+  formatted_shims=$(mktemp /tmp/asdf-command-reshim-formatted-shims.XXXXXX)
+  printf "%s\\n" "$shims" > "$formatted_shims"
+
+  formatted_exec_names=$(mktemp /tmp/asdf-command-reshim-formatted-exec-names.XXXXXX)
+  printf "%s\\n" "$exec_names" > "$formatted_exec_names"
+
+  obsolete_shims=$(comm -23 "$formatted_shims" "$formatted_exec_names")
+  rm -f "$formatted_exec_names" "$formatted_shims"
 
   for shim_name in $obsolete_shims; do
     remove_shim_for_version "$plugin_name" "$full_version" "$shim_name"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -662,8 +662,10 @@ preset_versions() {
 }
 
 select_from_preset_version() {
-  shim_name=$1
-  grep -f <(get_shim_versions "$shim_name") <(preset_versions "$shim_name") | head -n 1 | xargs -IVERSION printf "%s\\n" VERSION
+  local shim_name=$1
+  local shim_versions=$(get_shim_versions "$shim_name")
+  local present_versions=$(preset_versions "$shim_name")
+  grep -f "$shim_versions" "$preset_versions" | head -n 1 | xargs -IVERSION printf "%s\\n" VERSION
 }
 
 select_version() {

--- a/test/banned_commands.bats
+++ b/test/banned_commands.bats
@@ -19,6 +19,8 @@ banned_commands=(
     # echo isn't consistent across operating systems, and sometimes output can
     # be confused with echo flags. printf does everything echo does and more.
     echo
+    # Process substitution isn't POSIX compliant and cause trouble
+    "<("
 )
 
 setup() {


### PR DESCRIPTION
# Summary

Process substitution is not POSIX compliant and has caused our users issues in the past. It's not to hard to work around not having it, and doing so makes asdf compatible in more environments.

Fixes: #851

