### PR TITLE
Support alternate location for .zshrc

### DIFF
--- a/docs/core-manage-asdf.md
+++ b/docs/core-manage-asdf.md
@@ -235,7 +235,7 @@ echo -e "\nsource "(brew --prefix asdf)"/asdf.fish" >> ~/.config/fish/config.fis
 Add `asdf.sh` to your `~/.zshrc` with:
 
 ```shell
-echo -e "\n. $(brew --prefix asdf)/asdf.sh" >> ~/.zshrc
+echo -e "\n. $(brew --prefix asdf)/asdf.sh" >> ${ZDOTDIR:-~}/.zshrc
 ```
 **OR** use a ZSH Framework plugin like [asdf for oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/asdf) which will source this script and setup completions.
 


### PR DESCRIPTION
Z shell supports placing your zshrc file in an alternate location, such as inside `.config` (which makes it far more conveninent to store your dot files in a Git repo, or even just sync them across machines with other folder-oriented synchronization tools).  

The current command assumes the default location of putting the rc file directly in the home directory.  But it is easy enough to support all alternate locations as well.  This version defaults to `~` if the variable `ZDOTDIR` is not defined.

I'm only including the case I've tested in this PR, but if you want me to do the same thing for other shells and other cases with Zsh, I'm open to doing that too.

# Summary

Provide a general description of the code changes in your pull request.

Fixes: List issue numbers here

## Other Information

If there is anything else that is relevant to your pull request include that
information here.

Thank you for contributing to asdf!
