### PR TITLE
docs: button for adding new translations

### DIFF
--- a/docs/_navbar.md
+++ b/docs/_navbar.md
@@ -1,2 +1,3 @@
 - Translations
   - [:uk: English](/)
+  - [Add translation](contributing-doc-site?id=translations)


### PR DESCRIPTION
The "language translation" section is somewhat diffcult to find, this addition makes it easily accessible even from the homepage.

Added a single line.