### PR TITLE
Add check command

### DIFF
--- a/lib/commands/command-check.bash
+++ b/lib/commands/command-check.bash
@@ -1,0 +1,18 @@
+# -*- sh -*-
+
+# shellcheck disable=SC2059
+check_command() {
+  local exit_status=0
+  local not_installed_description
+  not_installed_description="Not installed"
+
+  while read -r line; do
+    if [[ $line == *"$not_installed_description"* ]]; then
+      exit_status=$((exit_status + 1))
+    fi
+  done <<<"$(asdf current 2>&1)"
+
+  exit "$exit_status"
+}
+
+check_command

--- a/test/check_command.bats
+++ b/test/check_command.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+
+load test_helpers
+
+setup() {
+  setup_asdf_dir
+  install_dummy_plugin
+  install_dummy_version "1.1.0"
+
+  PROJECT_DIR=$HOME/project
+  mkdir $PROJECT_DIR
+}
+
+teardown() {
+  clean_asdf_dir
+}
+
+@test "check should return with exit code 0 when installed versions match" {
+  cd $PROJECT_DIR
+  echo 'dummy 1.1.0' >> $PROJECT_DIR/.tool-versions
+
+  run asdf check
+  [ "$status" -eq 0 ]
+}
+
+@test "check should return with exit code 1 when installed versions do not match" {
+  cd $PROJECT_DIR
+  echo "dummy 1.2.0" >> $PROJECT_DIR/.tool-versions
+
+  run asdf check
+  [ "$status" -eq 1 ]
+}
+
+@test "check should return with exit code 0 when no local versions specified" {
+  cd $PROJECT_DIR
+
+  run asdf check
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
# Summary

The check command returns exit code 0 or 1, depending if the version requirements for the current directory are met. Best used in conjunction with other tooling for automated installation, etc.

I have tested this in conjunction with a direnv containing:

```
if has asdf; then
  asdf check || asdf install
fi
```

...and it works like magic!

Fixes: #734 

## Other Information

This change goes out of its way to take advantage of another asdf function, `current` by parsing its output (rather than re-implementing roughly 80% of that function). Tests provided to ensure nothing breaks if ever the string parsing fails.