### PR TITLE
Always rewrite shims, not just update meta-data.

### DIFF
--- a/lib/commands/command-reshim.bash
+++ b/lib/commands/command-reshim.bash
@@ -67,18 +67,12 @@ write_shim_script() {
   local shim_path
   shim_path="$(asdf_data_dir)/shims/$executable_name"
 
-  if [ -f "$shim_path" ]; then
-    if ! grep -x "# asdf-plugin: ${plugin_name} ${version}" "$shim_path" >/dev/null; then
-      sed -i.bak -e "s/exec /# asdf-plugin: ${plugin_name} ${version}\\"$'\n''exec /' "$shim_path"
-      rm "$shim_path".bak
-    fi
-  else
-    cat <<EOF >"$shim_path"
+
+  cat <<EOF >"$shim_path"
 #!/usr/bin/env bash
 # asdf-plugin: ${plugin_name} ${version}
 exec $(asdf_dir)/bin/asdf exec "${executable_name}" "\$@"
 EOF
-  fi
 
   chmod +x "$shim_path"
 }


### PR DESCRIPTION
# Summary 
Always rewrite shims from scratch instead of doing meta-data comparison and updates, this means less state to maintain and less avenues where things can go wrong.
This also allows Homebrew to setup a `post_install` that triggers `asdf reshim`.

# Details 
So as I understand this, this checks if the meta-data inside a shim matches the expected version and plugin and rewrites the meta-data if it doesn't. 
```shell
sed -i.bak -e "s/exec /# asdf-plugin: ${plugin_name} ${version}\\"$'\n''exec /' "$shim_path"
rm "$shim_path".bak
```
One of the issues is, that it doesn't check to see if the path to asdf has changed, this can happen when homebrew updates and asdf finds itself changed from `..../0.8.o/asdf` to `..../0.8.1/asdf`
But we never check the path, just the meta-data. 

```shell
exec /usr/local/Cellar/asdf/0.8.0/libexec/bin/asdf exec "iex" "$@"
```

If a new version is released in Homebrew, the path above will be invalid. 

I am open to adding a different command or an option like `--force`, but in general I think this is for the better unless I've missed a substantial reason for doing meta-data comparison instead of just rewriting the file each time.
Performance is not it, as it is equally fast. 

Edit: Might want to point out that this isn't 100% necessary if we want to skip `asdf` path being under a versioned namespace. 

We can always just resort to `exec /usr/local/opt/asdf/libexec/bin/asdf exec "iex" "$@"` but for some reason I think that having asdf namespaced under a version to be good hygiene, but it will require a reshim on asdf updates. This can be automated with post_install hook but needs changes from this PR. 

Related: 
https://github.com/Homebrew/homebrew-core/pull/73173
https://github.com/asdf-vm/asdf/issues/891

