### PR TITLE
[WIP] asdf <global | local> <plugin> <version> should write/replace from .tools-version

### DIFF
--- a/lib/commands/version_commands.bash
+++ b/lib/commands/version_commands.bash
@@ -44,7 +44,7 @@ version_command() {
     resolved_versions+=("$version")
   done
   
-  if [ -z "$resolved_versions" ] || [ "$cmd" = "local-tree" ]; then
+  if [ "${#resolved_versions[@]}" -eq 0 ] || [ "$cmd" = "local-tree" ]; then
     exit 1
   fi
 

--- a/lib/commands/version_commands.bash
+++ b/lib/commands/version_commands.bash
@@ -40,15 +40,20 @@ version_command() {
     fi
     if ! (check_if_version_exists "$plugin_name" "$version"); then
       version_not_installed_text "$plugin_name" "$version" 1>&2
-      exit 1
     fi
     resolved_versions+=("$version")
   done
+  
+  if [ -z "$resolved_versions" ] || [ "$cmd" = "local-tree" ]; then
+    exit 1
+  fi
 
   if [ -f "$file" ] && grep "^$plugin_name " "$file" >/dev/null; then
     sed -i.bak -e "s|^$plugin_name .*$|$plugin_name ${resolved_versions[*]}|" "$file"
     rm "$file".bak
+    printf "Replacing %s %s with version %s in %s\\n" "$cmd" "$plugin_name" "${resolved_versions[*]}" "$file"
   else
-    printf "%s %s\\n" "$plugin_name" "${resolved_versions[*]}" >>"$file"
+    printf "\\n%s %s\\n" "$plugin_name" "${resolved_versions[*]}" >>"$file"
+    printf "Adding %s %s version %s to %s\\n" "$cmd" "$plugin_name" "${resolved_versions[*]}" "$file"
   fi
 }


### PR DESCRIPTION
# Summary
Make sure code matches [documentation claims](https://asdf-vm.com/#/core-manage-versions?id=set-current-version) that `$ asdf <global | local> <plugin> <version>` would write to the `.tools-version` file. 

Assuming default `$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME` set to `$HOME/.tool-versions` 
Running `$ asdf global ruby 3.0.0` should write `ruby 3.0.0` to `$HOME/.tool-versions` 
Only enabled for `global` and `local`, thus not enabled for `local-tree` as it would be too risky.

# Details
Now, I know the tests are claiming this is in place, but running the current version `0.8.0` on macOS, it doesn't seem to update my global file. 

It fails here
```shell
    if ! (check_if_version_exists "$plugin_name" "$version"); then
       version_not_installed_text "$plugin_name" "$version" 1>&2
       exit 1
     fi
```

I just moved the exit further down under conditions that doesn't want`.tool-versions` to be updated. 
```shell
if [ -z "$resolved_versions" ] || [ "$cmd" = "local-tree" ]; then
     exit 1
fi
```

And added some logging when adding
```shell
    printf "Adding %s %s version %s to %s\\n" "$cmd" "$plugin_name" "${resolved_versions[*]}" "$file"
```
or when replacing 
```shell
printf "Replacing %s %s with version %s in %s\\n" "$cmd" "$plugin_name" "${resolved_versions[*]}" "$file"
```

Maybe someone could comment on why the tests are claiming that feature is in place, but not actually working? 
I know that the current released version does not match the master branch, noticed all the `echo` been replaced with `printf` but that `exit 1` is on both code bases. 

WIP until tests are green

