### PR TITLE
fix: consistent system completion

### DIFF
--- a/completions/_asdf
+++ b/completions/_asdf
@@ -76,6 +76,21 @@ _asdf__installed_versions_of() {
     compadd -a versions
 }
 
+_asdf__installed_versions_of_plus_system() {
+  local plugin_dir="${asdf_dir:?}/installs/${1:?need a plugin version}"
+  if [[ ! -d "$plugin_dir" ]]; then
+    _wanted "asdf-versions-$1" expl "ASDF Plugin ${(q-)1} versions" \
+      compadd -x "no versions installed"
+    return
+  fi
+  local -a versions
+  versions=( "$plugin_dir"/*(:t) )
+  versions+="system"
+  _wanted "asdf-versions-$1" expl "ASDF Plugin ${(q-)1} versions" \
+    compadd -a versions
+}
+
+
 local -i IntermediateCount=0
 
 if (( CURRENT == 2 )); then
@@ -165,9 +180,13 @@ case "$subcmd" in
       compadd -- $(asdf list-all "$pkg" "$query")
   fi
   ;;
-(uninstall|shell|local|global|reshim)
+(uninstall|reshim)
   compset -n 2
   _arguments '1:plugin-name: _asdf__installed_plugins' '2:package-version:{_asdf__installed_versions_of ${words[2]}}'
+  ;;
+(shell|local|global)
+  compset -n 2
+  _arguments '1:plugin-name: _asdf__installed_plugins' '2:package-version:{_asdf__installed_versions_of_plus_system ${words[2]}}'
   ;;
 (where)
   # version is optional

--- a/completions/asdf.bash
+++ b/completions/asdf.bash
@@ -44,10 +44,22 @@ _asdf() {
     # shellcheck disable=SC2207
     COMPREPLY=($(compgen -W "--head" -- "$cur"))
     ;;
-  uninstall | where | reshim | local | global | shell)
+  uninstall | where | reshim)
     if [[ "$plugins" == *"$prev"* ]]; then
       local versions
       versions=$(asdf list "$prev" 2>/dev/null)
+      # shellcheck disable=SC2207
+      COMPREPLY=($(compgen -W "$versions" -- "$cur"))
+    else
+      # shellcheck disable=SC2207
+      COMPREPLY=($(compgen -W "$plugins" -- "$cur"))
+    fi
+    ;;
+  local | global | shell)
+    if [[ "$plugins" == *"$prev"* ]]; then
+      local versions
+      versions=$(asdf list "$prev" 2>/dev/null)
+      versions+=" system"
       # shellcheck disable=SC2207
       COMPREPLY=($(compgen -W "$versions" -- "$cur"))
     else


### PR DESCRIPTION
I am trying to add the "system" parameter for completion, in bash and zsh.

This present solution is similar to how it is done in fish, basically appending the "system" option at the end of the present versions. Because some options (shell, local, global) need this, but others such as uninstall do not need a "system" version in their completions, I was not able to do it elegantly. I had to split the completion code for the commands that do require system, and commands that do not require system.

This solves issue #868.