### PR TITLE
feat: Add versioning to plugin add command

### DIFF
--- a/lib/commands/command-plugin-update.bash
+++ b/lib/commands/command-plugin-update.bash
@@ -32,8 +32,8 @@ update_plugin() {
   logfile=$(mktemp)
 
   local current_ref
-  current_ref=$(git --git-dir "$plugin_path/.git" rev-parse --abbrev-ref --symbolic-full-name HEAD)
-  if [ "$current_ref" = "HEAD" ]; then
+  current_ref=$(git --git-dir "$plugin_path/.git" branch --show-current)
+  if [ ! "$current_ref" = "$plugin_remote_default_branch" ]; then
     {
       printf "Skipping detached %s\\n" "$plugin_name"
     } >"$logfile" 2>&1

--- a/test/plugin_add_command.bats
+++ b/test/plugin_add_command.bats
@@ -53,7 +53,7 @@ teardown() {
 }
 
 @test "plugin_add command with URL and git-ref specified adds a plugin using repo" {
-  install_mock_plugin_repo_with_ref "dummy"
+  install_mock_plugin_repo_with_ref "dummy" "tagname"
 
   run asdf plugin-add "dummy" "${BASE_DIR}/repo-dummy" "tagname"
   [ "$status" -eq 0 ]

--- a/test/plugin_add_command.bats
+++ b/test/plugin_add_command.bats
@@ -52,6 +52,20 @@ teardown() {
   [ "$output" = "dummy" ]
 }
 
+@test "plugin_add command with URL and git-ref specified adds a plugin using repo" {
+  install_mock_plugin_repo_with_ref "dummy"
+
+  run asdf plugin-add "dummy" "${BASE_DIR}/repo-dummy" "tagname"
+  [ "$status" -eq 0 ]
+
+  repo_head="$(git --git-dir "${BASE_DIR}/repo-dummy/.git" --work-tree "$ASDF_DIR/plugins/dummy" describe --tags)"
+  [ "$status" -eq 0 ]
+  [ "$repo_head" = "tagname" ]
+
+  run asdf plugin-list
+  [ "$output" = "dummy-tagname" ]
+}
+
 @test "plugin_add command with URL specified run twice returns error second time" {
   install_mock_plugin_repo "dummy"
 

--- a/test/plugin_update_command.bats
+++ b/test/plugin_update_command.bats
@@ -80,6 +80,21 @@ teardown() {
   [ "$repo_head" = "main" ]
 }
 
+@test "asdf plugin-update should skip updates for detached plugin" {
+  install_mock_plugin_repo_with_ref "dummy" "tagname"
+
+  run asdf plugin add "dummy" "${BASE_DIR}/repo-dummy" "tagname"
+  [ "$status" -eq 0 ]
+
+  run asdf plugin update dummy-tagname
+
+  current_ref="$(git --git-dir "$ASDF_DIR/plugins/dummy-tagname/.git" --work-tree "$ASDF_DIR/plugins/dummy-tagname" describe --tags)"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Skipping detached dummy-tagname"* ]]
+  [ "$current_ref" = "tagname" ]
+}
+
 @test "asdf plugin-update should not remove plugin versions" {
   run asdf install dummy 1.1
   [ "$status" -eq 0 ]

--- a/test/test_helpers.bash
+++ b/test/test_helpers.bash
@@ -57,8 +57,9 @@ install_mock_plugin_repo() {
 install_mock_plugin_repo_with_ref() {
   install_mock_plugin_repo "$1"
   local plugin_name=$1
+  local tagname=$2
   local location="${BASE_DIR}/repo-${plugin_name}"
-  git -C "${location}" tag "tagname"
+  git -C "${location}" tag "${tagname}"
 }
 
 install_mock_plugin_version() {

--- a/test/test_helpers.bash
+++ b/test/test_helpers.bash
@@ -54,6 +54,13 @@ install_mock_plugin_repo() {
   git -C "${location}" commit -q -m "asdf ${plugin_name} plugin"
 }
 
+install_mock_plugin_repo_with_ref() {
+  install_mock_plugin_repo "$1"
+  local plugin_name=$1
+  local location="${BASE_DIR}/repo-${plugin_name}"
+  git -C "${location}" tag "tagname"
+}
+
 install_mock_plugin_version() {
   local plugin_name=$1
   local plugin_version=$2


### PR DESCRIPTION
# Summary

Allows user to specify version along with URL when adding plugin to lock
to a specific version instead of always relying on HEAD.


```
❯ git clone https://github.com/theoretick/asdf.git ~/.asdf --branch support-plugin-versions
Cloning into '/Users/theoretick/.asdf'...
remote: Enumerating objects: 8, done.
remote: Counting objects: 100% (8/8), done.
remote: Compressing objects: 100% (8/8), done.
remote: Total 5913 (delta 0), reused 1 (delta 0), pack-reused 5905
Receiving objects: 100% (5913/5913), 1.10 MiB | 12.68 MiB/s, done.
Resolving deltas: 100% (3400/3400), done.

❯ source ~/.asdf/asdf.sh

❯ asdf plugin add java https://github.com/halcyon/asdf-java.git

❯ asdf plugin add java https://github.com/halcyon/asdf-java.git travis-fix

❯ asdf plugin list
java
java-travis-fix

❯
```

## Other Information

Relates to https://github.com/asdf-vm/asdf/pull/234