### PR TITLE
Fix tiny text for "By-passing asdf shims" heading

### DIFF
--- a/docs/core-manage-versions.md
+++ b/docs/core-manage-versions.md
@@ -122,6 +122,6 @@ source $(asdf which ${PLUGIN})/../script.sh
 source $(asdf where ${PLUGIN} $(asdf current ${PLUGIN}))/bin/script.sh
 ```
 
-###### By-passing asdf shims.
+### By-passing asdf shims
 
 If for some reason you want to by-pass asdf shims or want your environment variables automatically set upon entering your project's directory, the [asdf-direnv](https://github.com/asdf-community/asdf-direnv) plugin can be helpful. Be sure to check its README for more details.


### PR DESCRIPTION
# Summary

Fix the section heading level for "By-passing asdf shims" at https://asdf-vm.com/#/core-manage-versions?id=by-passing-asdf-shims .

- The text for H6 was extremely small - much smaller than the normal paragraph text. The font-size for the h6 was 9px. It looked incredibly small and silly. This fix will make the heading bigger, which may be against the original intention to keep this section small and out of the way, but honestly the way it looked was really silly and hard to read.
- The heading level wasn't consistent (was too deep relative to the heading structure), which may or may not be an accessibility issue. This isn't the important part though, just a common sense choice to fix the above issue about the font size.

Fixes: Ad-hoc (no issue)

# Other Information

There may be a related issue where h6 headings are styled to be too small font-size. Not sure if that's intention or not, but the h6 text is too small to comfortably read, and is smaller than the paragraph text.