### PR TITLE
fix: plugin update portability

### DIFF
--- a/lib/commands/command-plugin-update.bash
+++ b/lib/commands/command-plugin-update.bash
@@ -27,7 +27,7 @@ plugin_update_command() {
 update_plugin() {
   local plugin_name=$1
   local plugin_path=$2
-  plugin_remote_default_branch=$(git --git-dir "$plugin_path/.git" --work-tree "$plugin_path" ls-remote --symref origin HEAD | awk -F'[[:space:]]*' 'NR == 1 {sub(/refs\/heads\//, "", $2); print $2}')
+  plugin_remote_default_branch=$(git --git-dir "$plugin_path/.git" --work-tree "$plugin_path" ls-remote --symref origin HEAD | awk 'NR == 1 {sub(/refs\/heads\//, "", $2); print $2}')
   local gitref=${3:-${plugin_remote_default_branch}}
   logfile=$(mktemp)
   {

--- a/lib/commands/command-plugin-update.bash
+++ b/lib/commands/command-plugin-update.bash
@@ -27,7 +27,7 @@ plugin_update_command() {
 update_plugin() {
   local plugin_name=$1
   local plugin_path=$2
-  plugin_remote_default_branch=$(git --git-dir "$plugin_path/.git" --work-tree "$plugin_path" ls-remote --symref origin HEAD | awk 'NR == 1 {sub(/refs\/heads\//, "", $2); print $2}')
+  plugin_remote_default_branch=$(git --git-dir "$plugin_path/.git" --work-tree "$plugin_path" ls-remote --symref origin HEAD | awk '{ sub(/refs\/heads\//, ""); print $2; exit }')
   local gitref=${3:-${plugin_remote_default_branch}}
   logfile=$(mktemp)
   {


### PR DESCRIPTION
# Summary

Some people are having issues with the implementation of #800 

The issue seems to be the `awk` command, specifically the usage of `-F'[[:space:]]*'`.

>awk already splits by multiple spaces by default so we should not override this option

stated here https://github.com/asdf-vm/asdf/issues/899#issuecomment-816374482

Fixes: #899
Fixes: #919 