### PR TITLE
docs: describe using the system version

### DIFF
--- a/docs/core-manage-versions.md
+++ b/docs/core-manage-versions.md
@@ -84,6 +84,17 @@ The version format is the same supported by the `.tool-versions` file.
 ASDF_ELIXIR_VERSION=1.4.0 mix test
 ```
 
+## Fallback to system Version
+
+To use the system version of tool <name> instead of an asdf managed version you can set the version for the tool to `system`.
+
+Set system with either `global`, `local` or `shell` as outlined in [Set Current Version](#set-current-version) section above.
+
+```shell
+asdf local <name> system
+# asdf local python system
+```
+
 ## View Current Version
 
 ```shell

--- a/docs/core-manage-versions.md
+++ b/docs/core-manage-versions.md
@@ -84,9 +84,9 @@ The version format is the same supported by the `.tool-versions` file.
 ASDF_ELIXIR_VERSION=1.4.0 mix test
 ```
 
-## Fallback to system Version
+## Fallback to System Version
 
-To use the system version of tool <name> instead of an asdf managed version you can set the version for the tool to `system`.
+To use the system version of tool `<name>` instead of an asdf managed version you can set the version for the tool to `system`.
 
 Set system with either `global`, `local` or `shell` as outlined in [Set Current Version](#set-current-version) section above.
 


### PR DESCRIPTION
# Summary

Document `system` version usage in the "manage versions" doc page. 

Fixes: #868

## Other Information

This came about as I stated in https://github.com/asdf-vm/asdf/issues/868#issuecomment-787530624:

>We do list `system` on this page - asdf-vm.com/#/core-configuration?id=tool-versions
>But it should probably also be mentioned on this page too - asdf-vm.com/#/core-manage-versions

The OP of the issue PRd the tab completion fix for system on ZSH and Bash completions as the other part of this.
