### PR TITLE
fix: delete instructions to add dependencies with Homebrew

### DIFF
--- a/docs/core-manage-asdf.md
+++ b/docs/core-manage-asdf.md
@@ -36,9 +36,7 @@ sudo zypper install curl git
 
 #### -- macOS,Homebrew --
 
-```shell
-brew install coreutils curl git
-```
+Dependencies will be automatically installed by Homebrew.
 
 #### -- macOS,Spack --
 


### PR DESCRIPTION
# Summary

Delete instructions to add dependencies with Homebrew

Fixes: #936
