### PR TITLE
chore: comment out instructions in issue/pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,38 +1,38 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
-labels: ''
-assignees: ''
-
+title: ""
+labels: "bug"
+assignees: ""
 ---
 
 **Describe the bug**
 
-A clear and concise description of what the bug is.
+<!-- A clear and concise description of what the bug is. -->
 
 **To Reproduce**
 
-Tell us what actions you performed before the issue occurred
+<!-- Tell us what actions you performed before the issue occurred -->
 
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-
 **Expected behavior**
 
-Tell us what should have happened
+<!-- Tell us what should have happened -->
 
 **Actual behavior**
 
-Tell us what happened instead
+<!-- Tell us what happened instead -->
 
 ### Environment
 
 <!-- Copy the output of `asdf info` here -->
+
 ```shell
 
 ```
@@ -40,7 +40,9 @@ Tell us what happened instead
 **asdf plugins affected (if relevant)**:
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem.
+
+<!-- If applicable, add screenshots to help explain your problem. -->
 
 **Additional context**
-Add any other context about the problem here.
+
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,23 +1,27 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
-labels: ''
-assignees: ''
-
+title: ""
+labels: "enhancement"
+assignees: ""
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
 **Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+
+<!-- A clear and concise description of what you want to happen. -->
 
 **Describe similar asdf features and why they are not sufficient**
-Describe asdf features you tried to use to accomplish what you wanted. Explain why they are insufficient for the task you were trying to accomplish.
+
+<!-- Describe asdf features you tried to use to accomplish what you wanted. Explain why they are insufficient for the task you were trying to accomplish. -->
 
 **Describe workarounds you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,9 @@
 # Summary
 
-Provide a general description of the code changes in your pull request.
+<!-- Provide a general description of the code changes in your pull request. -->
 
 Fixes: List issue numbers here
 
 ## Other Information
 
-If there is anything else that is relevant to your pull request include that
-information here.
-
-Thank you for contributing to asdf!
+<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->


### PR DESCRIPTION
# Summary

Issue and PR reporters often do not remove the instructions from the template before submitting. This fixes that issue by commenting them out. They are visible when creating the issue, but do not require deletion before submission and do not pollute the Issue/PR for the readers.