### PR TITLE
ci: push-event triggers CI only on master branch

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,13 +2,13 @@ name: Main workflow
 
 on:
   push:
+    branches:
+      - master
     paths-ignore:
       - "**.md"
   pull_request:
     paths-ignore:
       - "**.md"
-  schedule:
-    - cron: 0 0 * * 5
 
 jobs:
   test:


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

Currently our PRs run 2 sets of the workflow for each of the `push` and `pull_request` events. We should only run one set of events on PRs which should be the PR events. Push events can run on `master` only.

I don't think this changes any developer workflows (observing push builds before opening PRs), but please discuss if this impacts your experience.

I also removed the cron execution as it is not really adding value.