### PR TITLE
feat: configurable plugin repo last check time

### DIFF
--- a/docs/core-configuration.md
+++ b/docs/core-configuration.md
@@ -45,6 +45,7 @@ legacy_version_file = yes
 - `legacy_version_file` - defaults to `no`. If set to yes it will cause plugins that support this feature to read the version files used by other version managers (e.g. `.ruby-version` in the case of Ruby's `rbenv`).
 - `use_release_candidates` - defaults to `no`. If set to yes it will cause the `asdf update` command to upgrade to the latest release candidate release instead of the latest semantic version.
 - `always_keep_download` - defaults to `no`. If set to `yes` it will cause `asdf install` always keep the source code or binary it downloads. If set to `no` the source code or binary downloaded by `asdf install` will be deleted after successful installation.
+- `plugin_repository_last_check_duration` - defaults to `60` mins (1 hrs). It will set asdf plugins repository last check duration. When `asdf plugin add <name>`, `asdf plugin list all` command be executed, it will check last update duration to update repository. If set to `0` it will update asdf plugins repository every time.
 
 ## Environment Variables
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -384,9 +384,11 @@ repository_needs_update() {
   update_file_dir="$(asdf_data_dir)/tmp"
   local update_file_name
   update_file_name="repo-updated"
-  # `find` outputs filename if it has not been modified in the last day
+  # `find` outputs filename if it has not been modified in plugin_repository_last_check_duration setting.
+  local plugin_repository_last_check_duration
+  plugin_repository_last_check_duration="$(get_asdf_config_value "plugin_repository_last_check_duration")"
   local find_result
-  find_result=$(find "$update_file_dir" -name "$update_file_name" -type f -mtime +1 -print)
+  find_result=$(find "$update_file_dir" -name "$update_file_name" -type f -mmin +"${plugin_repository_last_check_duration:-60}" -print)
   [ -n "$find_result" ]
 }
 

--- a/test/plugin_list_all_command.bats
+++ b/test/plugin_list_all_command.bats
@@ -26,6 +26,18 @@ foo                           http://example.com/foo"
   [[ "$output" =~ "$expected_plugins_list" ]]
 }
 
+@test "plugin_list_all no immediate repo sync expected because check_duration is greater than 0" {
+  echo 'plugin_repository_last_check_duration = 10' > $HOME/.asdfrc
+  run asdf plugin-list-all
+  local expected="\
+bar                           http://example.com/bar
+dummy                        *http://example.com/dummy
+foo                           http://example.com/foo"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
+}
+
 @test "plugin_list_all list all plugins in the repository" {
   run asdf plugin-list-all
   local expected="\

--- a/test/plugin_list_all_command.bats
+++ b/test/plugin_list_all_command.bats
@@ -12,6 +12,20 @@ teardown() {
   clean_asdf_dir
 }
 
+@test "plugin_list_all should sync repo when check_duration set to 0" {
+  echo 'plugin_repository_last_check_duration = 0' > $HOME/.asdfrc
+  run asdf plugin-list-all
+  local expected_plugin_repo_sync="updating plugin repository..."
+  local expected_plugins_list="\
+bar                           http://example.com/bar
+dummy                        *http://example.com/dummy
+foo                           http://example.com/foo"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "$expected_plugin_repo_sync" ]]
+  [[ "$output" =~ "$expected_plugins_list" ]]
+}
+
 @test "plugin_list_all list all plugins in the repository" {
   run asdf plugin-list-all
   local expected="\


### PR DESCRIPTION
# Summary
Add update plugins repo function to `asdf plugin-update` command that can be get latest asdf plugins list

Hi everyone,
I tried to update the asdf plugins today,
but I didn't get latest plugins list.

I can't find a way to update asdf plugin list, 
so I implement this function in plugin update command.

I think about plugin update command for user flow,
When user want to update plugin, 
they maybe want to get latest plugin list,
so I add trigger function on plugin update command.

I hope to help this project to be better.

Thanks.