### PR TITLE
ci: do not run WSL1 jobs on master

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   wsl1:
+    if: github.ref != 'refs/heads/master'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

A hotfix so the CI checks on `master` will remain green by not running the known-failing WSL1 workflow on master.

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->
