### PR TITLE
fix: lint scripts for local and CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,17 +17,7 @@ jobs:
         uses: asdf-vm/actions/install@v1
 
       - name: Run ShellCheck
-        run: |
-          shellcheck -s bash -x \
-            asdf.sh \
-            release/tag.sh \
-            bin/asdf \
-            bin/private/asdf-exec \
-            lib/utils.bash \
-            lib/commands/*.bash \
-            completions/*.bash \
-            test/test_helpers.bash \
-            test/fixtures/dummy_plugin/bin/*
+        run: scripts/shellcheck.bash
 
   shellfmt:
     runs-on: ubuntu-latest
@@ -42,4 +32,4 @@ jobs:
         run: shfmt -f .
 
       - name: Run shfmt
-        run: shfmt -d .
+        run: scripts/shfmt.bash

--- a/release/README.md
+++ b/release/README.md
@@ -1,19 +1,27 @@
-# Release README
-
-If you are a user you can ignore everything in this directory. This directory contains documentation and scripts for preparing and tagging new versions of asdf and is only used by asdf maintainers.
+If you are a user you can ignore everything in this directory. This directory
+contains documentation and scripts for preparing and tagging new versions of
+asdf and is only used by asdf maintainers.
 
 ## Tagging Release Candidates
 
 To tag release candidates
 
-1. Update the CHANGELOG. Make sure it contains an entry for the version you are tagging as well as a dev version things that come after the tag (e.g. a heading with the format `<next-version>-dev`)
-2. Run the tests and the linter - `bats test`
-3. Run the release script. The new version must be in the format `0.0.0-rc0`. For example: `release/tag.sh 0.0.0-rc0`
-4. If the release script succeeds, push to GitHub. Make sure to use the correct remote to push to the official repository
+1. Update the CHANGELOG. Make sure it contains an entry for the version you are
+   tagging as well as a dev version things that come after the tag (e.g. a heading
+   with the format `<next-version>-dev`).
+2. Run the tests, linter and format check - `bats test`, `./scripts/shellcheck.bash` and `./scripts/shfmt.bash`.
+3. Run the release script. The new version must be in the format `0.0.0-rc0`.
+   For example: `release/tag.sh 0.0.0-rc0`.
+4. If the release script succeeds, push to GitHub. Make sure to use the correct
+   remote to push to the official repository
 
 ## Tagging Releases
 
-1. Update the CHANGELOG. Make sure it contains an entry for the version you are tagging as well as a dev version things that come after the tag (e.g. a heading with the format `<next-version>-dev`)
-2. Run the tests and the linter - `bats test`
-3. Run the release script. The new version must be in the format `0.0.0`. For example: `release/tag.sh 0.0.0`
-4. If the release script succeeds, push to GitHub. Make sure to use the correct remote to push to the official repository
+1. Update the CHANGELOG. Make sure it contains an entry for the version you are
+   tagging as well as a dev version things that come after the tag (e.g. a heading
+   with the format `<next-version>-dev`).
+2. Run the tests, linter and format check - `bats test`, `./scripts/shellcheck.bash` and `./scripts/shfmt.bash`.
+3. Run the release script. The new version must be in the format `0.0.0`. For
+   example: `release/tag.sh 0.0.0`.
+4. If the release script succeeds, push to GitHub. Make sure to use the correct
+   remote to push to the official repository

--- a/release/README.md
+++ b/release/README.md
@@ -1,3 +1,5 @@
+# Release README
+
 If you are a user you can ignore everything in this directory. This directory
 contains documentation and scripts for preparing and tagging new versions of
 asdf and is only used by asdf maintainers.

--- a/scripts/shellcheck.bash
+++ b/scripts/shellcheck.bash
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+exec shellcheck -s bash -x \
+  asdf.sh \
+  completions/*.bash \
+  bin/asdf \
+  bin/private/asdf-exec \
+  lib/utils.bash \
+  lib/commands/*.bash \
+  release/tag.sh \
+  scripts/*.bash \
+  test/test_helpers.bash \
+  test/fixtures/dummy_plugin/bin/*

--- a/scripts/shfmt.bash
+++ b/scripts/shfmt.bash
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+exec shfmt -d .


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

Revert changes to local workflows from #956 

- [x] script for Shellcheck to run locally and in CI
- [x] script for Shfmt to run locally and in CI
- [x] update release docs to reflect new pre-release workflow
