### PR TITLE
chore: question Issue type & direct to GH Discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,2 +1,6 @@
 # Force users to use one of our predefined issue templates
 blank_issues_enabled: false
+contact_links:
+  - name: Question
+    url: https://github.com/asdf-vm/asdf/discussions/
+    about: Ask new or browse existing questions in GitHub Discussions.


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

This will add an option in the New Issue selection (https://github.com/asdf-vm/asdf/issues/new/choose) to select a "question" type which will direct people to our GitHub Discussions

The goal being reduction in Issues that are merely questions/clarifications.