### PR TITLE
fix shell config command for Linux,Fish,Pacman

### DIFF
--- a/docs/core-manage-asdf.md
+++ b/docs/core-manage-asdf.md
@@ -174,7 +174,7 @@ Add the following to `~/.bashrc`:
 Add the following to `~/.config/fish/config.fish`:
 
 ```shell
-source /opt/asdf-vm/asdf.sh
+source /opt/asdf-vm/asdf.fish
 ```
 
 !> Completions are automatically configured on installation by the AUR package.


### PR DESCRIPTION
# Summary

Fixes the instruction for sourcing asdf for Linux,Fish,Pacman.

It currently says to source the `.sh` file instead of the correct `.fish` one.
