### PR TITLE
fix: ensure shims get created when data dir has spaces

### DIFF
--- a/lib/commands/command-reshim.bash
+++ b/lib/commands/command-reshim.bash
@@ -103,7 +103,9 @@ generate_shim_for_executable() {
 generate_shims_for_version() {
   local plugin_name=$1
   local full_version=$2
-  for executable_path in $(plugin_executables "$plugin_name" "$full_version"); do
+  local all_executable_paths
+  IFS=$'\n' read -rd '' -a all_executable_paths <<<"$(plugin_executables "$plugin_name" "$full_version")"
+  for executable_path in "${all_executable_paths[@]}"; do
     write_shim_script "$plugin_name" "$full_version" "$executable_path"
   done
 }

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -576,7 +576,9 @@ with_plugin_env() {
 plugin_executables() {
   local plugin_name=$1
   local full_version=$2
-  for bin_path in $(list_plugin_exec_paths "$plugin_name" "$full_version"); do
+  local all_bin_paths
+  IFS=$'\n' read -rd '' -a all_bin_paths <<<"$(list_plugin_exec_paths "$plugin_name" "$full_version")"
+  for bin_path in "${all_bin_paths[@]}"; do
     for executable_file in "$bin_path"/*; do
       if is_executable "$executable_file"; then
         printf "%s\\n" "$executable_file"

--- a/test/reshim_command.bats
+++ b/test/reshim_command.bats
@@ -3,11 +3,11 @@
 load test_helpers
 
 setup() {
-  setup_asdf_dir
+  ASDF_BATS_SPACE_IN_PATH=true setup_asdf_dir
   install_dummy_plugin
 
-  PROJECT_DIR=$HOME/project
-  mkdir $PROJECT_DIR
+  PROJECT_DIR="$HOME/project"
+  mkdir "$PROJECT_DIR"
 }
 
 teardown() {
@@ -69,28 +69,28 @@ teardown() {
 }
 
 @test "reshim should not duplicate shims" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
 
   run asdf install dummy 1.0
   run asdf install dummy 1.1
   [ "$status" -eq 0 ]
   [ -f "$ASDF_DIR/shims/dummy" ]
 
-  run rm $ASDF_DIR/shims/*
+  run rm "$ASDF_DIR/shims/"*
   [ "$status" -eq 0 ]
-  [ "0" -eq "$(ls $ASDF_DIR/shims/dummy* | wc -l)" ]
+  [ "0" -eq "$(ls "$ASDF_DIR/shims/"dummy* | wc -l)" ]
 
   run asdf reshim dummy
   [ "$status" -eq 0 ]
-  [ "1" -eq "$(ls $ASDF_DIR/shims/dummy* | wc -l)" ]
+  [ "1" -eq "$(ls "$ASDF_DIR/shims/"dummy* | wc -l)" ]
 
   run asdf reshim dummy
   [ "$status" -eq 0 ]
-  [ "1" -eq "$(ls $ASDF_DIR/shims/dummy* | wc -l)" ]
+  [ "1" -eq "$(ls "$ASDF_DIR/shims/"dummy* | wc -l)" ]
 }
 
 @test "reshim should create shims only for files and not folders" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
 
   run asdf install dummy 1.0
   run asdf install dummy 1.1
@@ -98,32 +98,32 @@ teardown() {
   [ -f "$ASDF_DIR/shims/dummy" ]
   [ ! -f "$ASDF_DIR/shims/subdir" ]
 
-  run rm $ASDF_DIR/shims/*
+  run rm "$ASDF_DIR/shims/"*
   [ "$status" -eq 0 ]
-  [ "0" -eq "$(ls $ASDF_DIR/shims/dummy* | wc -l)" ]
-  [ "0" -eq "$(ls $ASDF_DIR/shims/subdir* | wc -l)" ]
+  [ "0" -eq "$(ls "$ASDF_DIR/shims/"dummy* | wc -l)" ]
+  [ "0" -eq "$(ls "$ASDF_DIR/shims/"subdir* | wc -l)" ]
 
   run asdf reshim dummy
   [ "$status" -eq 0 ]
-  [ "1" -eq "$(ls $ASDF_DIR/shims/dummy* | wc -l)" ]
-  [ "0" -eq "$(ls $ASDF_DIR/shims/subdir* | wc -l)" ]
+  [ "1" -eq "$(ls "$ASDF_DIR/shims/"dummy* | wc -l)" ]
+  [ "0" -eq "$(ls "$ASDF_DIR/shims/"subdir* | wc -l)" ]
 
 }
 
 @test "reshim without arguments reshims all installed plugins" {
   run asdf install dummy 1.0
-  run rm $ASDF_DIR/shims/*
+  run rm "$ASDF_DIR/shims/"*
   [ "$status" -eq 0 ]
-  [ "0" -eq "$(ls $ASDF_DIR/shims/dummy* | wc -l)" ]
+  [ "0" -eq "$(ls "$ASDF_DIR/shims/"dummy* | wc -l)" ]
   run asdf reshim
   [ "$status" -eq 0 ]
-  [ "1" -eq "$(ls $ASDF_DIR/shims/dummy* | wc -l)" ]
+  [ "1" -eq "$(ls "$ASDF_DIR/shims/"dummy* | wc -l)" ]
 }
 
 @test "reshim command executes configured pre hook" {
   run asdf install dummy 1.0
 
-  cat > $HOME/.asdfrc <<-'EOM'
+  cat > "$HOME/.asdfrc" <<-'EOM'
 pre_asdf_reshim_dummy = echo RESHIM
 EOM
 
@@ -134,7 +134,7 @@ EOM
 @test "reshim command executes configured post hook" {
   run asdf install dummy 1.0
 
-  cat > $HOME/.asdfrc <<-'EOM'
+  cat > "$HOME/.asdfrc" <<-'EOM'
 post_asdf_reshim_dummy = echo RESHIM
 EOM
 

--- a/test/test_helpers.bash
+++ b/test/test_helpers.bash
@@ -8,17 +8,21 @@ unset ASDF_DIR
 . "$(dirname "$BATS_TEST_DIRNAME")"/lib/utils.bash
 
 setup_asdf_dir() {
-  BASE_DIR=$(mktemp -dt asdf.XXXX)
-  HOME=$BASE_DIR/home
-  ASDF_DIR=$HOME/.asdf
+  if [ -n "${ASDF_BATS_SPACE_IN_PATH:-}" ]; then
+    BASE_DIR="$(mktemp -dt "asdf with spaces.XXXX")"
+  else
+    BASE_DIR="$(mktemp -dt asdf.XXXX)"
+  fi
+  HOME="$BASE_DIR/home"
+  ASDF_DIR="$HOME/.asdf"
   mkdir -p "$ASDF_DIR/plugins"
   mkdir -p "$ASDF_DIR/installs"
   mkdir -p "$ASDF_DIR/shims"
   mkdir -p "$ASDF_DIR/tmp"
-  ASDF_BIN=$(dirname "$BATS_TEST_DIRNAME")/bin
+  ASDF_BIN="$(dirname "$BATS_TEST_DIRNAME")/bin"
 
   # shellcheck disable=SC2031
-  PATH=$ASDF_BIN:$ASDF_DIR/shims:$PATH
+  PATH="$ASDF_BIN:$ASDF_DIR/shims:$PATH"
 }
 
 install_mock_plugin() {


### PR DESCRIPTION
# Summary

If `ASDF_DATA_DIR` has a space in the path (by default, this means `asdf` itself was installed to a path with a space), then the shims will not be created correctly in bash.  This PR fixes the issue.

## Other Information

I have only checked up to the actual executable (in my case, node) running — I do not yet know if there are other issues related to spaces in the path.

I'm using extra variables for the lists (which contain newlines) because POSIX shell wouldn't support `while read … done; while < <(command)` (and is caught by the tests).