### PR TITLE
docs: pt-br translation migration

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -9,12 +9,12 @@ module.exports = {
       lang: "en-US",
       title: "asdf",
       description: "Manage multiple runtime versions with a single CLI tool"
+    },
+    "/pt-br/": {
+      lang: "pt-br",
+      title: "asdf",
+      description: "Gerencie múltiplas versões com um simples CLI"
     }
-    // "/pt-BR/": {
-    //   lang: "pt-BR",
-    //   title: "asdf",
-    //   description: "TODO: translate"
-    // }
   },
 
   themeConfig: {
@@ -26,13 +26,15 @@ module.exports = {
       "/": {
         selectLanguageName: "English",
         sidebar: sidebar.en,
-        navbar: navbar.en
+        navbar: navbar.en,
+        editLinkText: "Edit this page"
+      },
+      "/pt-br/": {
+        selectLanguageName: "Brazilian Portuguese",
+        sidebar: sidebar.pt_br,
+        navbar: navbar.pt_br,
+        editLinkText: "Edit this page"
       }
-      // "/pt-BR/": {
-      //   selectLanguageName: "Brazilian Portuguese",
-      //   sidebar: sidebar.pt_br,
-      //   navbar: navbar.pt_br
-      // }
     }
   },
 
@@ -43,10 +45,10 @@ module.exports = {
         locales: {
           "/": {
             placeholder: "Search"
+          },
+          "/pt-br/": {
+            placeholder: "Search"
           }
-          // "/pt-BR/": {
-          //   placeholder: "Search"
-          // }
         }
       }
     ],

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -33,7 +33,11 @@ module.exports = {
         selectLanguageName: "Brazilian Portuguese",
         sidebar: sidebar.pt_br,
         navbar: navbar.pt_br,
-        editLinkText: "Edit this page"
+        editLinkText: "Edit this page",
+
+        // 404 page
+        notFound: ["Parece que estamos perdido!"],
+        backToHome: "Voltar para a página inicial"
       }
     }
   },

--- a/docs/.vuepress/navbar.js
+++ b/docs/.vuepress/navbar.js
@@ -130,8 +130,132 @@ const en = [
 const pt_br = [
   {
     text: "Getting Started",
-    link: "/pt-BR/guide/getting-started.html",
-    activeMatch: "/pt-BR/guide/"
+    link: "/pt-br/guide/getting-started.html",
+    activeMatch: "/pt-br/guide/"
+  },
+  {
+    text: "Reference",
+    children: [
+      {
+        text: "Manage",
+        children: [
+          "/pt-br/manage/core.md",
+          "/pt-br/manage/plugins.md",
+          "/pt-br/manage/versions.md",
+          "/pt-br/manage/configuration.md",
+          "/pt-br/manage/commands.md",
+          {
+            text: "Alterações",
+            link: "https://github.com/asdf-vm/asdf/blob/master/CHANGELOG.md"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    text: "Plugins",
+    children: [
+      {
+        text: "Author",
+        children: [
+          "/pt-br/plugins/create.md",
+          {
+            text: "GitHub Plugin Template",
+            link: "https://github.com/asdf-vm/asdf-plugin-template"
+          }
+        ]
+      },
+      {
+        text: "First Party Plugins",
+        children: [
+          {
+            text: "Elixir",
+            link: "https://github.com/asdf-vm/asdf-elixir"
+          },
+          {
+            text: "Erlang",
+            link: "https://github.com/asdf-vm/asdf-erlang"
+          },
+          {
+            text: "Node.js",
+            link: "https://github.com/asdf-vm/asdf-nodejs"
+          },
+          {
+            text: "Ruby",
+            link: "https://github.com/asdf-vm/asdf-ruby"
+          }
+        ]
+      },
+      {
+        text: "Community Plugins",
+        children: [
+          {
+            text: "asdf-community",
+            link: "https://github.com/asdf-community"
+          },
+          {
+            text: "GitHub Topics Search",
+            link: "https://github.com/topics/asdf-plugin"
+          }
+        ]
+      },
+      {
+        text: "Reference",
+        children: [
+          {
+            text: "Plugin Shortname Index",
+            link: "https://github.com/asdf-vm/asdf-plugins"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    text: "Contribute",
+    children: [
+      {
+        text: "Core",
+        children: [
+          "/pt-br/contribute/core.md",
+          "/pt-br/contribute/documentation.md"
+        ]
+      },
+      {
+        text: "Plugins",
+        children: ["/pt-br/contribute/first-party-plugins.md"]
+      },
+      {
+        text: "CICD",
+        children: ["/pt-br/contribute/github-actions.md"]
+      }
+    ]
+  },
+  {
+    text: "Learn More",
+    children: [
+      {
+        text: "Questions",
+        children: [
+          "/pt-br/learn-more/faq.md",
+          {
+            text: "GitHub Issues",
+            link: "https://github.com/asdf-vm/asdf/issues"
+          },
+          {
+            text: "GitHub Discussions",
+            link: "https://github.com/asdf-vm/asdf/discussions"
+          },
+          {
+            text: "StackOverflow Tag",
+            link: "https://stackoverflow.com/questions/tagged/asdf-vm"
+          }
+        ]
+      },
+      {
+        text: "Resources",
+        children: ["/pt-br/learn-more/thanks.md"]
+      }
+    ]
   }
 ];
 

--- a/docs/.vuepress/sidebar.js
+++ b/docs/.vuepress/sidebar.js
@@ -106,9 +106,112 @@ const en = {
 };
 
 const pt_br = {
-  "/pt-BR/guide/": [
-    "/pt-BR/guide/introduction.md",
-    "/pt-BR/guide/getting-started.md"
+  "/pt-br/guide/": [
+    "/pt-br/guide/introduction.md",
+    "/pt-br/guide/getting-started.md"
+  ],
+  "/pt-br/manage/": [
+    {
+      text: "Manage",
+      children: [
+        "/pt-br/manage/core.md",
+        "/pt-br/manage/plugins.md",
+        "/pt-br/manage/versions.md",
+        "/pt-br/manage/configuration.md",
+        "/pt-br/manage/commands.md",
+        {
+          text: "Alterações",
+          link: "https://github.com/asdf-vm/asdf/blob/master/CHANGELOG.md"
+        }
+      ]
+    }
+  ],
+  "/pt-br/plugins/": [
+    {
+      text: "Author",
+      children: [
+        "/pt-br/plugins/create.md",
+        {
+          text: "GitHub Plugin Template",
+          link: "https://github.com/asdf-vm/asdf-plugin-template"
+        }
+      ]
+    },
+    {
+      text: "First Party Plugins",
+      children: [
+        {
+          text: "Elixir",
+          link: "https://github.com/asdf-vm/asdf-elixir"
+        },
+        {
+          text: "Erlang",
+          link: "https://github.com/asdf-vm/asdf-erlang"
+        },
+        {
+          text: "Node.js",
+          link: "https://github.com/asdf-vm/asdf-nodejs"
+        },
+        {
+          text: "Ruby",
+          link: "https://github.com/asdf-vm/asdf-ruby"
+        }
+      ]
+    },
+    {
+      text: "Community Plugins",
+      children: [
+        {
+          text: "asdf-community",
+          link: "https://github.com/asdf-community/"
+        }
+      ]
+    },
+    {
+      text: "Reference",
+      children: [
+        {
+          text: "Plugin Shortname Index",
+          link: "https://github.com/asdf-vm/asdf-plugins"
+        }
+      ]
+    }
+  ],
+  "/pt-br/contribute/": [
+    {
+      text: "Contribute",
+      children: [
+        "/pt-br/contribute/core.md",
+        "/pt-br/contribute/documentation.md",
+        "/pt-br/contribute/first-party-plugins.md",
+        "/pt-br/contribute/github-actions.md"
+      ]
+    }
+  ],
+  "/pt-br/learn-more/": [
+    {
+      text: "Questions",
+      children: [
+        "/pt-br/learn-more/faq.md",
+
+        {
+          text: "GitHub Issues",
+          link: "https://github.com/asdf-vm/asdf/issues"
+        },
+        {
+          text: "GitHub Discussions",
+          link: "https://github.com/asdf-vm/asdf/discussions"
+        },
+        {
+          text: "StackOverflow Tag",
+          link: "https://stackoverflow.com/questions/tagged/asdf-vm"
+        }
+      ]
+    },
+    {
+      text: "Resources",
+      children: ["/pt-br/learn-more/thanks.md"]
+    }
   ]
 };
 

--- a/docs/manage/versions.md
+++ b/docs/manage/versions.md
@@ -95,7 +95,7 @@ can set an environment variable like `ASDF_${TOOL}_VERSION`.
 The following example runs tests on an Elixir project with version `1.4.0`.
 The version format is the same supported by the `.tool-versions` file.
 
-```shell
+```shell:no-line-numbers
 ASDF_ELIXIR_VERSION=1.4.0 mix test
 ```
 

--- a/docs/pt-BR/guide/getting-started.md
+++ b/docs/pt-BR/guide/getting-started.md
@@ -1,3 +1,0 @@
-# Getting Started
-
-TODO: Translate

--- a/docs/pt-BR/guide/introduction.md
+++ b/docs/pt-BR/guide/introduction.md
@@ -1,3 +1,0 @@
-# Introduction
-
-TODO: Translate

--- a/docs/pt-br/contribute/core.md
+++ b/docs/pt-br/contribute/core.md
@@ -1,5 +1,7 @@
 # asdf
 
+> Hi, we've recently migrated our docs and added some new pages. If you would like to help translate this page, see the "Edit this page" link at the bottom of the page.
+
 `asdf` core contribution guide.
 
 ## Initial Setup

--- a/docs/pt-br/contribute/documentation.md
+++ b/docs/pt-br/contribute/documentation.md
@@ -1,0 +1,121 @@
+# Docs & Site
+
+> Hi, we've recently migrated our docs and added some new pages. If you would like to help translate this page, see the "Edit this page" link at the bottom of the page.
+
+Documentation & site contribution guide.
+
+## Initial Setup
+
+Fork `asdf` on GitHub and/or Git clone the default branch:
+
+```shell:no-line-numbers
+# clone your fork
+git clone https://github.com/<GITHUB_USER>/asdf.git
+# or clone asdf
+git clone https://github.com/asdf-vm/asdf.git
+```
+
+The tools for Docs site development are managed with `asdf` in the `docs/.tool-versions`. Add the plugins with:
+
+```shell:no-line-numbers
+asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs
+```
+
+Install the tool version(s) with:
+
+```shell:no-line-numbers
+asdf install
+```
+
+- [Node.js](https://nodejs.org): JavaScript runtime built on Chrome's V8 JavaScript engine.
+
+Install Node.js dependencies from `docs/package.json`:
+
+```shell:no-line-numbers
+npm install
+```
+
+## Development
+
+[Vuepress (v2)](https://v2.vuepress.vuejs.org/) is the Static Site Generator (SSG) we use to build the asdf documentation site. It was chosen to replace [Docsify.js](https://docsify.js.org/) as we would like to support an HTML only fallback when users do not have JavaScript available or enabled. This was not possible with Docsify. Other than this, the feature-set is largely the same, with the focus on writing Markdown files with minimal configuration.
+
+`package.json` contains the scripts required for development:
+
+@[code json{3-5}](../package.json)
+
+To start the local development server:
+
+```shell:no-line-numbers
+npm run dev
+```
+
+Format the code before committing:
+
+```shell:no-line-numbers
+npm run format
+```
+
+## Pull Requests, Releases & Conventional Commits
+
+`asdf` is using an automated release pipeline which relies on Conventional Commits in PR titles. Detailed documentation found in the [core contribution guide](./core.md).
+
+When creating a PR for documentation changes please make the PR title with the Conventional Commit type `docs` in the format `docs: <description>`.
+
+## Vuepress
+
+Configuration of the site is contained within a few JavaScript files with JS Objects used to represent the config. They are:
+
+- `docs/.vuepress/config.js`: the root config file for the site. Read the [Vuepress documentation](https://v2.vuepress.vuejs.org/guide/configuration.html#config-file) for it's spec.
+
+To simplify the root config, the larger JS Objects representing the _navbar_ and _sidebar_ configuration have been extracted and separated by their locale. See both in:
+
+- `docs/.vuepress/navbar.js`
+- `docs/.vuepress/sidebar.js`
+
+With the official documentation for these configs living in the [Default Theme Reference](https://v2.vuepress.vuejs.org/reference/default-theme/config.html#locale-config).
+
+## I18n
+
+Vuepress has first-class support for internationalization. The
+root config `docs/.vuepress/config.js` defines the supported locales with their URL, title in the selection dropdown menu and navbar/sidebar configs references.
+
+The navbar/sidebar configs are captured in the aforementioned config files, separated by locale and exported individually.
+
+The markdown content for each locale must fall under a folder with the same name as the keys for `locales` in the root config. That is:
+
+```js
+{
+  ...
+  themeConfig: {
+    locales: {
+      "/": {
+        selectLanguageName: "English (US)",
+        sidebar: sidebar.en,
+        navbar: navbar.en
+      },
+      "/pt-BR/": {
+        selectLanguageName: "Brazilian Portuguese",
+        sidebar: sidebar.pt_br,
+        navbar: navbar.pt_br
+      }
+    }
+  }
+}
+```
+
+`/pt-BR/` will require the same set of markdown files located under `docs/pt-BR/`, like so:
+
+```shell:no-line-numbers
+docs
+├─ README.md
+├─ foo.md
+├─ nested
+│  └─ README.md
+└─ pt-BR
+   ├─ README.md
+   ├─ foo.md
+   └─ nested
+      └─ README.md
+```
+
+The [official Vuepress i18n documentation](https://v2.vuepress.vuejs.org/guide/i18n.html#site-i18n-config) goes into more detail.

--- a/docs/pt-br/contribute/first-party-plugins.md
+++ b/docs/pt-br/contribute/first-party-plugins.md
@@ -1,0 +1,16 @@
+# First-Party Plugins
+
+> Hi, we've recently migrated our docs and added some new pages. If you would like to help translate this page, see the "Edit this page" link at the bottom of the page.
+
+The asdf core team has authored some plugins relevant to their daily work life. Help is always welcome in maintaining and improving these plugins. See the associated repo for each linked below:
+
+- [Elixir](https://github.com/asdf-vm/asdf-elixir)
+- [Erlang](https://github.com/asdf-vm/asdf-erlang)
+- [Node.js](https://github.com/asdf-vm/asdf-nodejs)
+- [Ruby](https://github.com/asdf-vm/asdf-ruby)
+
+For community plugins, see:
+
+- [`asdf-community` organisation](https://github.com/asdf-community): A collaborative, community-driven project for long-term maintenance of `asdf` plugins.
+- [`asdf-plugins` shortname repo](https://github.com/asdf-vm/asdf-plugins): Short-name list used by `asdf` core to lookup popular `asdf` plugins.
+- [GitHub `asdf-plugin` topic search](https://github.com/topics/asdf-plugin)

--- a/docs/pt-br/contribute/github-actions.md
+++ b/docs/pt-br/contribute/github-actions.md
@@ -1,0 +1,5 @@
+# GitHub Actions
+
+> Hi, we've recently migrated our docs and added some new pages. If you would like to help translate this page, see the "Edit this page" link at the bottom of the page.
+
+Thanks for your interest, please see the [asdf actions repo](https://github.com/asdf-vm/actions) for their existing Issues, conversations and Contributing Guidelines.

--- a/docs/pt-br/guide/getting-started.md
+++ b/docs/pt-br/guide/getting-started.md
@@ -1,0 +1,297 @@
+# Getting Started
+
+> Hi, we've recently migrated our docs and added some new pages. If you would like to help translate this page, see the "Edit this page" link at the bottom of the page.
+
+`asdf` installation involves:
+
+1. Installing dependencies
+2. Installing `asdf` core
+3. Adding `asdf` to your shell
+4. install a plugin for each tool/runtime you wish to manage
+5. install a version of the tool/runtime
+6. set global and project versions via `.tool-versions` config files
+
+## 1. Install Dependencies
+
+**Linux**:
+
+| Package Manager | Command                        |
+| --------------- | ------------------------------ |
+| Aptitude        | `sudo apt install curl git`    |
+| DNF             | `sudo dnf install curl git`    |
+| Pacman          | `sudo pacman -S curl git`      |
+| Zypper          | `sudo zypper install curl git` |
+
+**macOS**:
+
+| Package Manager | Command                                                   |
+| --------------- | --------------------------------------------------------- |
+| Homebrew        | Dependencies will be automatically installed by Homebrew. |
+| Spack           | `spack install coreutils curl git`                        |
+
+## 2. Install asdf
+
+We recommend installing via Git, though there are other platform specific methods:
+
+| Method   | Command                                                                                                                                                             |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Git      | `git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.8.1`                                                                                             |
+| Homebrew | `brew install asdf`                                                                                                                                                 |
+| Pacman   | `git clone https://aur.archlinux.org/asdf-vm.git && cd asdf-vm && makepkg -si` or use your preferred [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers) |
+
+## 3. Add to your Shell
+
+There are many different combinations of Shells, OSs & Installation methods all of which affect the configuration here. Expand the selection below that best matches your system:
+
+::: details Bash & Git
+
+Add the following to `~/.bashrc`:
+
+```shell
+. $HOME/.asdf/asdf.sh
+```
+
+Completions must be configured by adding the following to your `.bashrc`:
+
+```shell
+. $HOME/.asdf/completions/asdf.bash
+```
+
+:::
+
+::: details Bash & Git (macOS)
+
+If using **macOS Catalina or newer**, the default shell has changed to **ZSH**. Unless changing back to Bash, follow the ZSH instructions.
+
+Add the following to `~/.bash_profile`:
+
+```shell
+. $HOME/.asdf/asdf.sh
+```
+
+Completions must be configured manually with the following entry in your `.bash_profile`:
+
+```shell
+. $HOME/.asdf/completions/asdf.bash
+```
+
+:::
+
+::: details Bash & Homebrew (macOS)
+
+If using **macOS Catalina or newer**, the default shell has changed to **ZSH**. Unless changing back to Bash, follow the ZSH instructions.
+
+Add `asdf.sh` to your `~/.bash_profile` with:
+
+```shell:no-line-numbers
+echo -e "\n. $(brew --prefix asdf)/asdf.sh" >> ~/.bash_profile
+```
+
+Completions will need to be [configured as per Homebrew's instructions](https://docs.brew.sh/Shell-Completion#configuring-completions-in-bash) or with the following:
+
+```shell:no-line-numbers
+echo -e "\n. $(brew --prefix asdf)/etc/bash_completion.d/asdf.bash" >> ~/.bash_profile
+```
+
+:::
+
+::: details Bash & Pacman
+
+Add the following to `~/.bashrc`:
+
+```shell
+. /opt/asdf-vm/asdf.sh
+```
+
+[`bash-completion`](https://wiki.archlinux.org/title/bash#Common_programs_and_options) needs to be installed for the completions to work.
+:::
+
+::: details Fish & Git
+
+Add the following to `~/.config/fish/config.fish`:
+
+```shell
+source ~/.asdf/asdf.fish
+```
+
+Completions must be configured manually with the following command:
+
+```shell:no-line-numbers
+mkdir -p ~/.config/fish/completions; and ln -s ~/.asdf/completions/asdf.fish ~/.config/fish/completions
+```
+
+:::
+
+::: details Fish & Homebrew
+
+Add `asdf.fish` to your `~/.config/fish/config.fish` with:
+
+```shell:no-line-numbers
+echo -e "\nsource "(brew --prefix asdf)"/asdf.fish" >> ~/.config/fish/config.fish
+```
+
+Completions are [handled by Homebrew for the Fish shell](https://docs.brew.sh/Shell-Completion#configuring-completions-in-fish). Friendly!
+:::
+
+::: details Fish & Pacman
+
+Add the following to `~/.config/fish/config.fish`:
+
+```shell
+source /opt/asdf-vm/asdf.fish
+```
+
+Completions are automatically configured on installation by the AUR package.
+:::
+
+::: details ZSH & Git
+
+Add the following to `~/.zshrc`:
+
+```shell
+. $HOME/.asdf/asdf.sh
+```
+
+**OR** use a ZSH Framework plugin like [asdf for oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/asdf) which will source this script and setup completions.
+
+Completions are configured by either a ZSH Framework `asdf` plugin or by adding the following to your `.zshrc`:
+
+```shell
+# append completions to fpath
+fpath=(${ASDF_DIR}/completions $fpath)
+# initialise completions with ZSH's compinit
+autoload -Uz compinit && compinit
+```
+
+- if you are using a custom `compinit` setup, ensure `compinit` is below your sourcing of `asdf.sh`
+- if you are using a custom `compinit` setup with a ZSH Framework, ensure `compinit` is below your sourcing of the framework
+
+**Warning**
+
+If you are using a ZSH Framework the associated `asdf` plugin may need to be updated to use the new ZSH completions properly via `fpath`. The Oh-My-ZSH asdf plugin is yet to be updated, see [ohmyzsh/ohmyzsh#8837](https://github.com/ohmyzsh/ohmyzsh/pull/8837).
+:::
+
+::: details ZSH & Homebrew
+
+Add `asdf.sh` to your `~/.zshrc` with:
+
+```shell
+echo -e "\n. $(brew --prefix asdf)/asdf.sh" >> ${ZDOTDIR:-~}/.zshrc
+```
+
+**OR** use a ZSH Framework plugin like [asdf for oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/asdf) which will source this script and setup completions.
+
+Completions are configured by either a ZSH Framework `asdf` or will need to be [configured as per Homebrew's instructions](https://docs.brew.sh/Shell-Completion#configuring-completions-in-zsh). If you are using a ZSH Framework the associated plugin for asdf may need to be updated to use the new ZSH completions properly via `fpath`. The Oh-My-ZSH asdf plugin is yet to be updated, see [ohmyzsh/ohmyzsh#8837](https://github.com/ohmyzsh/ohmyzsh/pull/8837).
+:::
+
+::: details ZSH & Pacman
+
+Add the following to `~/.zshrc`:
+
+```shell
+. /opt/asdf-vm/asdf.sh
+```
+
+Completions are placed in a ZSH friendly location, but [ZSH must be configured to use the autocompletions](https://wiki.archlinux.org/index.php/zsh#Command_completion).
+:::
+
+`asdf` scripts need to be sourced **after** you have set your `$PATH` and **after** you have sourced your framework (oh-my-zsh etc).
+
+Restart your shell so that `PATH` changes take effect. Opening a new terminal tab will usually do it.
+
+## 4. Install a Plugin
+
+For demonstration purposes we will install & set [Node.js](https://nodejs.org/) via the [`asdf-nodejs`](https://github.com/asdf-vm/asdf-nodejs/) plugin.
+
+### Plugin Dependencies
+
+Each plugin has dependencies so we need to check the plugin repo where they should be listed. For `asdf-nodejs` they are:
+
+| OS             | Dependency Installation                 |
+| -------------- | --------------------------------------- |
+| Linux (Debian) | `apt-get install dirmngr gpg curl gawk` |
+| macOS          | `brew install gpg gawk`                 |
+
+We should install dependencies first as some Plugins have post-install hooks.
+
+### Install the Plugin
+
+```shell:no-line-numbers
+asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git
+```
+
+## 5. Install a Version
+
+Now we have a plugin for Node.js we can install a version of the tool.
+
+We can observer which versions are available with `asdf list all nodejs` or a subset of versions with `asdf list all nodejs 14`.
+
+We will just install the `latest` available version:
+
+```shell:no-line-numbers
+asdf install nodejs latest
+```
+
+::: tip Note
+`asdf` enforces exact versions. `latest` is a helper throughout `asdf` that will resolve to the actual version number at the time of execution.
+:::
+
+## 6. Set a Version
+
+`asdf` performs a version lookup of a tool in all `.tool-versions` files from the current working directory up to the `$HOME` directory. The lookup occurs just-in-time when you execute a tool that `asdf` manages.
+
+::: warning
+Without a version listed for a tool execution of the tool will **error**. `asdf current` will show you the tool & version resolution, or absence of, from your current directory so you can observe which tools will fail to execute.
+:::
+
+### Global
+
+Global defaults are managed in `$HOME/.tool-versions`. Set a global version with:
+
+```shell:no-line-numbers
+asdf global nodejs latest
+```
+
+`$HOME/.tool-versions` will then look like:
+
+```
+nodejs 16.5.0
+```
+
+Some OSs already have tools installed that are managed by the system and not `asdf`, `python` is a common example. You need to tell `asdf` to pass the management back to the system. The [Versions reference section](/pt-br/manage/versions.md) will guide you.
+
+### Local
+
+Local versions are defined in the `$PWD/.tool-versions` file (your current working directory). Usually, this will be the Git respository for a project. When in your desired directory execute:
+
+```shell:no-line-numbers
+asdf local nodejs latest
+```
+
+`$PWD/.tool-versions` will then look like:
+
+```
+nodejs 16.5.0
+```
+
+### Using Existing Tool Version Files
+
+`asdf` supports the migration from existing version files from other version managers. Eg: `.ruby-version` for the case of `rbenv`. This is supported on a per-plugin basis.
+
+[`asdf-nodejs`](https://github.com/asdf-vm/asdf-nodejs/) supports this via both `.nvmrc` and `.node-version` files. To enable this, add the following to your `asdf` configuration file `$HOME/.asdfrc`:
+
+```
+legacy_version_file = yes
+```
+
+See the [configuration](/pt-br/manage/configuration.md) reference page for more config options.
+
+## Setup Complete!
+
+That completes the initial setup of `asdf` :tada: You can now manage `nodejs` versions for your project. Follow similar steps for each type of tool in your project!
+
+`asdf` has a many more commands to become familiar with, you can see them all by running `asdf --help` or `asdf`. The core of the commands are broken into three categories:
+
+- [core `asdf`](/pt-br/manage/core.md)
+- [plugins](/pt-br/manage/plugins.md)
+- [versions (of tools)](/pt-br/manage/versions.md)

--- a/docs/pt-br/guide/introduction.md
+++ b/docs/pt-br/guide/introduction.md
@@ -1,0 +1,59 @@
+# Introduction
+
+> Hi, we've recently migrated our docs and added some new pages. If you would like to help translate this page, see the "Edit this page" link at the bottom of the page.
+
+`asdf` is a tool version manager. All tool version definitions are contained within one file (`.tool-versions`) which you can check-in to your project's Git repository to share with your team, ensuring everyone is using the **exact** same versions of tools.
+
+The old way of working required multiple CLI version managers, each with their distinct API, configurations files and implementation (e.g. `$PATH` manipulation, shims, environment variables, etc...). `asdf` provides a single interface and configuration file to simplify development workflows, and can be extended to all tools and runtimes via a simple plugin interface.
+
+## How It Works
+
+Once `asdf` core is setup with your Shell configuration, plugins are installed to manage particular tools. When a tool is installed by a plugin, the executables that are installed have [shims](<https://en.wikipedia.org/wiki/Shim_(computing)>) created for each of them. When you try and run one of these executables, the shim is run instead, allowing `asdf` to identify which version of the tool is set in `.tool-versions` and execute that version.
+
+## Related Projects
+
+### nvm / n / rbenv etc
+
+Tools like [nvm](https://github.com/nvm-sh/nvm), [n](https://github.com/tj/n) and [rbenv](https://github.com/rbenv/rbenv) are all written as Shell scripts which create shims for the executables installed by these tools.
+
+`asdf` is very similar and was built to compete in this space of tool/runtime version management. The differentiating factor for `asdf` is it's plugin system which removes the need for a manager per tool/runtime, different commands per manager and different `*-version` files in your repo.
+
+<!-- ### pyenv
+
+TODO: someone with Python background expand on this
+
+`asdf` has some similarities to `pyenv` but is missing some key features. The `asdf` team is looking at introducing some of these `pyenv` specific features, though no roadmap or timeline is available. -->
+
+### direnv
+
+> augments existing shells with a new feature that can load and unload environment variables depending on the current directory.
+
+`asdf` does not manage Environment Variables, however there is a plugin [`asdf-direnv`](https://github.com/asdf-community/asdf-direnv) to integrate direnv behaviour with `asdf`.
+
+See [direnv docs](https://direnv.net/) for more.
+
+### Homebrew
+
+> The Missing Package Manager for macOS (or Linux)
+
+Homebrew manages your packages and their upstream dependencies. `asdf` does not manage upstream dependencies, it is not a package manager, that burden is upon the user, though we try and keep the dependency list small.
+
+See [Homebrew docs](https://brew.sh/) for more.
+
+### NixOS
+
+> Nix is a tool that takes a unique approach to package management and system configuration
+
+NixOS aims to build truly reproducible environments by managing exact versions of packages up the entire dependency tree of each tool, something `asdf` does not do. NixOS does this with it's own programming language, many CLI tools and a pacakges collection of over 60,000 packages.
+
+Again `asdf` does not manage upstream dependencies and is not a package manager.
+
+See [NixOS docs](https://nixos.org/guides/how-nix-works.html) for more.
+
+## Why use asdf?
+
+`asdf` ensures teams are using the **exact** same versions of tools, with support for **many** tools via a plugin system, and the _simplicity and familiarity_ of being a single **Shell** script you include in your Shell config.
+
+::: tip Note
+`asdf` is not intended to be a system package manager. It is a tool version manager. Just because you can create a plugin for any tool and manage it's versions with `asdf`, does not mean that is the best course of action for that specific tool.
+:::

--- a/docs/pt-br/index.md
+++ b/docs/pt-br/index.md
@@ -3,11 +3,11 @@ home: true
 title: Home
 # heroImage: https://vuejs.org/images/logo.png
 actions:
-  - text: "TODO: Translate"
-    link: /pt-BR/guide/getting-started.html
+  - text: "Começar"
+    link: /pt-br/guide/getting-started.html
     type: primary
-  - text: "TODO: Translate"
-    link: /pt-BR/guide/introduction.html
+  - text: "Introduction"
+    link: /pt-br/guide/introduction.html
     type: secondary
 features:
   - title: One Tool

--- a/docs/pt-br/learn-more/faq.md
+++ b/docs/pt-br/learn-more/faq.md
@@ -1,0 +1,27 @@
+# Perguntas frequentes
+
+> Hi, we've recently migrated our docs and added some new pages. If you would like to help translate this page, see the "Edit this page" link at the bottom of the page.
+
+Here are some common questions regarding `asdf`.
+
+## WSL1 support?
+
+WSL1 ([Windows Subsystem for Linux](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux) 1) is not officially supported. Some aspects of `asdf` may not work properly. We do not intend to add official support for WSL1.
+
+## WSL2 support?
+
+WSL2 ([Windows Subsystem for Linux](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux#WSL_2) 2) should work using the setup & dependency instructions for you chosen WSL distro.
+
+Importantly, WSL2 is _only_ expected to work properly when the current working directory is a Unix drive and not a bound Windows drive.
+
+We intend to run out test suite on WSL2 when host runner support is available on GitHub Actions, currently this does not appear to be the case.
+
+## Newly installed exectable not running?
+
+> I just `npm install -g yarn`, but cannot execute `yarn`. What gives?
+
+`asdf` uses [shims](<https://en.wikipedia.org/wiki/Shim_(computing)>) to manage executables. Those installed by plugins have shims automatically created, whereas installing executables via an `asdf` managed tool will require you to notify `asdf` of the need to create shims. In this instance, to create a shim for [Yarn](https://yarnpkg.com/). See the [`asdf reshim` command docs](/manage/core.md#reshim).
+
+## Shell not detecting newly installed shims?
+
+If `asdf reshim` is not resolving your issue, then it is most-likely due to the sourcing of `asdf.sh` or `asdf.fish` _not_ being at the **BOTTOM** of your Shell config file (`.bash_profile`, `.zshrc`, `config.fish` etc). It needs to be sourced **AFTER** you have set your `$PATH` and **AFTER** you have sourced your framework (oh-my-zsh etc) if any.

--- a/docs/pt-br/learn-more/thanks.md
+++ b/docs/pt-br/learn-more/thanks.md
@@ -1,0 +1,17 @@
+# Créditos
+
+Eu ([@HashNuke](https://github.com/HashNuke)), febre alta, resfriado e tosse.
+
+Copyright 2014 até o final dos tempos ([MIT License](https://github.com/asdf-vm/asdf/blob/master/LICENSE))
+
+## Mantenedores
+
+- [@HashNuke](https://github.com/HashNuke)
+- [@danhper](https://github.com/danhper)
+- [@Stratus3D](https://github.com/Stratus3D)
+- [@vic](https://github.com/vic)
+- [@jthegedus](https://github.com/jthegedus)
+
+## Contribuidores
+
+Veja em [lista de contribuidores](https://github.com/asdf-vm/asdf/graphs/contributors) :pray: no GitHub

--- a/docs/pt-br/manage/commands.md
+++ b/docs/pt-br/manage/commands.md
@@ -1,0 +1,7 @@
+# All Commands
+
+> Hi, we've recently migrated our docs and added some new pages. If you would like to help translate this page, see the "Edit this page" link at the bottom of the page.
+
+The list of all commands available in `asdf`. This list is the `asdf help` command text.
+
+@[code](../../../help.txt)

--- a/docs/pt-br/manage/configuration.md
+++ b/docs/pt-br/manage/configuration.md
@@ -1,0 +1,62 @@
+# Configuration
+
+> Hi, we've recently migrated our docs and added some new pages. If you would like to help translate this page, see the "Edit this page" link at the bottom of the page.
+
+Configuration of `asdf` encompasses both the sharable `.tool-versions` files as well as user specific customisations with `.asdfrc` and Environment Variables.
+
+## .tool-versions
+
+Sempre que o arquivo `.tool-versions` estiver presente em um diretório, as versões da ferramenta que ele declara serão usadas nesse diretório e em seus subdiretórios.
+
+?> Configurações globais podem ser modificadas no arquivo `$HOME/.tool-versions`
+
+O arquivo `.tool-versions` se parece assim:
+
+```:no-line-numbers
+ruby 2.5.3
+nodejs 10.15.0
+```
+
+As versões podem estar no seguinte formato:
+
+- `10.15.0` - uma versão real. Os plugins que suportam o download de binários farão o download de binários.
+- `ref:v1.0.2-a` ou `ref:39cb398vb39` - _tag/commit/branch_ para download pelo github e compilação
+  um path costumizado e compi
+- `path:/src/elixir` - um path para uma versão compilada e personalizada de uma ferramenta pronta para usar. Para uso por linguagens de desenvolvimento e outros.
+- `system` - faz com que asdf passe para a versão da ferramenta no sistema que não é gerenciada por asdf .
+
+Várias versões podem ser definidas, separando-as com um espaço. Por exemplo, para usar Python 3.7.2, e também Python 2.7.15, use a linha abaixo em seu arquivo `.tool-versions`.
+
+```:no-line-numbers
+python 3.7.2 2.7.15 system
+```
+
+Para instalar todas as ferramentas definidas em `.tool-versions`, execute o camando `asdf install` sem argumentos no mesmo diretório de `.tool-versions`.
+
+Para isntalar somente uma ferramenta definida em `.tool-versions`, execute o camando `asdf install` sem argumentos no mesmo diretório de `.tool-versions`. A ferramenta será instalada na versão especificada no arquivo `.tool-versions`.
+
+Edite o arquivo diretamente no diretório ou use `asdf local` (ou `asdf global`) para atualiza-lo.
+
+## \$HOME/.asdfrc
+
+Adicione um arquivo `.asdfrc` ao seu diretório home e asdf usará as configurações especificadas no arquivo. O arquivo deve ser formatado assim:
+
+```:no-line-numbers
+legacy_version_file = yes
+```
+
+**Configurações**
+
+- `legacy_version_file` - por padrão é `no`. Se definido como `yes`, fará com que os plug-ins que suportam esse recurso leiam os arquivos de versão usados por outros gerenciadores de versão (por exemplo, `.ruby-version` no caso do ` rbenv` do Ruby).
+- `use_release_candidates` - por padrão é `no`. Se definido como `yes`, fará com que o comando `asdf update` atualize para o mais recente em vez da versão semântica mais recente.
+
+- `always_keep_download` - por padrão é `no`. Se definido como `yes`, fará com que o ` asdf install` sempre mantenha o código-fonte ou binário baixado. Se definido como `no`, o código fonte ou binário baixado por ` asdf install` será excluído após a instalação bem sucedida.
+
+- `plugin_repository_last_check_duration` - por padrão é `60` min (1 hrs). Ele define a duração da última verificação do repositório de plugins asdf. Quando o comando `asdf plugin add <nome>`, `asdf plugin list all` for executado, ele verificará a duração da última atualização para atualizar o repositório. Se definido como `0`, ele atualizará o repositório de plugins asdf todas as vezes.
+
+## Variáveis de ambiente
+
+- `ASDF_CONFIG_FILE` - O padrão é `~ / .asdfrc` conforme descrito acima. Pode ser definido para qualquer local.
+- `ASDF_DEFAULT_TOOL_VERSIONS_FILENAME` - O nome do arquivo que armazena os nomes e versões das ferramentas. O padrão é `.tool-versions`. Pode ser qualquer nome de arquivo válido. Normalmente você não deve substituir o valor padrão, a menos que deseja que o asdf ignore os arquivos `.tool-versions`.
+- `ASDF_DIR` - O padrão é `~/.asdf` - Localização dos arquivos `asdf`. Se você instalar `asdf` em algum outro diretório, defina-o para esse diretório. Por exemplo, se você estiver instalando através do AUR, você deve definir isso para `/ opt / asdf-vm`.
+- `ASDF_DATA_DIR` - O padrão é `~/.asdf` - Local onde `asdf` instala plugins, correções e instalações. Pode ser definido para qualquer local antes de fornecer `asdf.sh` ou` asdf.fish` mencionado na seção acima.

--- a/docs/pt-br/manage/configuration.md
+++ b/docs/pt-br/manage/configuration.md
@@ -47,10 +47,10 @@ legacy_version_file = yes
 
 **Configurações**
 
-- `legacy_version_file` - por padrão é `no`. Se definido como `yes`, fará com que os plug-ins que suportam esse recurso leiam os arquivos de versão usados por outros gerenciadores de versão (por exemplo, `.ruby-version` no caso do ` rbenv` do Ruby).
+- `legacy_version_file` - por padrão é `no`. Se definido como `yes`, fará com que os plug-ins que suportam esse recurso leiam os arquivos de versão usados por outros gerenciadores de versão (por exemplo, `.ruby-version` no caso do `rbenv` do Ruby).
 - `use_release_candidates` - por padrão é `no`. Se definido como `yes`, fará com que o comando `asdf update` atualize para o mais recente em vez da versão semântica mais recente.
 
-- `always_keep_download` - por padrão é `no`. Se definido como `yes`, fará com que o ` asdf install` sempre mantenha o código-fonte ou binário baixado. Se definido como `no`, o código fonte ou binário baixado por ` asdf install` será excluído após a instalação bem sucedida.
+- `always_keep_download` - por padrão é `no`. Se definido como `yes`, fará com que o `asdf install` sempre mantenha o código-fonte ou binário baixado. Se definido como `no`, o código fonte ou binário baixado por `asdf install` será excluído após a instalação bem sucedida.
 
 - `plugin_repository_last_check_duration` - por padrão é `60` min (1 hrs). Ele define a duração da última verificação do repositório de plugins asdf. Quando o comando `asdf plugin add <nome>`, `asdf plugin list all` for executado, ele verificará a duração da última atualização para atualizar o repositório. Se definido como `0`, ele atualizará o repositório de plugins asdf todas as vezes.
 
@@ -59,4 +59,4 @@ legacy_version_file = yes
 - `ASDF_CONFIG_FILE` - O padrão é `~ / .asdfrc` conforme descrito acima. Pode ser definido para qualquer local.
 - `ASDF_DEFAULT_TOOL_VERSIONS_FILENAME` - O nome do arquivo que armazena os nomes e versões das ferramentas. O padrão é `.tool-versions`. Pode ser qualquer nome de arquivo válido. Normalmente você não deve substituir o valor padrão, a menos que deseja que o asdf ignore os arquivos `.tool-versions`.
 - `ASDF_DIR` - O padrão é `~/.asdf` - Localização dos arquivos `asdf`. Se você instalar `asdf` em algum outro diretório, defina-o para esse diretório. Por exemplo, se você estiver instalando através do AUR, você deve definir isso para `/ opt / asdf-vm`.
-- `ASDF_DATA_DIR` - O padrão é `~/.asdf` - Local onde `asdf` instala plugins, correções e instalações. Pode ser definido para qualquer local antes de fornecer `asdf.sh` ou` asdf.fish` mencionado na seção acima.
+- `ASDF_DATA_DIR` - O padrão é `~/.asdf` - Local onde `asdf` instala plugins, correções e instalações. Pode ser definido para qualquer local antes de fornecer `asdf.sh` ou`asdf.fish` mencionado na seção acima.

--- a/docs/pt-br/manage/core.md
+++ b/docs/pt-br/manage/core.md
@@ -1,0 +1,340 @@
+# Core
+
+> Hi, we've recently migrated our docs and added some new pages. If you would like to help translate this page, see the "Edit this page" link at the bottom of the page.
+
+The core `asdf` command list is rather small, but can facilitate many workflows.
+
+## Installation & Setup
+
+Covered in the [Getting Started](/pt-br/guide/getting-started.md) guide.
+
+## Exec
+
+```shell:no-line-numbers
+asdf exec <command> [args...]
+```
+
+Executes the command shim for the current version.
+
+<!-- TODO: expand on this with example -->
+
+## Env
+
+```shell:no-line-numbers
+asdf env <command> [util]
+```
+
+<!-- TODO: expand on this with example -->
+
+## Info
+
+```shell:no-line-numbers
+asdf info
+```
+
+A helper command to print the OS, Shell and `asdf` debug information. Share this when making a bug report.
+
+## Reshim
+
+```shell:no-line-numbers
+asdf reshim <name> <version>
+```
+
+This recreates the shims for the current version of a package. By default, shims are created by plugins during installation of a tool. Some tools like the [npm CLI](https://docs.npmjs.com/cli/) allow global installation of executables, for example, installing [Yarn](https://yarnpkg.com/) via `npm install -g yarn`. Since this executable was not installed via the plugin lifecycle, no shim exists for it yet. `asdf reshim nodejs <version>` will force recalculation of shims for any new executables, like `yarn`, for `<version>` of `nodejs` .
+
+## Shim-versions
+
+```shell:no-line-numbers
+asdf shim-versions <command>
+```
+
+Lists the plugins and versions that provide shims for a command.
+
+As an example, [Node.js](https://nodejs.org/) ships with two executables, `node` and `npm`. When many versions of the tools are installed with [`asdf-nodejs`](https://github.com/asdf-vm/asdf-nodejs/) `shim-versions` can return:
+
+```shell:no-line-numbers
+➜ asdf shim-versions node
+nodejs 14.8.0
+nodejs 14.17.3
+nodejs 16.5.0
+```
+
+```shell:no-line-numbers
+➜ asdf shim-versions npm
+nodejs 14.8.0
+nodejs 14.17.3
+nodejs 16.5.0
+```
+
+## Atualizar
+
+`asdf` has a built in command to update which relies on Git (our recommended installation method). If you installed using a different method you should follow the steps for that method:
+
+| Method         | Latest Stable Release                                                                                                                          | Latest commit on `master`  |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
+| asdf (via Git) | `asdf update`                                                                                                                                  | `asdf update --head`       |
+| Homebrew       | `brew upgrade asdf`                                                                                                                            | `brew upgrade asdf --HEAD` |
+| Pacman         | Obter manualmente um novo `PKGBUILD` e <br/> reconstruir ou usar suas preferências de [AUR](https://wiki.archlinux.org/index.php/AUR_helpers). |                            |
+
+## Desinstalar
+
+Para desinstalar `asdf` siga os passos:
+
+::: details Bash & Git
+
+1. Em seu `~/.bashrc` remova as linhas do `asdf.sh` e seus complementos:
+
+```shell
+. $HOME/.asdf/asdf.sh
+. $HOME/.asdf/completions/asdf.bash
+```
+
+2. Remova o diretório `$HOME/.asdf`:
+
+```shell
+rm -rf ${ASDF_DATA_DIR:-$HOME/.asdf}
+```
+
+3. Execute o comando para remover todos os arquivos de configurações do `asdf`:
+
+```shell
+rm -rf $HOME/.tool-versions $HOME/.asdfrc
+```
+
+:::
+
+::: details Bash & Git (macOS)
+
+1. Em seu `~/.bash_profile` remova as linhas do `asdf.sh` e remova seus complementos:
+
+```shell
+. $HOME/.asdf/asdf.sh
+. $HOME/.asdf/completions/asdf.bash
+```
+
+2. Remova o diretório `$HOME/.asdf`:
+
+```shell
+rm -rf ${ASDF_DATA_DIR:-$HOME/.asdf}
+```
+
+3. Execute o comando para remover todos os arquivos de configurações do `asdf`:
+
+```shell
+rm -rf $HOME/.tool-versions $HOME/.asdfrc
+```
+
+:::
+
+::: details Bash & Homebrew (macOS)
+
+Caso esteja usando **macOs Catalina ou mais recente**, por padrão o _shell_ é **ZSH**. Se não achar alguma configuração em seu `~/.bash_profile` talvez esteja em `~/.zshrc` em cada caso siga as intruções do ZSH.
+
+1. Em seu `~/.bash_profile` remova as linhas do `asdf.sh` e remova seus complementos:
+
+```shell
+. $(brew --prefix asdf)/asdf.sh
+. $(brew --prefix asdf)/etc/bash_completion.d/asdf.bash
+```
+
+?> Os complementos precisam [instruções de configuração do Homebrew](https://docs.brew.sh/Shell-Completion#configuring-completions-in-bash) e siga o guia de remoção.
+
+2. Desinstale usando seu gerenciador de pacotes:
+
+```shell
+brew uninstall asdf --force
+```
+
+3. Execute o comando para remover todos os arquivos de configurações do `asdf`:
+
+```shell
+rm -rf $HOME/.tool-versions $HOME/.asdfrc
+```
+
+:::
+
+::: details Bash & Pacman
+
+1. Em seu `~/.bashrc` remova as linhas do `asdf.sh` e seus complementos:
+
+```shell
+. /opt/asdf-vm/asdf.sh
+```
+
+2. Desinstale usando seu gerenciador de pacotes:
+
+```shell
+pacman -Rs asdf-vm
+```
+
+3. Remova o diretório `$HOME/.asdf`:
+
+```shell
+rm -rf ${ASDF_DATA_DIR:-$HOME/.asdf}
+```
+
+4. Execute o comando para remover todos os arquivos de configurações do `asdf`:
+
+```shell
+rm -rf $HOME/.tool-versions $HOME/.asdfrc
+```
+
+:::
+
+::: details Fish & Git
+
+1. Em seu `~/.config/fish/config.fish` remova as linhas do `asdf.sh`:
+
+```shell
+source ~/.asdf/asdf.fish
+```
+
+e remova os complementos de com esse comando:
+
+```shell
+rm -rf ~/.config/fish/completions/asdf.fish
+```
+
+2. Remova o diretório `$HOME/.asdf`:
+
+```shell
+rm -rf ${ASDF_DATA_DIR:-$HOME/.asdf}
+```
+
+3. Execute o comando para remover todos os arquivos de configurações do `asdf`:
+
+```shell
+rm -rf $HOME/.tool-versions $HOME/.asdfrc
+```
+
+:::
+
+::: details Fish & Homebrew
+
+1. Em seu `~/.config/fish/config.fish` remova as linhas do `asdf.fish`:
+
+```shell
+source "(brew --prefix asdf)"/asdf.fish
+```
+
+2. Desinstale usando seu gerenciador de pacotes:
+
+```shell
+brew uninstall asdf --force
+```
+
+3. Execute o comando para remover todos os arquivos de configurações do `asdf`:
+
+```shell
+rm -rf $HOME/.tool-versions $HOME/.asdfrc
+```
+
+:::
+
+::: details Fish & Pacman
+
+1. Em seu `~/.config/fish/config.fish` remova as linhas do `asdf.fish`:
+
+```shell
+source /opt/asdf-vm/asdf.fish
+```
+
+2. Desinstale usando seu gerenciador de pacotes:
+
+```shell
+pacman -Rs asdf-vm
+```
+
+3. Remova o diretório `$HOME/.asdf`:
+
+```shell
+rm -rf ${ASDF_DATA_DIR:-$HOME/.asdf}
+```
+
+4. Execute o comando para remover todos os arquivos de configurações do `asdf`:
+
+```shell
+rm -rf $HOME/.tool-versions $HOME/.asdfrc
+```
+
+:::
+
+::: details ZSH & Git
+
+1. Em seu `~/.zshrc` remova as linhas do `asdf.sh` e seus complementos:
+
+```shell
+. $HOME/.asdf/asdf.sh
+# ...
+fpath=(${ASDF_DIR}/completions $fpath)
+autoload -Uz compinit
+compinit
+```
+
+**Ou** use ZSH Framework plugin.
+
+2. Remova o diretório `$HOME/.asdf`:
+
+```shell
+rm -rf ${ASDF_DATA_DIR:-$HOME/.asdf}
+```
+
+3. Execute o comando para remover todos os arquivos de configurações do `asdf`:
+
+```shell
+rm -rf $HOME/.tool-versions $HOME/.asdfrc
+```
+
+:::
+
+::: details ZSH & Homebrew
+
+1. Em seu `~/.zshrc` remova as linhas do `asdf.sh`:
+
+```shell
+. $(brew --prefix asdf)/asdf.sh
+```
+
+2. Desinstale usando seu gerenciador de pacotes:
+
+```shell
+brew uninstall asdf --force
+```
+
+3. Execute o comando para remover todos os arquivos de configurações do `asdf`:
+
+```shell
+rm -rf $HOME/.tool-versions $HOME/.asdfrc
+```
+
+:::
+
+::: details ZSH & Pacman
+
+1. Em seu `~/.zshrc` remova as linhas do `asdf.sh`:
+
+```shell
+. /opt/asdf-vm/asdf.sh
+```
+
+2. Desinstale usando seu gerenciador de pacotes:
+
+```shell
+pacman -Rs asdf-vm
+```
+
+3. Remova o diretório `$HOME/.asdf`:
+
+```shell
+rm -rf ${ASDF_DATA_DIR:-$HOME/.asdf}
+```
+
+4. Execute o comando para remover todos os arquivos de configurações do `asdf`:
+
+```shell
+rm -rf $HOME/.tool-versions $HOME/.asdfrc
+```
+
+:::
+
+Tudo pronto! 🎉

--- a/docs/pt-br/manage/plugins.md
+++ b/docs/pt-br/manage/plugins.md
@@ -1,0 +1,83 @@
+# Plugins
+
+> Hi, we've recently migrated our docs and added some new pages. If you would like to help translate this page, see the "Edit this page" link at the bottom of the page.
+
+Plugins são como `asdf` sabe lidar com diferentes ferramentas, tais quais Node.js, Ruby, Elixir etc.
+
+See [Creating Plugins](/pt-br/plugins/create.md) for the plugin API used to support more tools.
+
+## Adicionar
+
+Adicione os plugins via sua Url Git:
+
+```shell:no-line-numbers
+asdf plugin add <name> <git-url>
+# asdf plugin add elm https://github.com/vic/asdf-elm
+```
+
+ou pelo nome abreviado dentro do repositório de plugins:
+
+```shell:no-line-numbers
+asdf plugin add <name>
+# asdf plugin add erlang
+```
+
+::: tip Recommendation
+Prefira o método mais longo `git-url`, pois ele é independente do repositório de nome abreviado.
+:::
+
+## Listar Instalados
+
+```shell:no-line-numbers
+asdf plugin list
+# asdf plugin list
+# java
+# nodejs
+```
+
+```shell:no-line-numbers
+asdf plugin list --urls
+# asdf plugin list
+# java            https://github.com/halcyon/asdf-java.git
+# nodejs          https://github.com/asdf-vm/asdf-nodejs.git
+```
+
+## Listar todos nomes abreviados no repositório
+
+```shell:no-line-numbers
+asdf plugin list all
+```
+
+See [Plugins Shortname Index](https://github.com/asdf-vm/asdf-plugin-template) for the entire short-name list of plugins.
+
+## Atualizar
+
+```shell:no-line-numbers
+asdf plugin update --all
+```
+
+Se você quiser atualizar um pacote específico, apenas use.
+
+```shell:no-line-numbers
+asdf plugin update <name>
+# asdf plugin update erlang
+```
+
+Esta atualização irá buscar o último _commit_ na _branch_ padrão no _origin_ de seu respositório. Plugins e atualizações das versões estão sendo desenvolvidas ([#916](https://github.com/asdf-vm/asdf/pull/916))
+
+## Remover
+
+```bash:no-line-numbers
+asdf plugin remove <name>
+# asdf plugin remove erlang
+```
+
+Removendo o plugin irá remover todas as instalações feitas com o plugin. Isso pode ser usado como um atalho para apagar/remover sujeiras de versões não utilizadas de uma ferramenta.
+
+## Sincronizar nome abreviado no repositório
+
+O nome abreviado do repositório é sincronizado em seu máquina local e periodicamente atualizado. Esse período pode ser determinado com o seguinte método:
+
+- comandos `asdf plugin add <name>` ou `asdf plugin list all` disparam a sincronização
+- ocorre uma sincronização se não houver nenhuma nos últimos `X` minutos
+- `X` por padrão é `60`, mas pode ser mudado em `.asdfrc` via as opções do `plugin_repository_last_check_duration`. Seja mais em [asdf documentação de configuração](/pt-br/manage/configuration.md).

--- a/docs/pt-br/manage/versions.md
+++ b/docs/pt-br/manage/versions.md
@@ -106,7 +106,6 @@ Para usar o sistema de versão da ferramenta `<name>` inicie um gerenciador de v
 Selecione o sistema com `global`, `local` ou `shell`
 Set system with either `global`, `local` or `shell` conforme descrito em [Selecionar versão atual](#selecionar-versão-atual).
 
-
 ```shell:no-line-numbers
 asdf local <name> system
 # asdf local python system

--- a/docs/pt-br/manage/versions.md
+++ b/docs/pt-br/manage/versions.md
@@ -1,0 +1,157 @@
+# Versões
+
+> Hi, we've recently migrated our docs and added some new pages. If you would like to help translate this page, see the "Edit this page" link at the bottom of the page.
+
+## Instalar Versão
+
+```shell:no-line-numbers
+asdf install <name> <version>
+# asdf install erlang 17.3
+```
+
+Se um plugin suporta o download e compilação do código-fonte, você pode especificar `ref:foo` no qual `foo` é uma 'branch' especifica, 'tag', ou 'commit'. Você também precisará usar o mesmo nome e referência ao desinstalar.
+
+## Instalar última versão estável
+
+```shell:no-line-numbers
+asdf install <name> latest
+# asdf install erlang latest
+```
+
+Instale a última versão estável que inicia com um texto.
+
+```shell:no-line-numbers
+asdf install <name> latest:<version>
+# asdf install erlang latest:17
+```
+
+## Listar versões instaladas
+
+```shell:no-line-numbers
+asdf list <name>
+# asdf list erlang
+```
+
+Limite as versões que inicie com um determinado texto.
+
+```shell:no-line-numbers
+asdf list <name> <version>
+# asdf list erlang 17
+```
+
+## Listar todas as versões disponíveis
+
+```shell:no-line-numbers
+asdf list all <name>
+# asdf list all erlang
+```
+
+Limite as versões que inicie com um determinado texto.
+
+```shell:no-line-numbers
+asdf list all <name> <version>
+# asdf list all erlang 17
+```
+
+## Mostrar última versão estável
+
+```shell:no-line-numbers
+asdf latest <name>
+# asdf latest erlang
+```
+
+Mostrar última versão estável que inicie com um determinado texto.
+
+```shell:no-line-numbers
+asdf latest <name> <version>
+# asdf latest erlang 17
+```
+
+## Selecionar versão atual
+
+```shell:no-line-numbers
+asdf global <name> <version> [<version>...]
+asdf shell <name> <version> [<version>...]
+asdf local <name> <version> [<version>...]
+# asdf global elixir 1.2.4
+
+asdf global <name> latest[:<version>]
+asdf local <name> latest[:<version>]
+# asdf global elixir latest
+```
+
+`global` escreve a versão para `$HOME/.tool-versions`.
+
+`shell` selecione a versão na variável de ambiente `ASDF_${LANG}_VERSION`, para a atual seção do _shell_.
+
+`local` escreve a versão para `$PWD/.tool-versions`, crie se necessário .
+
+Veja em `.tool-versions` [arquivo de seleção de configuração](/pt-br/core-configuration) para mais detalhes.
+
+::: warning Alternativa
+Se você quiser selecionar a versão atual do seu _shell_ ou para executar um comando em uma versão específica de sua ferramenta, você pode selecionar a versão na variável de ambiente `ASDF_${TOOL}_VERSION`.
+:::
+
+O seguinte exemplo executa os testes em um projeto Elixir na versão `1.4.0`.
+O formato da versão é o mesmo suportado pelo arquivo `.tool-versions`.
+
+```shell:no-line-numbers
+ASDF_ELIXIR_VERSION=1.4.0 mix test
+```
+
+## Resposta do sistema de versão
+
+Para usar o sistema de versão da ferramenta `<name>` inicie um gerenciador de versões do asdf para selecionar a versão na ferramenta do `system`.
+
+Selecione o sistema com `global`, `local` ou `shell`
+Set system with either `global`, `local` or `shell` conforme descrito em [Selecionar versão atual](#selecionar-versão-atual).
+
+
+```shell:no-line-numbers
+asdf local <name> system
+# asdf local python system
+```
+
+## Verificar a versão atual
+
+```shell:no-line-numbers
+asdf current
+# asdf current
+# erlang 17.3 (set by /Users/kim/.tool-versions)
+# nodejs 6.11.5 (set by /Users/kim/cool-node-project/.tool-versions)
+
+asdf current <name>
+# asdf current erlang
+# 17.3 (set by /Users/kim/.tool-versions)
+```
+
+## Desinstalar versão
+
+```shell:no-line-numbers
+asdf uninstall <name> <version>
+# asdf uninstall erlang 17.3
+```
+
+## Shims
+
+Quando asdf instala um pacote é criado _shims_ para cada programa executado no pacote do diretório `$ASDF_DATA_DIR/shims` (padrão `~/.asdf/shims`). Esse diretório começa no `$PATH` (pelos `asdf.sh` ou `asdf.fish`) é como o programa instalado é disponibilizado no ambiente do sistema.
+
+Os _shims_ em si são atalhos simples que executam um programa auxiliar `asdf exec` passando o nome do plugin e o caminho para o executável no pacote instalado que o _shim_ está contido.
+
+O `asdf exec` ajuda a determinar a versão do pacote usado (como especificado no arquivo `.tool-versions`, pelo `asdf local ...` ou `asdf global ...`), o final do _path_ do executavél no pacote instalado no diretório (pode ser manipulado pelo `exec-path` no _callback_ do plugin) e o ambiente executado em (também fornecido pelo plugin - `exec-env`) e finalmente executado.
+
+::: warning Observação
+Observe que, como este sistema usa chamadas `exec`, qualquer _scripts_ no pacote devem ser fornecidos pelo _shell_, a instancia em execução precisa ser aessado diretamente ao invés do _shim_. Os dois comandos do asdf: `which` e `where` pode ajudar com o retorno do caminho para o pacote instalado:
+:::
+
+```shell
+# retorna o 'path' da versão atual em execução
+source $(asdf which ${PLUGIN})/../script.sh
+
+# retorna o 'path' do pacote instalado no diretório
+source $(asdf where ${PLUGIN} $(asdf current ${PLUGIN}))/bin/script.sh
+```
+
+### Ignorando _shims_ do asdf
+
+Se por algum motivo você deseja ignorar _shims_ do asdf ou deseja que suas variáveis de ambiente sejam definidas automaticamente ao entrar no diretório do seu projeto, pode ser útil o [asdf-direnv](https://github.com/asdf-community/asdf-direnv). Verifique o README para mais detalhes.

--- a/docs/pt-br/plugins/create.md
+++ b/docs/pt-br/plugins/create.md
@@ -1,0 +1,285 @@
+# Create a Plugin
+
+> Hi, we've recently migrated our docs and added some new pages. If you would like to help translate this page, see the "Edit this page" link at the bottom of the page.
+
+## What's in a Plugin
+
+A plugin is a git repo, with a couple executable scripts, to support versioning another language or tool. These scripts are run when `list-all`, `install` or `uninstall` commands are run. You can set or unset env vars and do anything required to setup the environment for the tool.
+
+## Required Scripts
+
+- `bin/list-all` - lists all installable versions
+- `bin/download` - download source code or binary for the specified version
+- `bin/install` - installs the specified version
+
+## Environment Variables
+
+All scripts except `bin/list-all` will have access to the following env vars to act upon:
+
+- `ASDF_INSTALL_TYPE` - `version` or `ref`
+- `ASDF_INSTALL_VERSION` - if `ASDF_INSTALL_TYPE` is `version` then this will be the version number. Else it will be the git ref that is passed. Might point to a tag/commit/branch on the repo.
+- `ASDF_INSTALL_PATH` - the dir where the it _has been_ installed (or _should_ be installed in case of the `bin/install` script)
+
+These additional environment variables will be available to the `bin/install` script:
+
+- `ASDF_CONCURRENCY` - the number of cores to use when compiling the source code. Useful for setting `make -j`.
+- `ASDF_DOWNLOAD_PATH` - the path to where the source code or binary was downloaded by the `bin/download` script.
+
+These additional environment variables will be available to the `bin/download` script:
+
+- `ASDF_DOWNLOAD_PATH` - the path to where the source code or binary should be downloaded.
+
+#### bin/list-all
+
+Must print a string with a space-separated list of versions. Example output would be the following:
+
+```shell
+1.0.1 1.0.2 1.3.0 1.4
+```
+
+Note that the newest version should be listed last so it appears closer to the user's prompt. This is helpful since the `list-all` command prints each version on it's own line. If there are many versions it's possible the early versions will be off screen.
+
+If versions are being pulled from releases page on a website it's recommended to not sort the versions if at all possible. Often the versions are already in the correct order or, in reverse order, in which case something like `tac` should suffice. If you must sort versions manually you cannot rely on `sort -V` since it is not supported on OSX. An alternate sort function [like this is a better choice](https://github.com/vic/asdf-idris/blob/master/bin/list-all#L6).
+
+#### bin/download
+
+This script must download the source or binary, in the path contained in the `ASDF_DOWNLOAD_PATH` environment variable. If the downloaded source or binary is compressed, only the uncompressed source code or binary may be placed in the `ASDF_DOWNLOAD_PATH` directory.
+
+The script must exit with a status of `0` when the download is successful. If the download fails the script must exit with any non-zero exit status.
+
+If possible the script should only place files in the `ASDF_DOWNLOAD_PATH`. If the download fails no files should be placed in the directory.
+
+If this script is not present asdf will assume that the `bin/install` script is present and will download and install the version. asdf only works without this script to support legacy plugins. All plugins must include this script, and eventually support for legacy plugins will be removed.
+
+#### bin/install
+
+This script should install the version, in the path mentioned in `ASDF_INSTALL_PATH`. By default, asdf will create shims for any files in `$ASDF_INSTALL_PATH/bin` (this can be customized with the optional [bin/list-bin-paths](#binlist-bin-paths) script).
+
+The install script should exit with a status of `0` when the installation is successful. If the installation fails the script should exit with any non-zero exit status.
+
+If possible the script should only place files in the `ASDF_INSTALL_PATH` directory once the build and installation of the tool is deemed successful by the install script. asdf [checks for the existence](https://github.com/asdf-vm/asdf/blob/242d132afbf710fe3c7ec23c68cec7bdd2c78ab5/lib/utils.sh#L44) of the `ASDF_INSTALL_PATH` directory in order to determine if that version of the tool is installed. If the `ASDF_INSTALL_PATH` directory is populated at the beginning of the installation process other asdf commands run in other terminals during the installation may consider that version of the tool installed, even when it is not fully installed.
+
+If you want your plugin to work with asdf version 0.7._ and earlier and version 0.8._ and newer check for the presence of the `ASDF_DOWNLOAD_PATH` environment variable. If it is not set download the source code in the bin/install callback. If it is set assume the `bin/download` script already downloaded it.
+
+## Optional Scripts
+
+#### bin/help scripts
+
+This is not one callback script but rather a set of callback scripts that each print different documentation to STDOUT. The possible callback scripts are listed below. Note that `bin/help.overview` is a special case as it must be present for any help output to be displayed for the script.
+
+- `bin/help.overview` - This script should output a general description about the plugin and the tool being managed. No heading should be printed as asdf will print headings. Output may be free-form text but ideally only one short paragraph. This script must be present if you want asdf to provide help information for your plugin. All other help callback scripts are optional.
+- `bin/help.deps` - This script should output the list of dependencies tailored to the operating system. One dependency per line.
+- `bin/help.config` - This script should print any required or optional configuration that may be available for the plugin and tool. Any environment variables or other flags needed to install or compile the tool (for the users operating system when possible). Output can be free-form text.
+- `bin/help.links` - This should be a list of links relevant to the plugin and tool (again, tailored to the current operating system when possible). One link per line. Lines may be in the format `<title>: <link>` or just `<link>`.
+
+Each of these scripts should tailor their output to the current operating system. For example, when on Ubuntu the deps script could output the dependencies as apt-get packages that must be installed. The script should also tailor its output to the value of `ASDF_INSTALL_VERSION` and `ASDF_INSTALL_TYPE` when the variables are set. They are optional and will not always be set.
+
+The help callback script MUST NOT output any information that is already covered in the core asdf-vm documentation. General asdf usage information must not be present.
+
+#### bin/list-bin-paths
+
+List executables for the specified version of the tool. Must print a string with a space-separated list of dir paths that contain executables. The paths must be relative to the install path passed. Example output would be:
+
+```shell
+bin tools veggies
+```
+
+This will instruct asdf to create shims for the files in `<install-path>/bin`, `<install-path>/tools` and `<install-path>/veggies`
+
+If this script is not specified, asdf will look for the `bin` dir in an installation and create shims for those.
+
+#### bin/exec-env
+
+Setup the env to run the binaries in the package.
+
+#### bin/exec-path
+
+Get the executable path for the specified version of the tool. Must print a string with the relative executable path. This allows the plugin to conditionally override the shim's specified executable path, otherwise return the default path specified by the shim.
+
+```shell
+Usage:
+  plugin/bin/exec-path <install-path> <command> <executable-path>
+
+Example Call:
+  ~/.asdf/plugins/foo/bin/exec-path "~/.asdf/installs/foo/1.0" "foo" "bin/foo"
+
+Output:
+  bin/foox
+```
+
+#### bin/uninstall
+
+Uninstalls a specific version of a tool.
+
+#### bin/list-legacy-filenames
+
+Register additional setter files for this plugin. Must print a string with a space-separated list of filenames.
+
+```shell
+.ruby-version .rvmrc
+```
+
+Note: This will only apply for users who have enabled the `legacy_version_file` option in their `~/.asdfrc`.
+
+#### bin/parse-legacy-file
+
+This can be used to further parse the legacy file found by asdf. If `parse-legacy-file` isn't implemented, asdf will simply cat the file to determine the version. The script will be passed the file path as its first argument.
+
+#### bin/post-plugin-add
+
+This can be used to run any post-installation actions after the plugin has been added to asdf.
+
+The script has access to the path the plugin was installed (`${ASDF_PLUGIN_PATH}`) and the source URL (`${ASDF_PLUGIN_SOURCE_URL}`), if any was used.
+
+See also the related hooks:
+
+- `pre_asdf_plugin_add`
+- `pre_asdf_plugin_add_${plugin_name}`
+- `post_asdf_plugin_add`
+- `post_asdf_plugin_add_${plugin_name}`
+
+#### bin/pre-plugin-remove
+
+This can be used to run any pre-removal actions before the plugin will be removed from asdf.
+
+The script has access to the path the plugin was installed in (`${ASDF_PLUGIN_PATH}`).
+
+See also the related hooks:
+
+- `pre_asdf_plugin_remove`
+- `pre_asdf_plugin_remove_${plugin_name}`
+- `post_asdf_plugin_remove`
+- `post_asdf_plugin_remove_${plugin_name}`
+
+## Extension commands for asdf CLI.
+
+It's possible for plugins to define new asdf commands by providing `lib/commands/command*.bash` scripts or executables that
+will be callable using the asdf command line interface by using the plugin name as a subcommand.
+
+For example, suppose a `foo` plugin has:
+
+```shell
+foo/
+  lib/commands/
+    command.bash
+    command-bat.bash
+    command-bat-man.bash
+    command-help.bash
+```
+
+Users can now execute
+
+```shell
+$ asdf foo         # same as running `$ASDF_DATA_DIR/plugins/foo/lib/commands/command.bash`
+$ asdf foo bar     # same as running `$ASDF_DATA_DIR/plugins/foo/lib/commands/command.bash bar`
+$ asdf foo help    # same as running `$ASDF_DATA_DIR/plugins/foo/lib/commands/command-help.bash`
+$ asdf foo bat man # same as running `$ASDF_DATA_DIR/plugins/foo/lib/commands/command-bat-man.bash`
+$ asdf foo bat baz # same as running `$ASDF_DATA_DIR/plugins/foo/lib/commands/command-bat.bash baz`
+```
+
+Plugin authors can use this feature to provide utilities related to their tools,
+or even create plugins that are just new command extensions for asdf itself.
+
+When invoked, if extension commands do not have their executable-bit set, they will be
+sourced as bash scripts, having all of the functions from `$ASDF_DIR/lib/utils.bash` available.
+Also, the `$ASDF_CMD_FILE` resolves to the full path of the file being sourced.
+If the executable bit is set, they are just executed and replace the asdf execution.
+
+A good example of this feature is for plugins like [`haxe`](https://github.com/asdf-community/asdf-haxe)
+which provides the `asdf haxe neko-dylibs-link` to fix an issue where haxe executables expect to find
+dynamic libraries relative to the executable directory.
+
+If your plugin provides an asdf extension command, be sure to mention about it on your plugin's README.
+
+## Custom shim templates
+
+**PLEASE use this feature only if absolutely required**
+
+asdf allows custom shim templates. For an executable called `foo`, if there's a `shims/foo` file in the plugin, then asdf will copy that file instead of using it's standard shim template.
+
+This must be used wisely. For now AFAIK, it's only being used in the Elixir plugin, because an executable is also read as an Elixir file apart from just being an executable. Which makes it not possible to use the standard bash shim.
+
+## Testing plugins
+
+`asdf` contains the `plugin-test` command to test your plugin. You can use it as follows
+
+```shell
+asdf plugin test <plugin-name> <plugin-url> [--asdf-tool-version <version>] [--asdf-plugin-gitref <git-ref>] [test-command*]
+```
+
+Only the two first arguments are required.
+If \__version_ is specified, the tool will be installed with that specific version. Defaults to whatever returns `asdf latest <plugin-name>`.
+If _git-ref_ is specified, the plugin itself is checked out at that commit/branch/tag, useful for testing a pull-request on your plugin's CI.
+
+Rest arguments are considered the command to execute to ensure the installed tool works correctly.
+Normally it would be something that takes `--version` or `--help`.
+For example, to test the NodeJS plugin, we could run
+
+```shell
+asdf plugin test nodejs https://github.com/asdf-vm/asdf-nodejs.git node --version
+```
+
+We strongly recommend you test your plugin on a CI environment and make sure it works on both Linux and OSX.
+
+#### Example GitHub Action
+
+The [asdf-vm/actions](https://github.com/asdf-vm/actions) repo provides a GitHub Action for testing your plugins hosted on github.
+
+```yaml
+steps:
+  - name: asdf_plugin_test
+    uses: asdf-vm/actions/plugin-test@v1
+    with:
+      command: "my_tool --version"
+    env:
+      GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }} # automatically provided
+```
+
+#### Example TravisCI config
+
+Here is a sample `.travis.yml` file, customize it to your needs
+
+```yaml
+language: c
+script: asdf plugin test nodejs $TRAVIS_BUILD_DIR 'node --version'
+before_script:
+  - git clone https://github.com/asdf-vm/asdf.git asdf
+  - . asdf/asdf.sh
+os:
+  - linux
+  - osx
+```
+
+Note:
+When using another CI, you will need to check what variable maps to the repo path.
+
+You also have the option to pass a relative path to `plugin-test`.
+
+For example, if the test script is ran in the repo directory: `asdf plugin test nodejs . 'node --version'`.
+
+## GitHub API Rate Limiting
+
+If your plugin's `list-all` depends on accessing the GitHub API, make sure you provide an Authorization token when accessing it, otherwise your tests might fail due to rate limiting.
+
+To do so, create a [new personal token](https://github.com/settings/tokens/new) with only `public_repo` access.
+
+Then on your travis.ci build settings add a _secure_ environment variable for it named something like `GITHUB_API_TOKEN`. And _DO NOT_ EVER publish your token in your code.
+
+Finally, add something like the following to `bin/list-all`
+
+```shell
+cmd="curl -s"
+if [ -n "$GITHUB_API_TOKEN" ]; then
+ cmd="$cmd -H 'Authorization: token $GITHUB_API_TOKEN'"
+fi
+
+cmd="$cmd $releases_path"
+```
+
+## Submitting plugins to the official plugins repository
+
+`asdf` can easily install plugins by specifying the plugin repository url, e.g. `plugin add my-plugin https://github.com/user/asdf-my-plugin.git`.
+
+To make it easier on your users, you can add your plugin to the official plugins repository to have your plugin listed and easily installable using a shorter command, e.g. `asdf plugin add my-plugin`.
+
+Follow the instruction at the plugins repository: [asdf-vm/asdf-plugins](https://github.com/asdf-vm/asdf-plugins).


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

This is a follow up to #1000 adding the pt-br translations from @Rogerio-Viana in #970 back to the new site.

I copied over content from the old docs as best I could. Instead of leaving un-translated pages blank I copied over the English page and added a comment to the top of the page.

>Hi, we've recently migrated our docs and added some new pages. If you would like to help translate this page, see the "Edit this page" link at the bottom of the page.

The Introduction and Getting Started pages are the ones which need entire rewrites, as with the Contribution pages. I am sorry @Rogerio-Viana that this migration didn't happen before you put in the huge effort to translate. I hope this is a good start for you and others to build upon :pray:

`docs/.vuepress/navbar.js` and `docs/.vuepress/sidebar.js` contain the navbar and sidebar contents. Translations for those should need to be made there. Vuepress picks up Sidebar headings from the files themselves. It will makes sense once you get hands on.

See our english docs for instructions about contributing translations for more - https://asdf-vm.com/contribute/documentation.html#i18n

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->
See the Vuepress docs site for language switching behaviour - https://v2.vuepress.vuejs.org/