### PR TITLE
fix: don't override existing ASDF_DIR

### DIFF
--- a/asdf.sh
+++ b/asdf.sh
@@ -3,16 +3,18 @@
 # For Bash, ${BASH_SOURCE[0]} will be used to obtain this script's path.
 # For Zsh and others, $0 (the path to the shell or script) will be used.
 _under="$_"
-if [ "${BASH_SOURCE[0]}" != "" ]; then
-  current_script_path="${BASH_SOURCE[0]}"
-elif [[ "$_under" == *".sh" ]]; then
-  current_script_path="$_under"
-else
-  current_script_path="$0"
-fi
+if [ -z "$ASDF_DIR" ]; then
+  if [ -n "${BASH_SOURCE[0]}" ]; then
+    current_script_path="${BASH_SOURCE[0]}"
+  elif [[ "$_under" == *".sh" ]]; then
+    current_script_path="$_under"
+  else
+    current_script_path="$0"
+  fi
 
+  ASDF_DIR="$(dirname "$current_script_path")"
+fi
 export ASDF_DIR
-ASDF_DIR="$(dirname "$current_script_path")"
 # shellcheck disable=SC2016
 [ -d "$ASDF_DIR" ] || echo '$ASDF_DIR is not a directory'
 
@@ -31,3 +33,5 @@ PATH="${ASDF_USER_SHIMS}:$PATH"
 # shellcheck source=lib/asdf.sh
 # Load the asdf wrapper function
 . "${ASDF_DIR}/lib/asdf.sh"
+
+unset _under current_script_path ASDF_BIN ASDF_USER_SHIMS

--- a/test/version_commands.bats
+++ b/test/version_commands.bats
@@ -21,6 +21,9 @@ setup() {
   mkdir -p $CHILD_DIR
 
   cd $PROJECT_DIR
+
+  # asdf lib needed to run asdf.sh
+  cp -rf $BATS_TEST_DIRNAME/../{bin,lib} $ASDF_DIR/
 }
 
 teardown() {


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->
Allow users to define their own value of ASDF_DIR before sourcing asdf.sh, e.g. when it was installed with homebrew.

For example, I can use this in my shell startup script:

```
ASDF_DIR=/usr/local/opt/asdf
source "$ASDF_DIR/asdf.sh"
```

Also, similar test for `[ -z "$ASDF_DIR" ]` is already being done in `lib/utils.bash`.

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->
Also unset locally used variables at the end.
