### PR TITLE
docs: use list so rendering isn't merged

### DIFF
--- a/docs/contribute/core.md
+++ b/docs/contribute/core.md
@@ -94,7 +94,7 @@ feat!: feature with breaking change
 
 The full list of `<types>` are: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`.
 
-* `!` indicates a breaking change
+* `!`: indicates a breaking change
 * `fix`: will create a new SemVer `patch`
 * `feat`: will create a new SemVer `minor`
 * `<type>!`: will create a new SemVer `major`

--- a/docs/contribute/core.md
+++ b/docs/contribute/core.md
@@ -94,11 +94,10 @@ feat!: feature with breaking change
 
 The full list of `<types>` are: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`.
 
-The `!` indicates a breaking change.
-
-`fix`: will create a new SemVer `patch`
-`feat`: will create a new SemVer `minor`
-`<type>!`: will create a new SemVer `major`
+* `!` indicates a breaking change
+* `fix`: will create a new SemVer `patch`
+* `feat`: will create a new SemVer `minor`
+* `<type>!`: will create a new SemVer `major`
 
 The Pull Request Title must follow this format.
 


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

Fix rendering issue. The items should be a list, as markdown renders singularly newlined paragraphs as the same paragraph. 

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->

### Before:

![image](https://user-images.githubusercontent.com/20798510/126887925-4964e3c5-0da9-4465-a0fd-d3971a41ce3a.png)

### After:

![image](https://user-images.githubusercontent.com/20798510/126887968-ec1ae717-061b-4727-a582-4877449f646f.png)
