### PR TITLE
feat: toggle off repo sync completely

### DIFF
--- a/docs/manage/configuration.md
+++ b/docs/manage/configuration.md
@@ -53,12 +53,12 @@ plugin_repository_last_check_duration = 60
 
 ### `legacy_version_file`
 
-Plugins with support can read the versions files used by other version managers, for example, `.ruby-version` in the case of Ruby's `rbenv`.
+Plugins **with support** can read the versions files used by other version managers, for example, `.ruby-version` in the case of Ruby's `rbenv`.
 
-| Options                                                    | Description                                                   |
-| :--------------------------------------------------------- | :------------------------------------------------------------ |
-| `no` <Badge type="tip" text="default" vertical="middle" /> | Use `.tool-versions` to read versions                         |
-| `yes`                                                      | Use plugin fallback to legacy version files (`.ruby-version`) |
+| Options                                                    | Description                                                                |
+| :--------------------------------------------------------- | :------------------------------------------------------------------------- |
+| `no` <Badge type="tip" text="default" vertical="middle" /> | Use `.tool-versions` to read versions                                      |
+| `yes`                                                      | Use plugin fallback to legacy version files (`.ruby-version`) if available |
 
 ### `use_release_candidates`
 

--- a/docs/manage/configuration.md
+++ b/docs/manage/configuration.md
@@ -53,34 +53,40 @@ plugin_repository_last_check_duration = 60
 
 ### `legacy_version_file`
 
-If set to `yes`, plugins with support will read the versions files used by other version managers (e.g. `.ruby-version` in the case of Ruby's `rbenv`).
+Plugins with support can read the versions files used by other version managers, for example, `.ruby-version` in the case of Ruby's `rbenv`.
 
-- Defaults to `no`
-- Valid values: `yes` or `no`
+| Options                                                    | Description                                                   |
+| :--------------------------------------------------------- | :------------------------------------------------------------ |
+| `no` <Badge type="tip" text="default" vertical="middle" /> | Use `.tool-versions` to read versions                         |
+| `yes`                                                      | Use plugin fallback to legacy version files (`.ruby-version`) |
 
 ### `use_release_candidates`
 
-If set to `yes`, the `asdf update` command to upgrade will use the latest release candidate release instead of the latest semantic version.
+Configure the `asdf update` command to upgrade to the latest Release Candidate instead of the latest Semantic Version.
 
-- Defaults to `no`
-- Valid values: `yes` or `no`
+| Options                                                    | Description               |
+| :--------------------------------------------------------- | :------------------------ |
+| `no` <Badge type="tip" text="default" vertical="middle" /> | Semantic Version is used  |
+| `yes`                                                      | Release Candidate is used |
 
 ### `always_keep_download`
 
-If set to `yes`, `asdf install` will always keep the source code or binary it downloads. If set to `no` the source code or binary downloaded by `asdf install` will be deleted after successful installation.
+Configure the `asdf install` command to keep or delete the source code or binary it downloads.
 
-- Defaults to `no`
-- Valid values: `yes` or `no`
+| Options                                                    | Description                                |
+| :--------------------------------------------------------- | :----------------------------------------- |
+| `no` <Badge type="tip" text="default" vertical="middle" /> | Delete source code or binary after install |
+| `yes`                                                      | Keep source code or binary after install   |
 
 ### `plugin_repository_last_check_duration`
 
-Sets the duration (in minutes) until the asdf plugins repository should be synced since previous sync. The check triggers when command `asdf plugin add <name>` or `asdf plugin list all` are executed.
+Configure the duration since the last asdf plugin repository sync to the next. Commands `asdf plugin add <name>` or `asdf plugin list all` will trigger a check of the duration, if the duration has passed then a sync occurs.
 
-- Defaults to `60`
-- Valid values: `never` or a number in the range `0` to `999999999` (1902 years).
-
-When set to `0` a sync will occur on **each** trigger. When set to `never` a sync will **never** occur. When set to a number `>0` a sync will occur on next trigger if the set number of **minutes** has passed since previous trigger.
-
+| Options                                                                                                 | Description                                                  |
+| :------------------------------------------------------------------------------------------------------ | :----------------------------------------------------------- |
+| integer in range `1` to `999999999` <br/> `60` is <Badge type="tip" text="default" vertical="middle" /> | Sync on trigger event if duration since last sync has passed |
+| `0`                                                                                                     | Sync on each trigger event                                   |
+| `never`                                                                                                 | Never sync                                                   |
 
 ## Environment Variables
 

--- a/docs/manage/configuration.md
+++ b/docs/manage/configuration.md
@@ -25,6 +25,7 @@ The versions can be in the following format:
 - `system` - this keyword causes asdf to passthrough to the version of the tool on the system that is not managed by asdf.
 
 ::: tip
+
 Multiple versions can be set by separating them with a space. For example, to use Python `3.7.2`, fallback to Python `2.7.15` and finally to the `system` Python, the following line can be added to `.tool-versions`.
 
 ```:no-line-numbers
@@ -41,18 +42,43 @@ Edit the file directly or use `asdf local` (or `asdf global`) which updates it.
 
 ## `$HOME/.asdfrc`
 
-Add a `.asdfrc` file to your home directory and asdf will use the settings specified in the file. The file should be formatted like this:
+Add an `.asdfrc` file to your home directory and asdf will use the settings specified in the file. The file below shows the required format with the default values to demonstrate:
 
 ```:no-line-numbers
-legacy_version_file = yes
+legacy_version_file = no
+use_release_candidates = no
+always_keep_download = no
+plugin_repository_last_check_duration = 60
 ```
 
-**Settings**
+### `legacy_version_file`
 
-- `legacy_version_file` - defaults to `no`. If set to yes it will cause plugins that support this feature to read the version files used by other version managers (e.g. `.ruby-version` in the case of Ruby's `rbenv`).
-- `use_release_candidates` - defaults to `no`. If set to yes it will cause the `asdf update` command to upgrade to the latest release candidate release instead of the latest semantic version.
-- `always_keep_download` - defaults to `no`. If set to `yes` it will cause `asdf install` always keep the source code or binary it downloads. If set to `no` the source code or binary downloaded by `asdf install` will be deleted after successful installation.
-- `plugin_repository_last_check_duration` - defaults to `60` mins (1 hrs). It will set asdf plugins repository last check duration. When `asdf plugin add <name>`, `asdf plugin list all` command be executed, it will check last update duration to update repository. If set to `0` it will update asdf plugins repository every time.
+If set to `yes`, plugins with support will read the versions files used by other version managers (e.g. `.ruby-version` in the case of Ruby's `rbenv`).
+
+- Defaults to `no`
+- Valid values: `yes` or `no`
+
+### `use_release_candidates`
+
+If set to `yes`, the `asdf update` command to upgrade will use the latest release candidate release instead of the latest semantic version.
+
+- Defaults to `no`
+- Valid values: `yes` or `no`
+
+### `always_keep_download`
+
+If set to `yes`, `asdf install` will always keep the source code or binary it downloads. If set to `no` the source code or binary downloaded by `asdf install` will be deleted after successful installation.
+
+- Defaults to `no`
+- Valid values: `yes` or `no`
+
+### `plugin_repository_last_check_duration`
+
+Sets the duration (in minutes) until the asdf plugins repository should be synced since previous sync. The check occurs when command `asdf plugin add <name>` or `asdf plugin list all` are executed.
+
+- Defaults to `60`
+- Valid values: `never` or a number in the range `0` to `999999999` (1902 years).
+
 
 ## Environment Variables
 

--- a/docs/manage/configuration.md
+++ b/docs/manage/configuration.md
@@ -73,10 +73,10 @@ Configure the `asdf update` command to upgrade to the latest Release Candidate i
 
 Configure the `asdf install` command to keep or delete the source code or binary it downloads.
 
-| Options                                                    | Description                                |
-| :--------------------------------------------------------- | :----------------------------------------- |
-| `no` <Badge type="tip" text="default" vertical="middle" /> | Delete source code or binary after install |
-| `yes`                                                      | Keep source code or binary after install   |
+| Options                                                    | Description                                           |
+| :--------------------------------------------------------- | :---------------------------------------------------- |
+| `no` <Badge type="tip" text="default" vertical="middle" /> | Delete source code or binary after successful install |
+| `yes`                                                      | Keep source code or binary after install              |
 
 ### `plugin_repository_last_check_duration`
 

--- a/docs/manage/configuration.md
+++ b/docs/manage/configuration.md
@@ -74,10 +74,12 @@ If set to `yes`, `asdf install` will always keep the source code or binary it do
 
 ### `plugin_repository_last_check_duration`
 
-Sets the duration (in minutes) until the asdf plugins repository should be synced since previous sync. The check occurs when command `asdf plugin add <name>` or `asdf plugin list all` are executed.
+Sets the duration (in minutes) until the asdf plugins repository should be synced since previous sync. The check triggers when command `asdf plugin add <name>` or `asdf plugin list all` are executed.
 
 - Defaults to `60`
 - Valid values: `never` or a number in the range `0` to `999999999` (1902 years).
+
+When set to `0` a sync will occur on **each** trigger. When set to `never` a sync will **never** occur. When set to a number `>0` a sync will occur on next trigger if the set number of **minutes** has passed since previous trigger.
 
 
 ## Environment Variables

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -383,20 +383,23 @@ get_asdf_config_value() {
 # 0: if sync needs to occur
 # 1: if no sync needs to occur
 repository_needs_update() {
-  local update_file_dir
-  update_file_dir="$(asdf_data_dir)/tmp"
-  local update_file_name
-  update_file_name="repo-updated"
-  # `find` outputs filename if it has not been modified in plugin_repository_last_check_duration setting.
   local plugin_repository_last_check_duration
+  local sync_required
+
   plugin_repository_last_check_duration="$(get_asdf_config_value "plugin_repository_last_check_duration")"
+
   if [ "never" == "$plugin_repository_last_check_duration" ]; then
-    ! [ "never" == "$plugin_repository_last_check_duration" ]
+    sync_required=""
   else
-    local find_result
-    find_result=$(find "$update_file_dir" -name "$update_file_name" -type f -mmin +"${plugin_repository_last_check_duration:-60}" -print)
-    [ -n "$find_result" ]
+    local update_file_dir
+    local update_file_name
+    update_file_dir="$(asdf_data_dir)/tmp"
+    update_file_name="repo-updated"
+    # `find` outputs filename if it has not been modified in plugin_repository_last_check_duration setting.
+    sync_required=$(find "$update_file_dir" -name "$update_file_name" -type f -mmin +"${plugin_repository_last_check_duration:-60}" -print)
   fi
+
+  [ -n "$sync_required" ]
 }
 
 initialize_or_update_repository() {

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -379,6 +379,9 @@ get_asdf_config_value() {
     get_asdf_config_value_from_file "$default_config_path" "$key"
 }
 
+# Whether the plugin shortname repo needs to be synced
+# 0: if sync needs to occur
+# 1: if no sync needs to occur
 repository_needs_update() {
   local update_file_dir
   update_file_dir="$(asdf_data_dir)/tmp"
@@ -387,9 +390,13 @@ repository_needs_update() {
   # `find` outputs filename if it has not been modified in plugin_repository_last_check_duration setting.
   local plugin_repository_last_check_duration
   plugin_repository_last_check_duration="$(get_asdf_config_value "plugin_repository_last_check_duration")"
-  local find_result
-  find_result=$(find "$update_file_dir" -name "$update_file_name" -type f -mmin +"${plugin_repository_last_check_duration:-60}" -print)
-  [ -n "$find_result" ]
+  if [ "never" == "$plugin_repository_last_check_duration" ]; then
+    ! [ "never" == "$plugin_repository_last_check_duration" ]
+  else
+    local find_result
+    find_result=$(find "$update_file_dir" -name "$update_file_name" -type f -mmin +"${plugin_repository_last_check_duration:-60}" -print)
+    [ -n "$find_result" ]
+  fi
 }
 
 initialize_or_update_repository() {

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -380,17 +380,15 @@ get_asdf_config_value() {
 }
 
 # Whether the plugin shortname repo needs to be synced
-# 0: if sync needs to occur
-# 1: if no sync needs to occur
+# 0: if no sync needs to occur
+# 1: if sync needs to occur
 repository_needs_update() {
   local plugin_repository_last_check_duration
   local sync_required
 
   plugin_repository_last_check_duration="$(get_asdf_config_value "plugin_repository_last_check_duration")"
 
-  if [ "never" == "$plugin_repository_last_check_duration" ]; then
-    sync_required=""
-  else
+  if [ "never" != "$plugin_repository_last_check_duration" ]; then
     local update_file_dir
     local update_file_name
     update_file_dir="$(asdf_data_dir)/tmp"
@@ -399,7 +397,7 @@ repository_needs_update() {
     sync_required=$(find "$update_file_dir" -name "$update_file_name" -type f -mmin +"${plugin_repository_last_check_duration:-60}" -print)
   fi
 
-  [ -n "$sync_required" ]
+  [ "$sync_required" ]
 }
 
 initialize_or_update_repository() {

--- a/test/plugin_list_all_command.bats
+++ b/test/plugin_list_all_command.bats
@@ -38,6 +38,22 @@ foo                           http://example.com/foo"
   [ "$output" = "$expected" ]
 }
 
+@test "plugin_list_all skips repo sync because check_duration is set to never" {
+  echo 'plugin_repository_last_check_duration = never' > $HOME/.asdfrc
+  run asdf plugin-list-all
+  local expected="\
+bar                           http://example.com/bar
+dummy                        *http://example.com/dummy
+foo                           http://example.com/foo"
+
+  printf "%s\n" "status: $status"
+  printf "%s\n" "--------------------------------------------"
+  printf "%s\n" "output: $output"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
+}
+
 @test "plugin_list_all list all plugins in the repository" {
   run asdf plugin-list-all
   local expected="\

--- a/test/plugin_list_all_command.bats
+++ b/test/plugin_list_all_command.bats
@@ -46,10 +46,6 @@ bar                           http://example.com/bar
 dummy                        *http://example.com/dummy
 foo                           http://example.com/foo"
 
-  printf "%s\n" "status: $status"
-  printf "%s\n" "--------------------------------------------"
-  printf "%s\n" "output: $output"
-
   [ "$status" -eq 0 ]
   [ "$output" = "$expected" ]
 }
@@ -60,6 +56,7 @@ foo                           http://example.com/foo"
 bar                           http://example.com/bar
 dummy                        *http://example.com/dummy
 foo                           http://example.com/foo"
+
   [ "$status" -eq 0 ]
   [ "$output" = "$expected" ]
 }


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

This builds on #957 by allowing the plugin shortname repo sync to be toggled off completely with:

```
# $HOME/.asdfrc
plugin_repository_last_check_duration = never
```

Fixes: #978 

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->

<details>
<summary>Docs changes comparison</summary>

![image](https://user-images.githubusercontent.com/20798510/126918996-5dad561d-5a19-4498-91fe-05a46654e6b6.png)

</details>