### PR TITLE
feat: display plugin repo refs alongside urls in info cmd

### DIFF
--- a/lib/commands/command-info.bash
+++ b/lib/commands/command-info.bash
@@ -5,7 +5,7 @@ info_command() {
   printf "%s:\\n%s\\n\\n" "SHELL" "$($SHELL --version)"
   printf "%s:\\n%s\\n\\n" "ASDF VERSION" "$(asdf_version)"
   printf "%s:\\n%s\\n\\n" "ASDF ENVIRONMENT VARIABLES" "$(env | grep -E "ASDF_DIR|ASDF_DATA_DIR|ASDF_CONFIG_FILE|ASDF_DEFAULT_TOOL_VERSIONS_FILENAME")"
-  printf "%s:\\n%s\\n\\n" "ASDF INSTALLED PLUGINS" "$(asdf plugin list --urls)"
+  printf "%s:\\n%s\\n\\n" "ASDF INSTALLED PLUGINS" "$(asdf plugin list --urls --refs)"
 }
 
 info_command "$@"


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

`asdf plugin list --refs --urls` in `asdf info` command output

Fixes: #945 