### PR TITLE
docs: Update the link to the Plugin Shortname Index

### DIFF
--- a/docs/manage/plugins.md
+++ b/docs/manage/plugins.md
@@ -46,7 +46,7 @@ asdf plugin list --urls
 asdf plugin list all
 ```
 
-See [Plugins Shortname Index](https://github.com/asdf-vm/asdf-plugin-template) for the entire short-name list of plugins.
+See [Plugins Shortname Index](https://github.com/asdf-vm/asdf-plugins#plugin-list) for the entire short-name list of plugins.
 
 ## Update
 

--- a/docs/manage/plugins.md
+++ b/docs/manage/plugins.md
@@ -46,7 +46,7 @@ asdf plugin list --urls
 asdf plugin list all
 ```
 
-See [Plugins Shortname Index](https://github.com/asdf-vm/asdf-plugins#plugin-list) for the entire short-name list of plugins.
+See [Plugins Shortname Index](https://github.com/asdf-vm/asdf-plugins) for the entire short-name list of plugins.
 
 ## Update
 


### PR DESCRIPTION
The previous link was to a plugin template. Updated to point to a list of plugins. (I think this is the right place?)