### PR TITLE
feat: Displays a warning when a plugin from the tools-version list does not exist

### DIFF
--- a/lib/commands/command-install.bash
+++ b/lib/commands/command-install.bash
@@ -71,6 +71,7 @@ install_local_tool_versions() {
   search_path=$(pwd)
 
   local some_tools_installed
+  local some_plugin_not_installed
 
   local tool_versions_path
   tool_versions_path=$(find_tool_versions)
@@ -96,10 +97,15 @@ install_local_tool_versions() {
   if [ -f "$tool_versions_path" ]; then
     tools_file=$(strip_tool_version_comments "$tool_versions_path" | cut -d ' ' -f 1)
     for plugin_name in $tools_file; do
-      if [[ ! "${plugins_installed[*]}" =~ $plugin_name ]]; then
+      if ! printf '%s\n' "${plugins_installed[@]}" | grep -P -q "^$plugin_name\$"; then
         printf "%s plugin is not installed\n" "$plugin_name"
+        some_plugin_not_installed='yes'
       fi
     done
+  fi
+
+  if [ -n "$some_plugin_not_installed" ]; then
+    exit 1
   fi
 
   if [ -n "$plugins_installed" ]; then

--- a/lib/commands/command-install.bash
+++ b/lib/commands/command-install.bash
@@ -75,12 +75,6 @@ install_local_tool_versions() {
   local tool_versions_path
   tool_versions_path=$(find_tool_versions)
 
-  # Locate all the plugins defined in the versions file.
-  local tools_file
-  if [ -f "$tool_versions_path" ]; then
-    tools_file=$(strip_tool_version_comments "$tool_versions_path" | cut -d ' ' -f 1)
-  fi
-
   # Locate all the plugins installed in the system
   local plugins_installed
   if ls "$plugins_path" &>/dev/null; then
@@ -97,13 +91,19 @@ install_local_tool_versions() {
     exit 1
   fi
 
-  if [ -n "$tools_file" ]; then
+  # Locate all the plugins defined in the versions file.
+  local tools_file
+  if [ -f "$tool_versions_path" ]; then
+    tools_file=$(strip_tool_version_comments "$tool_versions_path" | cut -d ' ' -f 1)
     for plugin_name in $tools_file; do
       if [[ ! "${plugins_installed[*]}" =~ $plugin_name ]]; then
         printf "%s plugin is not installed\n" "$plugin_name"
-        continue
       fi
+    done
+  fi
 
+  if [ -n "$plugins_installed" ]; then
+    for plugin_name in $plugins_installed; do
       local plugin_version_and_path
       plugin_version_and_path="$(find_versions "$plugin_name" "$search_path")"
 

--- a/lib/commands/command-install.bash
+++ b/lib/commands/command-install.bash
@@ -97,7 +97,7 @@ install_local_tool_versions() {
   if [ -f "$tool_versions_path" ]; then
     tools_file=$(strip_tool_version_comments "$tool_versions_path" | cut -d ' ' -f 1)
     for plugin_name in $tools_file; do
-      if ! printf '%s\n' "${plugins_installed[@]}" | grep -P -q "^$plugin_name\$"; then
+      if ! printf '%s\n' "${plugins_installed[@]}" | grep -q "^$plugin_name\$"; then
         printf "%s plugin is not installed\n" "$plugin_name"
         some_plugin_not_installed='yes'
       fi

--- a/lib/commands/command-install.bash
+++ b/lib/commands/command-install.bash
@@ -89,13 +89,13 @@ install_local_tool_versions() {
       plugin_name=$(basename "$plugin_path")
       plugins_installed="$plugins_installed $plugin_name"
     done
-    plugins_installed=$(echo "$plugins_installed" | tr " " "\n")
+    plugins_installed=$(printf "%s" "$plugins_installed" | tr " " "\n")
   fi
 
   # Combine both lists into one
   local tools
   tools="${tools_file[*]} ${plugins_installed[*]}"
-  tools=$(echo "$tools" | sort | uniq)
+  tools=$(printf "%s" "$tools" | sort | uniq)
 
   if [ -n "$tools" ]; then
     for plugin_name in $tools; do

--- a/lib/commands/command-install.bash
+++ b/lib/commands/command-install.bash
@@ -92,13 +92,18 @@ install_local_tool_versions() {
     plugins_installed=$(printf "%s" "$plugins_installed" | tr " " "\n")
   fi
 
-  # Combine both lists into one
-  local tools
-  tools="${tools_file[*]} ${plugins_installed[*]}"
-  tools=$(printf "%s" "$tools" | sort | uniq)
+  if [ -z "$plugins_installed" ]; then
+    printf "Install plugins first to be able to install tools\\n"
+    exit 1
+  fi
 
-  if [ -n "$tools" ]; then
-    for plugin_name in $tools; do
+  if [ -n "$tools_file" ]; then
+    for plugin_name in $tools_file; do
+      if [[ ! "${plugins_installed[*]}" =~ $plugin_name ]]; then
+        printf "%s plugin is not installed\n" "$plugin_name"
+        continue
+      fi
+
       local plugin_version_and_path
       plugin_version_and_path="$(find_versions "$plugin_name" "$search_path")"
 
@@ -111,9 +116,6 @@ install_local_tool_versions() {
         done
       fi
     done
-  else
-    printf "Install plugins first to be able to install tools\\n"
-    exit 1
   fi
 
   if [ -z "$some_tools_installed" ]; then

--- a/lib/commands/command-install.bash
+++ b/lib/commands/command-install.bash
@@ -95,7 +95,7 @@ install_local_tool_versions() {
   # Combine both lists into one
   local tools
   tools="${tools_file[*]} ${plugins_installed[*]}"
-  tools=$(echo $tools | sort | uniq)
+  tools=$(echo "$tools" | sort | uniq)
 
   if [ -n "$tools" ]; then
     for plugin_name in $tools; do

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -133,6 +133,24 @@ teardown() {
   [ ! -f $ASDF_DIR/installs/dummy/1.1.0/version ]
 }
 
+@test "install_command fails if the plugin is not installed" {
+  cd $PROJECT_DIR
+  echo 'other_dummy 1.0.0' > $PROJECT_DIR/.tool-versions
+
+  run asdf install
+  [ "$status" -eq 1 ]
+  [ "$output" =  "other_dummy plugin is not installed" ]
+}
+
+@test "install_command fails if the plugin is not installed without collisions" {
+  cd $PROJECT_DIR
+  printf "dummy 1.0.0\ndum 1.0.0" > $PROJECT_DIR/.tool-versions
+
+  run asdf install
+  [ "$status" -eq 1 ]
+  [ "$output" =  "dum plugin is not installed" ]
+}
+
 @test "install_command fails when tool is specified but no version of the tool is configured in config file" {
   echo 'dummy 1.0.0' > $PROJECT_DIR/.tool-versions
   run asdf install other-dummy


### PR DESCRIPTION
# Summary

When calling the install command, asdf tries to look for versions for all the plugins available and installs them. With this change, it will attempt to find versions for all the installed plugins and plugins defined in the `.tool-versions`.

## Other Information

Fixes https://github.com/asdf-vm/asdf/issues/574