### PR TITLE
fix: incorrect usage of grep

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -681,7 +681,7 @@ select_from_preset_version() {
   shim_versions=$(get_shim_versions "$shim_name")
   if [ -n "$shim_versions" ]; then
     preset_versions=$(preset_versions "$shim_name")
-    grep -f "$shim_versions" "$preset_versions" | head -n 1 | xargs -IVERSION printf "%s\\n" VERSION
+    grep -F "$shim_versions" <<<"$preset_versions" | head -n 1 | xargs -IVERSION printf "%s\\n" VERSION
   fi
 }
 


### PR DESCRIPTION
# Summary
Message displayed when executing a command that does not specify a version, and the error message is output at the same time because of incorrect usage of grep.

Extract from macOS man:
> -F, --fixed-strings
>        Interpret pattern as a set of fixed strings (i.e. force grep to behave as fgrep).
> -f file, --file=file
>        Read one or more newline separated patterns from file.  Empty pattern lines match every input line.  Newlines are not considered part of a pattern.  If file is empty, nothing is matched.

Expected:
```shellscript
> go
No version set for command go
Consider adding one of the following versions in your config file at 
go-sdk 1.17
```

Actual(in head branch):
```shellscript
> go
grep: go-sdk 1.17
go-sdk system: No such file or directory
No version set for command go
Consider adding one of the following versions in your config file at 
go-sdk 1.17
```
<!-- Provide a general description of the code changes in your pull request. -->

