### PR TITLE
fix: wait until the plugin update are finished

### DIFF
--- a/lib/commands/command-plugin-update.bash
+++ b/lib/commands/command-plugin-update.bash
@@ -8,12 +8,14 @@ plugin_update_command() {
 
   local plugin_name="$1"
   local gitref="${2}"
+  local plugins=
 
   if [ "$plugin_name" = "--all" ]; then
     if [ -d "$(asdf_data_dir)"/plugins ]; then
-      find "$(asdf_data_dir)"/plugins -mindepth 1 -maxdepth 1 -type d | while IFS= read -r dir; do
+      plugins=$(find "$(asdf_data_dir)"/plugins -mindepth 1 -maxdepth 1 -type d)
+      while IFS= read -r dir; do
         update_plugin "$(basename "$dir")" "$dir" "$gitref" &
-      done
+      done <<<"$plugins"
       wait
     fi
   else

--- a/test/plugin_update_command.bats
+++ b/test/plugin_update_command.bats
@@ -112,3 +112,10 @@ teardown() {
   [ "$status" -eq 0 ]
   [ -f $ASDF_DIR/shims/dummy ]
 }
+
+@test "asdf plugin-update done for all plugins" {
+  local command="asdf plugin-update --all"
+  # Count the number of update processes remaining after the update command is completed.
+  run bash -c "${command} >/dev/null && ps -o 'ppid,args' | awk '{if(\$1==1 && \$0 ~ /${command}/ ) print}' | wc -l"
+  [[ 0 -eq "$output" ]]
+}


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

In `asdf plugin update --all`, `wait` is not working and the command exits before the update of each plugin are finished.

Executing `while` after a pipe will run it in a subshell, so you can't use `wait` on the caller to wait for each command to finish.

In such a case, *Process Substitution* is often used, but it seems to be prohibited in this project.
However, for the usage here, I think *Here string* is fine.