### PR TITLE
fix: sed re error trailing backslash on FreeBSD (#1046).

### DIFF
--- a/lib/commands/command-latest.bash
+++ b/lib/commands/command-latest.bash
@@ -25,7 +25,7 @@ latest_command() {
     # pattern from xxenv-latest (https://github.com/momo-lab/xxenv-latest)
     versions=$(asdf list-all "$plugin_name" "$query" |
       grep -vE "(^Available versions:|-src|-dev|-latest|-stm|[-\\.]rc|-alpha|-beta|[-\\.]pre|-next|(a|b|c)[0-9]+|snapshot|master)" |
-      sed 's/^\s\+//' |
+      sed 's/^[[:space:]]\+//' |
       tail -1)
     if [ -z "${versions}" ]; then
       exit 1


### PR DESCRIPTION
# Summary

This fixes the following error with sed on FreeBSD:

```
sed: 1: "s/^\s\+//": RE error: trailing backslash (\)
```

Fixes: #1046

## Other Information

I confirmed the command still works as expected on Linux and macOS.
