### PR TITLE
fix: help for extension commands for plugins with hyphens in the name.

### DIFF
--- a/lib/commands/command-help.bash
+++ b/lib/commands/command-help.bash
@@ -14,18 +14,23 @@ EOF
 }
 
 asdf_extension_cmds() {
-  local plugins_path ext_cmds plugin
+  local plugins_path ext_cmd_path ext_cmds plugin
   plugins_path="$(get_plugin_path)"
   # use find instead of ls -1
   # shellcheck disable=SC2012
-  ext_cmds="$(ls -1 "$plugins_path"/*/lib/commands/command*.bash 2>/dev/null |
-    sed "s#^$plugins_path/##;s#lib/commands/command##;s/.bash//;s/^-//;s/-/ /g")"
-  if test -n "$ext_cmds"; then
-    cut -d'/' -f 1 <<<"$ext_cmds" | uniq | while read -r plugin; do
+  for plugin in $(ls -1 "$plugins_path" 2>/dev/null | sed "s#^$plugins_path/##"); do
+    ext_cmd_path="$plugins_path/$plugin/lib/commands"
+    ext_cmds=$(
+      ls -1 "$ext_cmd_path"/command*.bash 2>/dev/null |
+        sed "s#$ext_cmd_path/##"
+    )
+    if [[ -n $ext_cmds ]]; then
       printf "\\nPLUGIN %s\\n" "$plugin"
-      grep "$plugin/" <<<"$ext_cmds" | sed "s#^$plugin/#  asdf $plugin#" | sort
-    done
-  fi
+      for ext_cmd in $ext_cmds; do
+        sed "s/-/ /g;s/.bash//;s/command-*/  asdf $plugin/;" <<<"$ext_cmd"
+      done | sort
+    fi
+  done
 }
 
 help_command() {

--- a/test/plugin_extension_command.bats
+++ b/test/plugin_extension_command.bats
@@ -28,6 +28,28 @@ teardown() {
   echo "$output" | grep "asdf dummy foo bar" # should present commands without hipens
 }
 
+@test "asdf help shows extension commands for plugin with hyphens in the name" {
+  cd $PROJECT_DIR
+
+  plugin_name=dummy-hyphenated
+  install_mock_plugin $plugin_name
+
+  plugin_path="$(get_plugin_path $plugin_name)"
+  mkdir -p "$plugin_path/lib/commands"
+  touch "$plugin_path/lib/commands/command.bash"
+  touch "$plugin_path/lib/commands/command-foo.bash"
+  touch "$plugin_path/lib/commands/command-foo-bar.bash"
+
+  run asdf help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PLUGIN $plugin_name"* ]]
+  # shellcheck disable=SC2154
+  listed_cmds=$(grep -c "asdf $plugin_name" <<<"${output}")
+  [[ $listed_cmds -eq 3 ]]
+  [[ "$output" == *"asdf $plugin_name foo"* ]]
+  [[ "$output" == *"asdf $plugin_name foo bar"* ]]
+}
+
 @test "asdf can execute plugin bin commands" {
   plugin_path="$(get_plugin_path dummy)"
 


### PR DESCRIPTION
# Summary
When a plugin with a hyphen in its name contains an extension command (lib/commands/commands-*), the - in the plugin name displayed by asdf help will be blank.

Fixes: #1034

