### PR TITLE
feat: add post update plugin support

### DIFF
--- a/docs/plugins/create.md
+++ b/docs/plugins/create.md
@@ -138,7 +138,7 @@ See also the related hooks:
 
 #### bin/post-plugin-update
 
-This can be used to run any post-plugin-update actions after the plugin has been updated to asdf.
+This can be used to run any post-plugin-update actions after asdf has downloaded the updated plugin
 
 The script has access to the path the plugin was installed (`${ASDF_PLUGIN_PATH}`), previous git-ref (`${ASDF_PLUGIN_PREV_REF}`), and updated git-ref (`${ASDF_PLUGIN_POST_REF}`).
 

--- a/docs/plugins/create.md
+++ b/docs/plugins/create.md
@@ -136,6 +136,19 @@ See also the related hooks:
 - `post_asdf_plugin_add`
 - `post_asdf_plugin_add_${plugin_name}`
 
+#### bin/post-plugin-update
+
+This can be used to run any post-plugin-update actions after the plugin has been updated to asdf.
+
+The script has access to the path the plugin was installed (`${ASDF_PLUGIN_PATH}`), previous git-ref (`${ASDF_PLUGIN_PREV_REF}`), and updated git-ref (`${ASDF_PLUGIN_POST_REF}`).
+
+See also the related hooks:
+
+- `pre_asdf_plugin_updated`
+- `pre_asdf_plugin_updated_${plugin_name}`
+- `post_asdf_plugin_updated`
+- `post_asdf_plugin_updated_${plugin_name}`
+
 #### bin/pre-plugin-remove
 
 This can be used to run any pre-removal actions before the plugin will be removed from asdf.

--- a/test/fixtures/dummy_plugin/bin/post-plugin-update
+++ b/test/fixtures/dummy_plugin/bin/post-plugin-update
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "plugin updated path=${ASDF_PLUGIN_PATH} old git-ref=${ASDF_PLUGIN_PREV_REF} new git-ref=${ASDF_PLUGIN_POST_REF}"


### PR DESCRIPTION
# Summary

Currently, asdf does not have a hook that is called when a plugin is updated, so it is not possible for plugins to perform migrations.

For example, if a plugin has a problem and needs to be fixed under "installs", the only way to do this is to have the user do it after installation.

With the post-install-hook, it will be possible to migrate when updating, which will make it easier to develop plug-ins and improve the usability for users.

## Other Information

This may also answer the request of #859 .
