### PR TITLE
docs: fix brew upgrade from latest commit on master command

### DIFF
--- a/docs/manage/core.md
+++ b/docs/manage/core.md
@@ -71,7 +71,7 @@ nodejs 16.5.0
 | Method         | Latest Stable Release                                                                                                          | Latest commit on `master`  |
 | -------------- | ------------------------------------------------------------------------------------------------------------------------------ | -------------------------- |
 | asdf (via Git) | `asdf update`                                                                                                                  | `asdf update --head`       |
-| Homebrew       | `brew upgrade asdf`                                                                                                            | `brew upgrade asdf --HEAD` |
+| Homebrew       | `brew upgrade asdf`                                                                                                            | `brew upgrade asdf --fetch-HEAD` |
 | Pacman         | Download a new `PKGBUILD` & rebuild <br/> or use your preferred [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers) |                            |
 
 ## Uninstall

--- a/docs/pt-br/manage/core.md
+++ b/docs/pt-br/manage/core.md
@@ -73,7 +73,7 @@ nodejs 16.5.0
 | Method         | Latest Stable Release                                                                                                                          | Latest commit on `master`  |
 | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- |
 | asdf (via Git) | `asdf update`                                                                                                                                  | `asdf update --head`       |
-| Homebrew       | `brew upgrade asdf`                                                                                                                            | `brew upgrade asdf --HEAD` |
+| Homebrew       | `brew upgrade asdf`                                                                                                                            | `brew upgrade asdf --fetch-HEAD` |
 | Pacman         | Obter manualmente um novo `PKGBUILD` e <br/> reconstruir ou usar suas preferências de [AUR](https://wiki.archlinux.org/index.php/AUR_helpers). |                            |
 
 ## Desinstalar


### PR DESCRIPTION
# Summary

Currently, the brew upgrade from latest commit on master command is specified like `brew upgrade asdf --HEAD`, which is incorrect, failing with 

`Error: invalid option: --HEAD`.

The correct option is [--fetch-HEAD](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/cmd/upgrade.rb#L57)

Fixes: display the correct command:

`brew upgrade asdf --fetch-HEAD`
