### PR TITLE
docs: Remove stray `a`

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -294,7 +294,7 @@ See the [configuration](/manage/configuration.md) reference page for more config
 
 That completes the Getting Started guide for `asdf` :tada: You can now manage `nodejs` versions for your project. Follow similar steps for each type of tool in your project!
 
-`asdf` has a many more commands to become familiar with, you can see them all by running `asdf --help` or `asdf`. The core of the commands are broken into three categories:
+`asdf` has many more commands to become familiar with, you can see them all by running `asdf --help` or `asdf`. The core of the commands are broken into three categories:
 
 - [core `asdf`](/manage/core.md)
 - [plugins](/manage/plugins.md)


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

Corrects minor grammar error in docs.