### PR TITLE
fix: don't generate on error if backup file doesn't exists

### DIFF
--- a/lib/commands/command-reshim.bash
+++ b/lib/commands/command-reshim.bash
@@ -70,7 +70,7 @@ write_shim_script() {
   if [ -f "$shim_path" ]; then
     if ! grep -x "# asdf-plugin: ${plugin_name} ${version}" "$shim_path" >/dev/null; then
       sed -i.bak -e "s/exec /# asdf-plugin: ${plugin_name} ${version}\\"$'\n''exec /' "$shim_path"
-      rm "$shim_path".bak
+      rm -f "$shim_path".bak
     fi
   else
     cat <<EOF >"$shim_path"

--- a/lib/commands/reshim.bash
+++ b/lib/commands/reshim.bash
@@ -20,6 +20,6 @@ remove_shim_for_version() {
 
   if ! grep "# asdf-plugin:" "$shim_path" >/dev/null ||
     [ "$count_installed" -eq 0 ]; then
-    rm "$shim_path"
+    rm -f "$shim_path"
   fi
 }

--- a/lib/commands/version_commands.bash
+++ b/lib/commands/version_commands.bash
@@ -60,7 +60,7 @@ version_command() {
 
   if [ -f "$file" ] && grep "^$plugin_name " "$file" >/dev/null; then
     sed -i.bak -e "s|^$plugin_name .*$|$plugin_name ${resolved_versions[*]}|" "$file"
-    rm "$file".bak
+    rm -f "$file".bak
   else
     printf "%s %s\\n" "$plugin_name" "${resolved_versions[*]}" >>"$file"
   fi


### PR DESCRIPTION
Signed-off-by: JrCs <90z7oey02@sneakemail.com>

# Summary

If the replacement (sed) is not done the backup file isn't create and the rm command return on error.  
With `rm -f` no error is generated even if the file doesn't exists.
