### PR TITLE
'asdf current --as-tool-versions' outputs a format suitable for export to `.tool-versions`

### DIFF
--- a/lib/commands/command-current.bash
+++ b/lib/commands/command-current.bash
@@ -32,10 +32,10 @@ plugin_current_command() {
     printf "$terminal_format" "$plugin" "$version" "$description" 1>&2
     return 1
   elif [ -z "$full_version" ]; then
-    if [ "$tool_versions" == "false" ]; then 
-        description="No version set. Run \"asdf <global|shell|local> $plugin <version>\""
-        printf "$terminal_format" "$plugin" "______" "$description" 1>&2
-        return 126
+    if [ "$tool_versions" == "false" ]; then
+      description="No version set. Run \"asdf <global|shell|local> $plugin <version>\""
+      printf "$terminal_format" "$plugin" "______" "$description" 1>&2
+      return 126
     fi
   else
     description="$version_file_path"

--- a/test/current_command.bats
+++ b/test/current_command.bats
@@ -143,3 +143,36 @@ foobar          1.0.0           $PROJECT_DIR/.tool-versions"
   [ "$status" -eq 0 ]
   [ "$output" = "$expected" ]
 }
+
+@test "should be able to output the equivalent of a .tool-versions" {
+  install_dummy_plugin
+  install_dummy_version "1.1.0"
+
+  install_mock_plugin "y"
+  install_mock_plugin_version "y" "2.1.0"
+
+  cd $PROJECT_DIR
+  echo 'dummy 1.1.0' >> $PROJECT_DIR/.tool-versions
+  echo 'y 2.1.0' >> $PROJECT_DIR/.tool-versions
+
+  run asdf current --as-tool-versions
+  [ "$status" -eq 0 ]
+  echo "$output" | grep '^dummy 1.1.0$'
+  echo "$output" | grep '^y 2.1.0$'
+}
+
+@test "should be able to output the equivalent of a .tool-versions for a single tool" {
+  install_dummy_plugin
+  install_dummy_version "1.1.0"
+
+  install_mock_plugin "y"
+  install_mock_plugin_version "y" "2.1.0"
+
+  cd $PROJECT_DIR
+  echo 'dummy 1.1.0' >> $PROJECT_DIR/.tool-versions
+  echo 'y 2.1.0' >> $PROJECT_DIR/.tool-versions
+
+  run asdf current --as-tool-versions y
+  [ "$status" -eq 0 ]
+  [ "$output" = "y 2.1.0" ]
+}


### PR DESCRIPTION
# Summary

Add in an option for `asdf current` that outputs a format compatible to use as a `.tool-versions` file.  This is useful for replicating a local configuration across one or more configuration files to be used by another host/environment and also outputs more controlled formats for other tools that may want to query what is currently active.