### PR TITLE
fix: Adds "grep -P" to the list of banned commands

### DIFF
--- a/test/banned_commands.bats
+++ b/test/banned_commands.bats
@@ -27,7 +27,7 @@ banned_commands=(
     "sort.*--sort-versions"
     # source isn't POSIX compliant. . behaves the same and is POSIX compliant
     source
- )
+)
 
 setup() {
   setup_asdf_dir


### PR DESCRIPTION
# Summary

As explained in #1062 #1033, `-P` is an option that does not exist in
OSX and causes problems of compatibility.

Fixes:  #1062 