### PR TITLE
fix: Quote commands correctly in plugin-test

### DIFF
--- a/lib/commands/command-plugin-test.bash
+++ b/lib/commands/command-plugin-test.bash
@@ -11,32 +11,32 @@ plugin_test_command() {
   local interpret_args_literally
 
   for arg; do
-      shift
-      if [ -n "${interpret_args_literally}" ]; then
-          set -- "$@" "${arg}"
-      else
-          case "${arg}" in
-              --asdf-plugin-gitref)
-                  plugin_gitref="$2"
-                  shift 2
-                  ;;
-              --asdf-tool-version)
-                  tool_version="$2"
-                  shift 2
-                  ;;
-              --)
-                  interpret_args_literally=true
-                  shift
-                  ;;
-              *)
-                  set -- "$@" "${arg}"
-                  ;;
-          esac
-      fi
+    shift
+    if [ -n "${interpret_args_literally}" ]; then
+      set -- "$@" "${arg}"
+    else
+      case "${arg}" in
+      --asdf-plugin-gitref)
+        plugin_gitref="$2"
+        shift 2
+        ;;
+      --asdf-tool-version)
+        tool_version="$2"
+        shift 2
+        ;;
+      --)
+        interpret_args_literally=true
+        shift
+        ;;
+      *)
+        set -- "$@" "${arg}"
+        ;;
+      esac
+    fi
   done
 
   if [ "$#" -eq 1 ]; then
-      set -- "${SHELL:-sh}" -c "$1"
+    set -- "${SHELL:-sh}" -c "$1"
   fi
 
   local exit_code

--- a/lib/commands/command-plugin-test.bash
+++ b/lib/commands/command-plugin-test.bash
@@ -36,7 +36,7 @@ plugin_test_command() {
   done
 
   if [ "$#" -eq 1 ]; then
-      set -- sh -c "$@"
+      set -- "${SHELL:-sh}" -c "$@"
   fi
 
   local exit_code

--- a/lib/commands/command-plugin-test.bash
+++ b/lib/commands/command-plugin-test.bash
@@ -23,13 +23,13 @@ plugin_test_command() {
       ;;
     *)
       plugin_command+=("$1") # save it in an array for later
-      shift                        # past argument
+      shift                  # past argument
       ;;
     esac
   done
 
   if [ "${#plugin_command[@]}" -eq 1 ]; then
-      plugin_command=(sh -c "${plugin_command[@]}")
+    plugin_command=(sh -c "${plugin_command[@]}")
   fi
 
   local exit_code
@@ -128,11 +128,11 @@ plugin_test_command() {
       fail_test "could not reshim plugin"
     fi
 
-    if [ -n "$plugin_command" ]; then
+    if [ "${#plugin_command[@]}" -gt 0 ]; then
       "${plugin_command[@]}"
       exit_code=$?
       if [ $exit_code != 0 ]; then
-        fail_test "$plugin_command[*] failed with exit code $?"
+        fail_test "${plugin_command[*]} failed with exit code $?"
       fi
     fi
 

--- a/lib/commands/command-plugin-test.bash
+++ b/lib/commands/command-plugin-test.bash
@@ -36,7 +36,7 @@ plugin_test_command() {
   done
 
   if [ "$#" -eq 1 ]; then
-      set -- "${SHELL:-sh}" -c "$@"
+      set -- "${SHELL:-sh}" -c "$1"
   fi
 
   local exit_code

--- a/lib/commands/command-plugin-test.bash
+++ b/lib/commands/command-plugin-test.bash
@@ -43,7 +43,7 @@ plugin_test_command() {
   local TEST_DIR
 
   fail_test() {
-    printf "FAILED: %s\\n" "$*"
+    printf "FAILED: %s\\n" "$1"
     rm -rf "$TEST_DIR"
     exit 1
   }

--- a/lib/commands/command-plugin-test.bash
+++ b/lib/commands/command-plugin-test.bash
@@ -4,12 +4,10 @@ plugin_test_command() {
 
   local plugin_name=$1
   local plugin_url=$2
-  local plugin_command_array=()
-  local plugin_command
+  local plugin_command=()
   local plugin_gitref="master"
   local tool_version
-  # shellcheck disable=SC2086
-  set -- ${*:3}
+  shift 2
 
   while [[ $# -gt 0 ]]; do
     case $1 in
@@ -24,13 +22,15 @@ plugin_test_command() {
       shift # past value
       ;;
     *)
-      plugin_command_array+=("$1") # save it in an array for later
+      plugin_command+=("$1") # save it in an array for later
       shift                        # past argument
       ;;
     esac
   done
 
-  plugin_command="${plugin_command_array[*]}"
+  if [ "${#plugin_command[@]}" -eq 1 ]; then
+      plugin_command=(sh -c "${plugin_command[@]}")
+  fi
 
   local exit_code
   local TEST_DIR
@@ -129,10 +129,10 @@ plugin_test_command() {
     fi
 
     if [ -n "$plugin_command" ]; then
-      $plugin_command
+      "${plugin_command[@]}"
       exit_code=$?
       if [ $exit_code != 0 ]; then
-        fail_test "$plugin_command failed with exit code $?"
+        fail_test "$plugin_command[*] failed with exit code $?"
       fi
     fi
 


### PR DESCRIPTION
# Summary

Quote variables correctly in `command-plugin-test.bash`, eliminating bizarre results when trying to run commands with whitespace in them.

## Other Information

Before:

```
% asdf plugin-test bundler https://github.com/jonathanmorley/asdf-bundler.git 'bundler --version | grep 2.2.29'
Updating bundler...
Already on 'master'
Your branch is up to date with 'origin/master'.
ERROR: "bundler version" was called with arguments ["|", "grep", "2.2.29"]
Usage: "bundler version"
FAILED: bundler --version | grep 2.2.29 failed with exit code 0
```

After:

```
% ./bin/asdf plugin-test bundler https://github.com/jonathanmorley/asdf-bundler.git 'bundler --version | grep 2.2.29'
Updating bundler to master
Already on 'master'
Your branch is up to date with 'origin/master'.
Bundler version 2.2.29
```

The intended behavior was somewhat unclear, but in the new code, if one argument is provided, it is assumed to be a shell command, while if multiple arguments are provided, it is assumed that the first is an executable and the remainder are arguments (so no shell is involved).

The use case that generated this pull request was specifying the following configuration to https://github.com/asdf-vm/actions for https://github.com/jonathanmorley/asdf-bundler/pull/4:

```yaml
      - name: asdf_plugin_test
        uses: asdf-vm/actions/plugin-test@v1
        with:
          command: bundle --version | grep -F "${{ matrix.version }}"
```

Where we see that [the command is passed as a single argument to `asdf plugin-test`](https://github.com/asdf-vm/actions/blob/b797cb8027b273ade6b7701ba2b4ce5fd1d477cb/lib/plugin-test/index.ts#L28), and therefore ought to be interpreted as a shell command, rather than being split on whitespace and then executed without shell interpretation, which is the current behavior (see the bizarre error message above).
