### PR TITLE
docs: Mention comments for `.tool-versions` files

### DIFF
--- a/docs/manage/configuration.md
+++ b/docs/manage/configuration.md
@@ -17,6 +17,14 @@ ruby 2.5.3
 nodejs 10.15.0
 ```
 
+You can also include comments:
+
+```:no-line-numbers
+ruby 2.5.3 # This is a comment
+# This is another comment
+nodejs 10.15.0
+```
+
 The versions can be in the following format:
 
 - `10.15.0` - an actual version. Plugins that support downloading binaries, will download binaries.


### PR DESCRIPTION
Closes #1091

# Summary

This includes a brief mention of, and some simple examples, of comments in `.tool-versions` files.

This fixes issue #1091.
