### PR TITLE
feat(latest): adds the flag --all to the latest command

### DIFF
--- a/test/latest_command.bats
+++ b/test/latest_command.bats
@@ -59,3 +59,12 @@ teardown() {
   [ "$(echo "No compatible versions available (legacy-dummy 3)")" == "$output" ]
   [ "$status" -eq 1 ]
 }
+
+################################
+####      latest --all      ####
+################################
+@test "[latest_command - all plugins] shows the latest stable version of all plugins" {
+  run asdf latest --all
+  [ "$(echo -e "dummy\t2.0.0\tinstalled\nlegacy-dummy\t2.0.0\tinstalled\n")" == "$output" ]
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
# Summary
As discussed in #1036, this patch adds a `--all` flag to the latest command which will show the list of plugins, their latest version and if this one is installed or not.

Fixes: #1036

## Other Information
This patch basically reuses the logic used in the list command and the latest command. The main different is the removal of the query parameter as different plugins might need different queries.