### PR TITLE
feat: Cleanup invalid shims

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -111,7 +111,9 @@ check_if_plugin_exists() {
     exit 1
   fi
 
-  if [ ! -d "$(asdf_data_dir)/plugins/$plugin_name" ]; then
+  # ".." is evaluated to the parent plugins folder, which should not be valid
+  if [ ".." == "${plugin_name}" ] \
+    || [ ! -d "$(asdf_data_dir)/plugins/$plugin_name" ]; then
     display_error "No such plugin: $plugin_name"
     exit 1
   fi


### PR DESCRIPTION
# Summary

Adds a new function `cleanup_invalid_shim_metadata`.

This function looks for references to non-installed plugins for the given plugin, and removes this metadata.

Also, adds a check in `check_if_plugin_exists` that filters out '..' as a plugin name.

Related: #1029
Closes: #1098
