### PR TITLE
fix: sort listing by version number in natural order

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -95,8 +95,7 @@ list_installed_versions() {
   plugin_installs_path="$(asdf_data_dir)/installs/${plugin_name}"
 
   if [ -d "$plugin_installs_path" ]; then
-    for install in "${plugin_installs_path}"/*/; do
-      [[ -e "$install" ]] || break
+    for install in $(ls -1v ${plugin_installs_path}); do
       basename "$install" | sed 's/^ref-/ref:/'
     done
   fi


### PR DESCRIPTION
# Summary

This PR fixes the issue where the installed versions from `asdf list` or `asdf list <plugin` command are not sorted in natural order.

## Other Information

Before:

```bash
$ asdf list elixir
   ...
  1.8.0-otp-20
  1.8.1
  1.8.1-otp-21
  1.8.1-otp-22
  1.8.2
  1.8.2-otp-21
  1.8.2-otp-22
  1.9
  1.9.1
  1.9.1-otp-22
  1.9.2-otp-22
  1.9.4
  1.9.4-otp-22
  master
  master-otp-24
```

After:

```bash
$ asdf list elixir
  ...
  1.12
  1.12.0
  1.12.1
  1.12.1-otp-24
  1.12.3-otp-23
  1.12.3-otp-24
  1.13.0-rc.0-otp-24
  1.13.0-rc.1-otp-24
  master
  master-otp-24
```
