### PR TITLE
fix: do not print `find` errors

### DIFF
--- a/lib/commands/command-help.bash
+++ b/lib/commands/command-help.bash
@@ -19,7 +19,7 @@ asdf_extension_cmds() {
   for plugin_path in "$plugins_path"/*; do
     plugin="$(basename "$plugin_path")"
     ext_cmd_path="$plugin_path/lib/commands"
-    ext_cmds="$(find "$ext_cmd_path" -name "command*.bash")"
+    ext_cmds="$(find "$ext_cmd_path" -name "command*.bash" 2>/dev/null)"
     if [[ -n $ext_cmds ]]; then
       printf "\\nPLUGIN %s\\n" "$plugin"
       for ext_cmd in $ext_cmds; do


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

Do not print errors `find` command produces when no `lib/commands` exists under plugin directories.

Fixes: #1101 

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->

Example output from `asdf help` on the current master branch.

```
...

RESOURCES
GitHub: https://github.com/asdf-vm/asdf
Docs:   https://asdf-vm.com
find: ‘/home/_/.asdf/plugins/deno/lib/commands’: No such file or directory

PLUGIN direnv
  asdf direnv
  asdf direnv hook asdf
find: ‘/home/_/.asdf/plugins/nodejs/lib/commands’: No such file or directory
find: ‘/home/_/.asdf/plugins/python/lib/commands’: No such file or directory
find: ‘/home/_/.asdf/plugins/ruby/lib/commands’: No such file or directory
find: ‘/home/_/.asdf/plugins/terraform/lib/commands’: No such file or directory

"Late but latest"
-- Rajinikanth
```

After applying this fix.

```
...

RESOURCES
GitHub: https://github.com/asdf-vm/asdf
Docs:   https://asdf-vm.com

PLUGIN direnv
  asdf direnv
  asdf direnv hook asdf

"Late but latest"
-- Rajinikanth
```