### PR TITLE
fix: shorthand grep options for alpine support

### DIFF
--- a/lib/commands/command-plugin-add.bash
+++ b/lib/commands/command-plugin-add.bash
@@ -8,7 +8,7 @@ plugin_add_command() {
 
   local plugin_name=$1
 
-  if ! printf "%s" "$plugin_name" | grep --quiet --extended-regexp "^[a-zA-Z0-9_-]+$"; then
+  if ! printf "%s" "$plugin_name" | grep -q -E "^[a-zA-Z0-9_-]+$"; then
     display_error "$plugin_name is invalid. Name must match regex ^[a-zA-Z0-9_-]+$"
     exit 1
   fi

--- a/lib/commands/command-plugin-add.bash
+++ b/lib/commands/command-plugin-add.bash
@@ -8,7 +8,7 @@ plugin_add_command() {
 
   local plugin_name=$1
 
-  if ! printf "%s" "$plugin_name" | grep -qE "^[a-zA-Z0-9_-]+$"; then
+  if ! printf "%s" "$plugin_name" | grep -q -E "^[a-zA-Z0-9_-]+$"; then
     display_error "$plugin_name is invalid. Name must match regex ^[a-zA-Z0-9_-]+$"
     exit 1
   fi

--- a/lib/commands/command-plugin-add.bash
+++ b/lib/commands/command-plugin-add.bash
@@ -8,7 +8,7 @@ plugin_add_command() {
 
   local plugin_name=$1
 
-  if ! printf "%s" "$plugin_name" | grep -q -E "^[a-zA-Z0-9_-]+$"; then
+  if ! printf "%s" "$plugin_name" | grep -qE "^[a-zA-Z0-9_-]+$"; then
     display_error "$plugin_name is invalid. Name must match regex ^[a-zA-Z0-9_-]+$"
     exit 1
   fi


### PR DESCRIPTION
# Summary

The version of grep that is shipped with alpine doesn't seem to support "long name" options

Fixes: List issue numbers here

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->
