### PR TITLE
docs: fix bug report info instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -44,7 +44,7 @@ body:
     id: environment
     attributes:
       label: Environment
-      description: Copy the output of `asdf-info` here
+      description: Copy the output of `asdf info` here
       render: shell
     validations:
       required: true


### PR DESCRIPTION
# Summary

Instructs bug reporters to use correct `asdf info` command.

Fixes: #1105
