### PR TITLE
fix: ban grep long flags

### DIFF
--- a/test/banned_commands.bats
+++ b/test/banned_commands.bats
@@ -14,7 +14,6 @@ banned_commands=(
     # It's best to avoid eval as it makes it easier to accidentally execute
     # arbitrary strings
     eval
-
     # realpath not available by default on OSX.
     realpath
     # readlink on OSX behaves differently from readlink on other Unix systems


### PR DESCRIPTION
Fixes #1109

Rather than just having one array of both literal commands and regex patterns, I split the banned commands into two arrays - one of literal commands and one of regex. This allows us to use the `-E` (extended regex) option when looking for banned commands via regex.