### PR TITLE
fix: latest --all correctly report plugins as missing

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -40,6 +40,8 @@ asdf global <name> latest[:<version>]   Set the package local version to the
 asdf shell <name> <version>             Set the package version to
                                         `ASDF_${LANG}_VERSION` in the current shell
 asdf latest <name> [<version>]          Show latest stable version of a package
+asdf latest --all                       Show latest stable version of all the
+                                        packages and if they are installed
 asdf list <name> [version]              List installed versions of a package and
                                         optionally filter the versions
 asdf list all <name> [<version>]        List all versions of a package and

--- a/lib/commands/command-latest.bash
+++ b/lib/commands/command-latest.bash
@@ -73,7 +73,7 @@ latest_all() {
       local installed_versions
       installed_versions=$(list_installed_versions "$plugin_name")
 
-      if ! printf '%s\n' "$installed_versions" | grep -q "^$version\$"; then
+      if [ -n "$installed_versions" ] && printf '%s\n' "$installed_versions" | grep -q "^$version\$"; then
         installed_status="installed"
       fi
       printf "%s\\t%s\\t%s\\n" "$plugin_name" "$version" "$installed_status"

--- a/test/latest_command.bats
+++ b/test/latest_command.bats
@@ -64,7 +64,16 @@ teardown() {
 ####      latest --all      ####
 ################################
 @test "[latest_command - all plugins] shows the latest stable version of all plugins" {
+  run asdf install dummy 2.0.0
+  run asdf install legacy-dummy 1.0.0
   run asdf latest --all
-  [ "$(echo -e "dummy\t2.0.0\tinstalled\nlegacy-dummy\t2.0.0\tinstalled\n")" == "$output" ]
+  echo "output $output"
+  [ "$(echo -e "dummy\t2.0.0\tinstalled\nlegacy-dummy\t2.0.0\tmissing\n")" == "$output" ]
+  [ "$status" -eq 0 ]
+}
+
+@test "[latest_command - all plugins] not installed plugin should return missing" {
+  run asdf latest --all
+  [ "$(echo -e "dummy\t2.0.0\tmissing\nlegacy-dummy\t2.0.0\tmissing\n")" == "$output" ]
   [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
# Summary

Fixes the bug reported at #1096. Uninstalled plug-ins are now marked as missing. The plug-in will be marked as installed only if the latest version is among the installed plug-ins.

Fixes: #1096
