### PR TITLE
feat: case-insensitive filtering of unstable versions in `latest`

### DIFF
--- a/lib/commands/command-latest.bash
+++ b/lib/commands/command-latest.bash
@@ -28,7 +28,7 @@ latest_command() {
   else
     # pattern from xxenv-latest (https://github.com/momo-lab/xxenv-latest)
     versions=$(asdf list-all "$plugin_name" "$query" |
-      grep -vE "(^Available versions:|-src|-dev|-latest|-stm|[-\\.]rc|-alpha|-beta|[-\\.]pre|-next|(a|b|c)[0-9]+|snapshot|master)" |
+      grep -ivE "(^Available versions:|-src|-dev|-latest|-stm|[-\\.]rc|-alpha|-beta|[-\\.]pre|-next|(a|b|c)[0-9]+|snapshot|master)" |
       sed 's/^[[:space:]]\+//' |
       tail -1)
     if [ -z "${versions}" ]; then
@@ -59,7 +59,7 @@ latest_all() {
       else
         # pattern from xxenv-latest (https://github.com/momo-lab/xxenv-latest)
         version=$(asdf list-all "$plugin_name" |
-          grep -vE "(^Available version:|-src|-dev|-latest|-stm|[-\\.]rc|-alpha|-beta|[-\\.]pre|-next|(a|b|c)[0-9]+|snapshot|master)" |
+          grep -ivE "(^Available version:|-src|-dev|-latest|-stm|[-\\.]rc|-alpha|-beta|[-\\.]pre|-next|(a|b|c)[0-9]+|snapshot|master)" |
           sed 's/^[[:space:]]\+//' |
           tail -1)
         if [ -z "${version}" ]; then

--- a/test/fixtures/dummy_legacy_plugin/bin/list-all
+++ b/test/fixtures/dummy_legacy_plugin/bin/list-all
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-versions_list=(1.0.0 1.1.0 2.0.0)
+versions_list=(1.0.0 1.1.0 2.0.0 3.0.0-alpha1 3.0.0-beta2 4.0.0 4.1.0-pre 5.0.0-Alpha1 5.1.0 5.2.0-Alpha2)
 echo "${versions_list[@]}"

--- a/test/latest_command.bats
+++ b/test/latest_command.bats
@@ -40,7 +40,7 @@ teardown() {
   run asdf latest legacy-dummy
   echo "status: $status"
   echo "output: $output"
-  [ "$(echo "2.0.0")" == "$output" ]
+  [ "$(echo "5.1.0")" == "$output" ]
   [ "$status" -eq 0 ]
 }
 
@@ -52,11 +52,35 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
-@test "[latest_command - dummy_legacy_plugin] an invalid version should return an error" {
+@test "[latest_command - dummy_legacy_plugin] No stable version should return an error" {
   run asdf latest legacy-dummy 3
   echo "status: $status"
   echo "output: $output"
-  [ "$(echo "No compatible versions available (legacy-dummy 3)")" == "$output" ]
+  [ -z "$output" ]
+  [ "$status" -eq 1 ]
+}
+
+@test "[latest_command - dummy_legacy_plugin] do not show latest unstable version that matches the given string" {
+  run asdf latest legacy-dummy 4
+  echo "status: $status"
+  echo "output: $output"
+  [ "$(echo "4.0.0")" == "$output" ]
+  [ "$status" -eq 0 ]
+}
+
+@test "[latest_command - dummy_legacy_plugin] do not show latest unstable version with capital characters that matches the given string" {
+  run asdf latest legacy-dummy 5
+  echo "status: $status"
+  echo "output: $output"
+  [ "$(echo "5.1.0")" == "$output" ]
+  [ "$status" -eq 0 ]
+}
+
+@test "[latest_command - dummy_legacy_plugin] an invalid version should return an error" {
+  run asdf latest legacy-dummy 6
+  echo "status: $status"
+  echo "output: $output"
+  [ "$(echo "No compatible versions available (legacy-dummy 6)")" == "$output" ]
   [ "$status" -eq 1 ]
 }
 
@@ -65,15 +89,15 @@ teardown() {
 ################################
 @test "[latest_command - all plugins] shows the latest stable version of all plugins" {
   run asdf install dummy 2.0.0
-  run asdf install legacy-dummy 1.0.0
+  run asdf install legacy-dummy 4.0.0
   run asdf latest --all
   echo "output $output"
-  [ "$(echo -e "dummy\t2.0.0\tinstalled\nlegacy-dummy\t2.0.0\tmissing\n")" == "$output" ]
+  [ "$(echo -e "dummy\t2.0.0\tinstalled\nlegacy-dummy\t5.1.0\tmissing\n")" == "$output" ]
   [ "$status" -eq 0 ]
 }
 
 @test "[latest_command - all plugins] not installed plugin should return missing" {
   run asdf latest --all
-  [ "$(echo -e "dummy\t2.0.0\tmissing\nlegacy-dummy\t2.0.0\tmissing\n")" == "$output" ]
+  [ "$(echo -e "dummy\t2.0.0\tmissing\nlegacy-dummy\t5.1.0\tmissing\n")" == "$output" ]
   [ "$status" -eq 0 ]
 }

--- a/test/version_commands.bats
+++ b/test/version_commands.bats
@@ -13,6 +13,7 @@ setup() {
   install_dummy_legacy_version "1.0.0"
   install_dummy_legacy_version "1.1.0"
   install_dummy_legacy_version "2.0.0"
+  install_dummy_legacy_version "5.1.0"
 
   PROJECT_DIR=$HOME/project
   mkdir -p $PROJECT_DIR
@@ -76,7 +77,7 @@ teardown() {
 @test "[local - dummy_legacy_plugin] with latest should use the latest installed version" {
   run asdf local "legacy-dummy" "latest"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "legacy-dummy 2.0.0" ]
+  [ "$(cat $PROJECT_DIR/.tool-versions)" = "legacy-dummy 5.1.0" ]
 }
 
 @test "[local - dummy_legacy_plugin] with latest:version should use the latest valid installed version" {
@@ -207,7 +208,7 @@ teardown() {
 @test "[global - dummy_legacy_plugin] with latest should use the latest installed version" {
   run asdf global "legacy-dummy" "latest"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "legacy-dummy 2.0.0" ]
+  [ "$(cat $HOME/.tool-versions)" = "legacy-dummy 5.1.0" ]
 }
 
 @test "[global - dummy_legacy_plugin] with latest:version should use the latest valid installed version" {
@@ -408,7 +409,7 @@ false"
 @test "[shell - dummy_legacy_plugin] wrapper function should support latest" {
   . $(dirname "$BATS_TEST_DIRNAME")/asdf.sh
   asdf shell "legacy-dummy" "latest"
-  [ $(echo $ASDF_LEGACY_DUMMY_VERSION) = "2.0.0" ]
+  [ $(echo $ASDF_LEGACY_DUMMY_VERSION) = "5.1.0" ]
   unset ASDF_LEGACY_DUMMY_VERSION
 }
 
@@ -423,7 +424,7 @@ false"
   echo 'legacy-dummy 1.0.0' >> $HOME/.tool-versions
   run asdf global "legacy-dummy" "1.0.0" "latest"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "legacy-dummy 1.0.0 2.0.0" ]
+  [ "$(cat $HOME/.tool-versions)" = "legacy-dummy 1.0.0 5.1.0" ]
 }
 
 @test "[local - dummy_plugin] should support latest" {
@@ -437,5 +438,5 @@ false"
   echo 'legacy-dummy 1.0.0' >> $PROJECT_DIR/.tool-versions
   run asdf local "legacy-dummy" "1.0.0" "latest"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "legacy-dummy 1.0.0 2.0.0" ]
+  [ "$(cat $PROJECT_DIR/.tool-versions)" = "legacy-dummy 1.0.0 5.1.0" ]
 }


### PR DESCRIPTION
# Summary

The `asdf latest` command currently only filters unstable versions with lowercase version suffixes (`alpha`, `pre`, `snapshot`, etc.) but fails if there are version suffixes using uppercase.

This is currently happening with the [asdf-kcctl](https://github.com/joschi/asdf-kcctl) plugin.