### PR TITLE
fix: Ban `ls` command

### DIFF
--- a/lib/commands/command-install.bash
+++ b/lib/commands/command-install.bash
@@ -78,7 +78,7 @@ install_local_tool_versions() {
 
   # Locate all the plugins installed in the system
   local plugins_installed
-  if ls "$plugins_path" &>/dev/null; then
+  if find "$plugins_path" -mindepth 1 -type d &>/dev/null; then
     for plugin_path in "$plugins_path"/*; do
       local plugin_name
       plugin_name=$(basename "$plugin_path")

--- a/lib/commands/command-latest.bash
+++ b/lib/commands/command-latest.bash
@@ -43,7 +43,7 @@ latest_all() {
   local plugins_path
   plugins_path=$(get_plugin_path)
 
-  if ls "$plugins_path" &>/dev/null; then
+  if find "$plugins_path" -mindepth 1 -type d &>/dev/null; then
     for plugin_path in "$plugins_path"/*; do
       plugin_name=$(basename "$plugin_path")
 

--- a/lib/commands/command-list.bash
+++ b/lib/commands/command-list.bash
@@ -8,7 +8,7 @@ list_command() {
     local plugins_path
     plugins_path=$(get_plugin_path)
 
-    if ls "$plugins_path" &>/dev/null; then
+    if find "$plugins_path" -mindepth 1 -type d &>/dev/null; then
       for plugin_path in "$plugins_path"/*; do
         plugin_name=$(basename "$plugin_path")
         printf "%s\\n" "$plugin_name"

--- a/lib/commands/command-plugin-list-all.bash
+++ b/lib/commands/command-plugin-list-all.bash
@@ -9,7 +9,7 @@ plugin_list_all_command() {
   local plugins_local_path
   plugins_local_path="$(get_plugin_path)"
 
-  if ls "$plugins_index_path" &>/dev/null; then
+  if find "$plugins_index_path" -mindepth 1 -type d &>/dev/null; then
     (
       for index_plugin in "$plugins_index_path"/*; do
         index_plugin_name=$(basename "$index_plugin")

--- a/lib/commands/command-plugin-list.bash
+++ b/lib/commands/command-plugin-list.bash
@@ -23,7 +23,7 @@ plugin_list_command() {
     esac
   done
 
-  if ls "$plugins_path" &>/dev/null; then
+  if find "$plugins_path" -mindepth 1 -type d &>/dev/null; then
     (
       for plugin_path in "$plugins_path"/*; do
         plugin_name=$(basename "$plugin_path")

--- a/lib/commands/command-reshim.bash
+++ b/lib/commands/command-reshim.bash
@@ -11,7 +11,7 @@ reshim_command() {
     local plugins_path
     plugins_path=$(get_plugin_path)
 
-    if ls "$plugins_path" &>/dev/null; then
+    if find "$plugins_path" -mindepth 1 -type d &>/dev/null; then
       for plugin_path in "$plugins_path"/*; do
         plugin_name=$(basename "$plugin_path")
         reshim_command "$plugin_name"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -454,7 +454,7 @@ resolve_symlink() {
   # This seems to be the only cross-platform way to resolve symlink paths to
   # the real file path.
   # shellcheck disable=SC2012
-  resolved_path=$(ls -l "$symlink" | sed -e 's|.*-> \(.*\)|\1|')
+  resolved_path=$(ls -l "$symlink" | sed -e 's|.*-> \(.*\)|\1|') # asdf_allow: ls '
 
   # Check if resolved path is relative or not by looking at the first character.
   # If it is a slash we can assume it's root and absolute. Otherwise we treat it

--- a/test/banned_commands.bats
+++ b/test/banned_commands.bats
@@ -21,14 +21,6 @@ banned_commands=(
     # source isn't POSIX compliant. . behaves the same and is POSIX compliant
     # Except in fish, where . is deprecated, and will be removed in the future.
     source
-
-    # ls often gets used when we want to glob for files that match a pattern
-    # or when we want to find all files/directories that match a pattern or are
-    # found in a certain location. Using shell globs is preferred over ls, and
-    # find is better at locating files that are in a certain location or that
-    # match certain filename patterns.
-    # https://github-wiki-see.page/m/koalaman/shellcheck/wiki/SC2012
-    ls
 )
 
 banned_commands_regex=(
@@ -41,6 +33,14 @@ banned_commands_regex=(
     # sort --sort-version isn't supported everywhere
     "sort.*-V"
     "sort.*--sort-versions"
+
+    # ls often gets used when we want to glob for files that match a pattern
+    # or when we want to find all files/directories that match a pattern or are
+    # found in a certain location. Using shell globs is preferred over ls, and
+    # find is better at locating files that are in a certain location or that
+    # match certain filename patterns.
+    # https://github-wiki-see.page/m/koalaman/shellcheck/wiki/SC2012
+    '\bls '
 )
 
 setup() {

--- a/test/banned_commands.bats
+++ b/test/banned_commands.bats
@@ -58,7 +58,7 @@ teardown() {
   # followed by an underscore (indicating it's a variable and not a
   # command).
   for cmd in "${banned_commands[@]}"; do
-      run bash -c "grep -nHR '$cmd' asdf.* lib bin\
+      run bash -c "grep -nHR --include \*.bash --include \*.sh '$cmd' asdf.* lib bin\
         | grep -v '#.*$cmd'\
         | grep -v '\".*$cmd.*\"' \
         | grep -v '${cmd}_'\
@@ -75,7 +75,7 @@ teardown() {
   done
 
   for cmd in "${banned_commands_regex[@]}"; do
-      run bash -c "grep -nHRE '$cmd' asdf.* lib bin\
+      run bash -c "grep -nHRE --include \*.bash --include \*.sh '$cmd' asdf.* lib bin\
         | grep -v '#.*$cmd'\
         | grep -v '\".*$cmd.*\"' \
         | grep -v '${cmd}_'\

--- a/test/banned_commands.bats
+++ b/test/banned_commands.bats
@@ -21,6 +21,14 @@ banned_commands=(
     # source isn't POSIX compliant. . behaves the same and is POSIX compliant
     # Except in fish, where . is deprecated, and will be removed in the future.
     source
+
+    # ls often gets used when we want to glob for files that match a pattern
+    # or when we want to find all files/directories that match a pattern or are
+    # found in a certain location. Using shell globs is preferred over ls, and
+    # find is better at locating files that are in a certain location or that
+    # match certain filename patterns.
+    # https://github-wiki-see.page/m/koalaman/shellcheck/wiki/SC2012
+    ls
 )
 
 banned_commands_regex=(


### PR DESCRIPTION
# Summary

`ls` should be banned because it's seldom the right tool for the job. Often plain old shell globbing, or `find` are more reliable ways of listing directories. 

* Only grep sh/bash files for banned commands
* Ban `ls` command
* Replace instances of `ls` with `find`

Related: https://github.com/asdf-vm/asdf/pull/1100 https://github.com/asdf-vm/asdf/issues/1029

Fixes: Uncertain whether this will fix any outstanding issues.
