### PR TITLE
docs: Fix help text for 'asdf global'

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -35,7 +35,7 @@ asdf local <name> <version>             Set the package local version
 asdf local <name> latest[:<version>]    Set the package local version to the
                                         latest provided version
 asdf global <name> <version>            Set the package global version
-asdf global <name> latest[:<version>]   Set the package local version to the
+asdf global <name> latest[:<version>]   Set the package global version to the
                                         latest provided version
 asdf shell <name> <version>             Set the package version to
                                         `ASDF_${LANG}_VERSION` in the current shell


### PR DESCRIPTION
The help text was 
```
…
asdf local <name> latest[:<version>]    Set the package local version to the
                                        latest provided version
asdf global <name> <version>            Set the package global version
asdf global <name> latest[:<version>]   Set the package local version to the
                                        latest provided version
…
```

This PR updates the help text for `asdf global <name> latest[:<version>]` to:

```
asdf global <name> latest[:<version>]   Set the package global version to the
                                        latest provided version
```

