### PR TITLE
fix: get invalid ASDF_DATA_DIR when exec asdf shims by non-shell

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -41,6 +41,8 @@ asdf_data_dir() {
 
   if [ -n "${ASDF_DATA_DIR}" ]; then
     data_dir="${ASDF_DATA_DIR}"
+  elif [ -n "$HOME" ]; then
+    data_dir="$HOME/.asdf"
   else
     data_dir=$(asdf_dir)
   fi

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -42,7 +42,7 @@ asdf_data_dir() {
   if [ -n "${ASDF_DATA_DIR}" ]; then
     data_dir="${ASDF_DATA_DIR}"
   else
-    data_dir="$HOME/.asdf"
+    data_dir=$(asdf_dir)
   fi
 
   printf "%s\\n" "$data_dir"


### PR DESCRIPTION
# Summary

`asdf_data_dir` function inits `ASDF_DATA_DIR` with `HOME` when value is empty.
`HOME` may replace to empty string when asdf shims called by non-shell program.
this makes invalid value of `ASDF_DATA_DIR`.

the PR fixes this issue by use `asdf_dir` function instead of call environment variable.

## Other Information

I faced this issue when using `hugo` which installed by [nklmilojevic/asdf-hugo](https://github.com/nklmilojevic/asdf-hugo) and nodejs which installed by [asdf-vm/asdf-nodejs](https://github.com/asdf-vm/asdf-nodejs) like this:

```shell
$ hugo server
Start building sites … 
hugo v0.91.2-1798BD3F linux/amd64 BuildDate=2021-12-23T15:33:34Z VendorInfo=gohugoio
Error: Error building site: POSTCSS: failed to transform "style/style.css" (text/css): unknown command: npx. Perhaps you have to reshim?
Built in 87 ms
```

I looked into it by edit `$ASDF_DIR/bin/asdf` shebang as `#!/usr/bin/env -S bash -x`.

log: https://gist.github.com/knokmki612/41b4dd92580c8c893e834c83c946114e#file-asdf-hugo-server-log

[My hugo site](https://github.com/knokmki612/kuno.kdns.info) using [PostCSS integration](https://gohugo.io/hugo-pipes/postcss/) and hugo call `npx` (in my environment, this places as asdf shims) when build the site by [this code](https://github.com/gohugoio/hugo/blob/f4389e48ce0a70807362772d66c12ab5cd9e15f8/common/hexec/exec.go#L148-L152). it seems no using sub shell and directly exec `npx`. this will drop environment variables.

### Environments

- asdf: v0.9.0-9ee24a3
- hugo: hugo v0.91.2-1798BD3F
- nodejs: v16.13.1
- distro: Fedora Silverblue 35

.tool-versions:

```
nodejs lts
hugo 0.91.2
```