### PR TITLE
docs: fix readme links after readme structure changed to be in a docs folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ asdf is a CLI tool that can manage multiple language runtime versions on a per-p
 
 ## Contributing
 
-See [CONTRIBUTING.md in the repo](https://github.com/asdf-vm/asdf/blob/master/CONTRIBUTING.md) or the [Contributing section on the docs site](http://asdf-vm.github.io/asdf/#/contributing-core-asdf).
+See [CONTRIBUTING.md in the repo](https://github.com/asdf-vm/asdf/blob/master/CONTRIBUTING.md) or the [Contributing section on the docs site](https://asdf-vm.github.io/asdf/#/contributing-core-asdf).
 
 ## Community & Questions
 

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -3,6 +3,7 @@ const sidebar = require("./sidebar");
 
 module.exports = {
   base: "/docs/",
+  dest: ".vuepress/dist/docs",
   head: [],
   locales: {
     "/": {

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -2,7 +2,7 @@ const navbar = require("./navbar");
 const sidebar = require("./sidebar");
 
 module.exports = {
-  base: "/",
+  base: "/docs/",
   head: [],
   locales: {
     "/": {

--- a/docs/SERVER_REDIRECT
+++ b/docs/SERVER_REDIRECT
@@ -1,0 +1,1 @@
+<meta http-equiv="refresh" content="0; url='/docs/'" />

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -306,7 +306,7 @@ asdf global nodejs latest
 nodejs 16.5.0
 ```
 
-Some OSs already have tools installed that are managed by the system and not `asdf`, `python` is a common example. You need to tell `asdf` to pass the management back to the system. The [Versions reference section](/manage/versions.md) will guide you.
+Some OSs already have tools installed that are managed by the system and not `asdf`, `python` is a common example. You need to tell `asdf` to pass the management back to the system. The [Versions reference section](/docs/manage/versions.md) will guide you.
 
 ### Local
 
@@ -332,7 +332,7 @@ nodejs 16.5.0
 legacy_version_file = yes
 ```
 
-See the [configuration](/manage/configuration.md) reference page for more config options.
+See the [configuration](/docs/manage/configuration.md) reference page for more config options.
 
 ## Guide Complete!
 
@@ -340,6 +340,6 @@ That completes the Getting Started guide for `asdf` :tada: You can now manage `n
 
 `asdf` has many more commands to become familiar with, you can see them all by running `asdf --help` or `asdf`. The core of the commands are broken into three categories:
 
-- [core `asdf`](/manage/core.md)
-- [plugins](/manage/plugins.md)
-- [versions (of tools)](/manage/versions.md)
+- [core `asdf`](/docs/manage/core.md)
+- [plugins](/docs/manage/plugins.md)
+- [versions (of tools)](/docs/manage/versions.md)

--- a/docs/learn-more/faq.md
+++ b/docs/learn-more/faq.md
@@ -18,7 +18,7 @@ We intend to run out test suite on WSL2 when host runner support is available on
 
 > I just `npm install -g yarn`, but cannot execute `yarn`. What gives?
 
-`asdf` uses [shims](<https://en.wikipedia.org/wiki/Shim_(computing)>) to manage executables. Those installed by plugins have shims automatically created, whereas installing executables via an `asdf` managed tool will require you to notify `asdf` of the need to create shims. In this instance, to create a shim for [Yarn](https://yarnpkg.com/). See the [`asdf reshim` command docs](/manage/core.md#reshim).
+`asdf` uses [shims](<https://en.wikipedia.org/wiki/Shim_(computing)>) to manage executables. Those installed by plugins have shims automatically created, whereas installing executables via an `asdf` managed tool will require you to notify `asdf` of the need to create shims. In this instance, to create a shim for [Yarn](https://yarnpkg.com/). See the [`asdf reshim` command docs](/docs/manage/core.md#reshim).
 
 ## Shell not detecting newly installed shims?
 

--- a/docs/manage/core.md
+++ b/docs/manage/core.md
@@ -4,7 +4,7 @@ The core `asdf` command list is rather small, but can facilitate many workflows.
 
 ## Installation & Setup
 
-Covered in the [Getting Started](/guide/getting-started.md) guide.
+Covered in the [Getting Started](/docs/guide/getting-started.md) guide.
 
 ## Exec
 

--- a/docs/manage/plugins.md
+++ b/docs/manage/plugins.md
@@ -2,7 +2,7 @@
 
 Plugins are how `asdf` knows to handle different tools like Node.js, Ruby, Elixir etc.
 
-See [Creating Plugins](/plugins/create.md) for the plugin API used to support more tools.
+See [Creating Plugins](/docs/plugins/create.md) for the plugin API used to support more tools.
 
 ## Add
 
@@ -78,4 +78,4 @@ The short-name repo is synced to your local machine and periodically refreshed. 
 
 - commands `asdf plugin add <name>` or `asdf plugin list all` can trigger a sync
 - a sync occurs if there has not been one in the last `X` minutes
-- `X` defaults to `60`, but can be configured in your `.asdfrc` via the `plugin_repository_last_check_duration` option. See the [asdf config docs](/manage/configuration.md) for more.
+- `X` defaults to `60`, but can be configured in your `.asdfrc` via the `plugin_repository_last_check_duration` option. See the [asdf config docs](/docs/manage/configuration.md) for more.

--- a/docs/manage/versions.md
+++ b/docs/manage/versions.md
@@ -84,7 +84,7 @@ asdf local <name> latest[:<version>]
 
 `local` writes the version to `$PWD/.tool-versions`, creating it if needed.
 
-See the `.tool-versions` [file in the Configuration section](/manage/configuration.md) for details.
+See the `.tool-versions` [file in the Configuration section](/docs/manage/configuration.md) for details.
 
 :::warning Alternatively
 If you want to set a version only for the current shell session

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "dev": "vuepress-vite dev .",
-    "build": "vuepress-vite build .",
+    "build": "vuepress-vite build .; cp SERVER_REDIRECT .vuepress/dist/index.html; cp .vuepress/dist/docs/404.html .vuepress/dist/404.html",
     "format": "npx -y prettier --write '{.vuepress/{config,navbar,sidebar}.js,./**/*.md}'"
   },
   "devDependencies": {

--- a/docs/pt-br/guide/getting-started.md
+++ b/docs/pt-br/guide/getting-started.md
@@ -300,7 +300,7 @@ asdf global nodejs latest
 nodejs 16.5.0
 ```
 
-Alguns sistemas operacionais vêm por padrão com ferramentas que são gerenciadas pelo próprio sistema e não pelo `asdf`, `python` é um exemplo. Você precisa indicar para o `asdf` para devolver o gerenciamento para o sistema. A [seção de referência de versões](/pt-br/manage/versions.md) irá guiá-lo.
+Alguns sistemas operacionais vêm por padrão com ferramentas que são gerenciadas pelo próprio sistema e não pelo `asdf`, `python` é um exemplo. Você precisa indicar para o `asdf` para devolver o gerenciamento para o sistema. A [seção de referência de versões](/docs/pt-br/manage/versions.md) irá guiá-lo.
 
 ### Versões locais
 
@@ -326,7 +326,7 @@ O [`asdf-nodejs`](https://github.com/asdf-vm/asdf-nodejs/) suporta tanto arquivo
 legacy_version_file = yes
 ```
 
-Veja a página de refencia da [configuração](/pt-br/manage/configuration.md) para mais opções de configuração.
+Veja a página de refencia da [configuração](/docs/pt-br/manage/configuration.md) para mais opções de configuração.
 
 ## Setup finalizado!
 
@@ -334,6 +334,6 @@ A configuração inicial do `asdf` foi finalizada :tada:. Agora, você pode gere
 
 O `asdf` possui diversos outros comandos para se acustomar ainda, você pode ver todos eles através do comando `asdf --help` ou simplesmente `asdf`. Eles estão divididos em três categorias:
 
-- [núcleo `asdf`](/pt-br/manage/core.md)
-- [plugins](/pt-br/manage/plugins.md)
-- [versões (de ferramentas)](/pt-br/manage/versions.md)
+- [núcleo `asdf`](/docs/pt-br/manage/core.md)
+- [plugins](/docs/pt-br/manage/plugins.md)
+- [versões (de ferramentas)](/docs/pt-br/manage/versions.md)

--- a/docs/pt-br/learn-more/faq.md
+++ b/docs/pt-br/learn-more/faq.md
@@ -18,7 +18,7 @@ Pretendemos executar o conjunto de testes no WSL2 quando o suporte ao host runne
 
 > Acabei de instalar o `npm -g yarn`, mas não consigo executar o `yarn`. O que da?
 
-`asdf` usa [shims](<https://en.wikipedia.org/wiki/Shim_(computing)>) para gerenciar executáveis. Aqueles instalados por plug-ins têm shims criados automaticamente, enquanto a instalação de executáveis ​​por meio de uma ferramenta gerenciada `asdf` exigirá que você notifique o`asdf` sobre a necessidade de criar shims. Neste caso, para criar um shim para [Yarn](https://yarnpkg.com/). Veja a documentação do comando [`asdf reshim`](/ manage / core.md # reshim).
+`asdf` usa [shims](<https://en.wikipedia.org/wiki/Shim_(computing)>) para gerenciar executáveis. Aqueles instalados por plug-ins têm shims criados automaticamente, enquanto a instalação de executáveis ​​por meio de uma ferramenta gerenciada `asdf` exigirá que você notifique o` asdf` sobre a necessidade de criar shims. Neste caso, para criar um shim para [Yarn](https://yarnpkg.com/). Veja a documentação do comando [`asdf reshim`](/docs/manage/core.md#reshim).
 
 ## Shell não detecta shims recém-instalados?
 

--- a/docs/pt-br/manage/core.md
+++ b/docs/pt-br/manage/core.md
@@ -6,7 +6,7 @@ The core `asdf` command list is rather small, but can facilitate many workflows.
 
 ## Installation & Setup
 
-Covered in the [Getting Started](/pt-br/guide/getting-started.md) guide.
+Covered in the [Getting Started](/docs/pt-br/guide/getting-started.md) guide.
 
 ## Exec
 

--- a/docs/pt-br/manage/plugins.md
+++ b/docs/pt-br/manage/plugins.md
@@ -4,7 +4,7 @@
 
 Plugins são como `asdf` sabe lidar com diferentes ferramentas, tais quais Node.js, Ruby, Elixir etc.
 
-See [Creating Plugins](/pt-br/plugins/create.md) for the plugin API used to support more tools.
+See [Creating Plugins](/docs/pt-br/plugins/create.md) for the plugin API used to support more tools.
 
 ## Adicionar
 
@@ -80,4 +80,4 @@ O nome abreviado do repositório é sincronizado em seu máquina local e periodi
 
 - comandos `asdf plugin add <name>` ou `asdf plugin list all` disparam a sincronização
 - ocorre uma sincronização se não houver nenhuma nos últimos `X` minutos
-- `X` por padrão é `60`, mas pode ser mudado em `.asdfrc` via as opções do `plugin_repository_last_check_duration`. Seja mais em [asdf documentação de configuração](/pt-br/manage/configuration.md).
+- `X` por padrão é `60`, mas pode ser mudado em `.asdfrc` via as opções do `plugin_repository_last_check_duration`. Seja mais em [asdf documentação de configuração](/docs/pt-br/manage/configuration.md).

--- a/docs/pt-br/manage/versions.md
+++ b/docs/pt-br/manage/versions.md
@@ -86,7 +86,7 @@ asdf local <name> latest[:<version>]
 
 `local` escreve a versão para `$PWD/.tool-versions`, crie se necessário .
 
-Veja em `.tool-versions` [arquivo de seleção de configuração](/pt-br/core-configuration) para mais detalhes.
+Veja em `.tool-versions` [arquivo de seleção de configuração](/docs/pt-br/core-configuration) para mais detalhes.
 
 ::: warning Alternativa
 Se você quiser selecionar a versão atual do seu _shell_ ou para executar um comando em uma versão específica de sua ferramenta, você pode selecionar a versão na variável de ambiente `ASDF_${TOOL}_VERSION`.

--- a/docs/zh-hans/guide/getting-started.md
+++ b/docs/zh-hans/guide/getting-started.md
@@ -308,7 +308,7 @@ asdf global nodejs latest
 nodejs 16.5.0
 ```
 
-某些操作系统已经有一些由系统而非 `asdf` 安装和管理的工具了，`python` 就是一个常见的例子。你需要告诉 `asdf` 将管理权还给系统。[版本参考部分](/zh-hans/manage/versions.md) 将会引导你。
+某些操作系统已经有一些由系统而非 `asdf` 安装和管理的工具了，`python` 就是一个常见的例子。你需要告诉 `asdf` 将管理权还给系统。[版本参考部分](/docs/zh-hans/manage/versions.md) 将会引导你。
 
 ### 本地
 
@@ -334,7 +334,7 @@ nodejs 16.5.0
 legacy_version_file = yes
 ```
 
-请查看 [配置](/zh-hans/manage/configuration.md) 参考页面可以了解更多配置选项。
+请查看 [配置](/docs/zh-hans/manage/configuration.md) 参考页面可以了解更多配置选项。
 
 ## 完成指南！
 
@@ -342,6 +342,6 @@ legacy_version_file = yes
 
 `asdf` 还有更多命令需要熟悉，你可以通过运行 `asdf --help` 或者 `asdf` 来查看它们。命令主要分为三类：
 
-- [`asdf` 核心](/zh-hans/manage/core.md)
-- [插件](/zh-hans/manage/plugins.md)
-- [（工具的）版本](/zh-hans/manage/versions.md)
+- [`asdf` 核心](/docs/zh-hans/manage/core.md)
+- [插件](/docs/zh-hans/manage/plugins.md)
+- [（工具的）版本](/docs/zh-hans/manage/versions.md)

--- a/docs/zh-hans/learn-more/faq.md
+++ b/docs/zh-hans/learn-more/faq.md
@@ -18,7 +18,7 @@ WSL2 ([Windows Subsystem for Linux 2](https://en.wikipedia.org/wiki/Windows_Subs
 
 > 我执行了 `npm install -g yarn` 命令，但是之后不能运行 `yarn` 命令。这是为什么？
 
-`asdf` 使用 [垫片](<https://zh.wikipedia.org/wiki/垫片_(程序设计)>) 来管理可执行程序。插件所安装的那些命令会自动创建垫片，而通过 `asdf` 管理工具安装过的可执行程序则需要通知 `asdf` 创建垫片的需要。在这个例子中，为 [Yarn](https://yarnpkg.com/) 创建一个垫片即可。请查看 [`asdf reshim` 命令文档](/zh-hans/manage/core.md#reshim) 了解更多。
+`asdf` 使用 [垫片](<https://zh.wikipedia.org/wiki/垫片_(程序设计)>) 来管理可执行程序。插件所安装的那些命令会自动创建垫片，而通过 `asdf` 管理工具安装过的可执行程序则需要通知 `asdf` 创建垫片的需要。在这个例子中，为 [Yarn](https://yarnpkg.com/) 创建一个垫片即可。请查看 [`asdf reshim` 命令文档](/docs/zh-hans/manage/core.md#reshim) 了解更多。
 
 ## Shell 没有检测到新安装的垫片？
 

--- a/docs/zh-hans/manage/core.md
+++ b/docs/zh-hans/manage/core.md
@@ -4,7 +4,7 @@
 
 ## 安装和配置
 
-请查看 [快速上手](/zh-hans/guide/getting-started.md) 了解更多详情。
+请查看 [快速上手](/docs/zh-hans/guide/getting-started.md) 了解更多详情。
 
 ## Exec
 

--- a/docs/zh-hans/manage/plugins.md
+++ b/docs/zh-hans/manage/plugins.md
@@ -2,7 +2,7 @@
 
 插件告诉 `asdf` 如何处理不同的工具，如 Node.js、 Ruby、 Elixir 等。
 
-请参考 [创建插件](/zh-hans/plugins/create.md) 了解用于支持更多工具的插件 API。
+请参考 [创建插件](/docs/zh-hans/plugins/create.md) 了解用于支持更多工具的插件 API。
 
 ## 添加
 
@@ -78,4 +78,4 @@ asdf plugin remove <name>
 
 - 命令 `asdf plugin add <name>` 或者 `asdf plugin list all` 将会触发同步
 - 如果在过去的 `X` 分钟内没有同步，则进行同步
-- `X` 默认是 `60`，但可以通过在 `.asdfrc` 文件中配置 `plugin_repository_last_check_duration` 选项来进行配置。请查看 [asdf 配置文档](/zh-hans/manage/configuration.md) 了解更多。
+- `X` 默认是 `60`，但可以通过在 `.asdfrc` 文件中配置 `plugin_repository_last_check_duration` 选项来进行配置。请查看 [asdf 配置文档](/docs/zh-hans/manage/configuration.md) 了解更多。

--- a/docs/zh-hans/manage/versions.md
+++ b/docs/zh-hans/manage/versions.md
@@ -84,7 +84,7 @@ asdf local <name> latest[:<version>]
 
 `local` 将版本写到 `$PWD/.tool-versions` 文件中，如果有需要也会创建此文件。
 
-请查看 [配置部分](/zh-hans/manage/configuration.md) 的 `.tool-versions` 文件了解更多详情。
+请查看 [配置部分](/docs/zh-hans/manage/configuration.md) 的 `.tool-versions` 文件了解更多详情。
 
 :::warning 可选
 如果你只是想为当前 shell 会话或者在特定工具版本下执行一条命令，你可以设置一个类似 `ASDF_${TOOL}_VERSION` 的环境变量。


### PR DESCRIPTION
# Summary

Fixed all of the broken links in the readme that occured after the folder structure for the project changed.

Fixes: #1155 
See also: #456 , #492 

## Other Information

I noticed that docsify was used for the translations? 

Are the english docs and any other docs auto generated?

If that is the case that change may need to be added in the auto generated docs.

#### Happy to provide any additional info