### PR TITLE
fix: Prevent unbound variable error with nounset in asdf.sh

### DIFF
--- a/asdf.sh
+++ b/asdf.sh
@@ -3,7 +3,7 @@
 # For Bash, ${BASH_SOURCE[0]} will be used to obtain this script's path.
 # For Zsh and others, $0 (the path to the shell or script) will be used.
 _under="$_"
-if [ -z "$ASDF_DIR" ]; then
+if [ -z "${ASDF_DIR:-}" ]; then
   if [ -n "${BASH_SOURCE[0]}" ]; then
     current_script_path="${BASH_SOURCE[0]}"
   elif [[ "$_under" == *".sh" ]]; then

--- a/test/asdf_sh.bats
+++ b/test/asdf_sh.bats
@@ -26,6 +26,22 @@ cleaned_path() {
   [ "$output" != "" ]
 }
 
+@test "does not error if nounset is enabled" {
+  result=$(
+    unset -f asdf
+    unset ASDF_DIR
+    PATH=$(cleaned_path)
+    set -o nounset
+
+    source_asdf_sh
+    echo $ASDF_DIR
+  )
+
+  output=$(echo "$result" | grep "asdf")
+  [ "$?" -eq 0 ]
+  [ "$output" != "" ]
+}
+
 @test "adds asdf dirs to PATH" {
   result=$(
     unset -f asdf


### PR DESCRIPTION
# Summary

`asdf` [v0.9.0][1] included a [bug fix][2] to not override an existing `ASDF_DIR`.

However, if `ASDF_DIR` is not set at all, then this causes an error when using bash `set -u`, or `set -o nounset` - see [here][3] for additional info.

`asdf.sh: line 6: ASDF_DIR: unbound variable`

Edit: see also #160 and #817

[1]: https://github.com/asdf-vm/asdf/releases/tag/v0.9.0
[2]: https://github.com/asdf-vm/asdf/pull/1008
[3]: https://mywiki.wooledge.org/BashFAQ/112
