### PR TITLE
feat(elvish)!: remove deprecated syntax for Elvish v0.17.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,11 +38,11 @@ jobs:
           sudo apt-get -y install fish curl
 
           # Download elvish binary and add to path
-          curl https://dl.elv.sh/linux-amd64/elvish-v0.16.3.tar.gz -o elvish-v0.16.3.tar.gz
-          tar xzf elvish-v0.16.3.tar.gz
-          rm elvish-v0.16.3.tar.gz
+          curl https://dl.elv.sh/linux-amd64/elvish-v0.17.0.tar.gz -o elvish-v0.17.0.tar.gz
+          tar xzf elvish-v0.17.0.tar.gz
+          rm elvish-v0.17.0.tar.gz
           mkdir -p "$HOME/bin"
-          mv elvish-v0.16.3 "$HOME/bin/elvish"
+          mv elvish-v0.17.0 "$HOME/bin/elvish"
           echo "$HOME/bin" >>"$GITHUB_PATH"
 
       - name: Install bats

--- a/asdf.elv
+++ b/asdf.elv
@@ -2,7 +2,7 @@ use re
 use str
 use path
 
-var asdf_dir = $E:HOME'/.asdf'
+var asdf_dir = ~/.asdf
 if (and (has-env ASDF_DIR) (!=s $E:ASDF_DIR '')) {
   set asdf_dir = $E:ASDF_DIR
 } else {
@@ -18,11 +18,11 @@ if (and (has-env ASDF_DATA_DIR) (!=s $E:ASDF_DATA_DIR '')) {
 fn asdf {|@args|
   if (and (> (count $args) 0) (==s $args[0] 'shell')) {
     # set environment variables
-    var parts = [($asdf_dir'/bin/asdf' export-shell-version elvish (drop 1 $args))]
-    if (==s $parts[0] 'set-env') {
-      set-env $parts[1] $parts[2]
-    } elif (==s $parts[0] 'unset-env') {
-      unset-env $parts[1]
+    var fn @fn_args = ($asdf_dir'/bin/asdf' export-shell-version elvish (drop 1 $args))
+    if (==s $fn 'set-env') {
+      set-env $@fn_args
+    } elif (==s $fn 'unset-env') {
+      unset-env $@fn_args
     }
   } else {
     # forward other commands to asdf script

--- a/asdf.elv
+++ b/asdf.elv
@@ -15,10 +15,10 @@ if (and (has-env ASDF_DATA_DIR) (!=s $E:ASDF_DATA_DIR '')) {
 }
 
 # Add function wrapper so we can export variables
-fn asdf {|command @args|
-  if (==s $command 'shell') {
+fn asdf {|@args|
+  if (and (> (count $args) 0) (==s $args[0] 'shell')) {
     # set environment variables
-    var parts = [($asdf_dir'/bin/asdf' export-shell-version elvish $@args)]
+    var parts = [($asdf_dir'/bin/asdf' export-shell-version elvish (drop 1 $args))]
     if (==s $parts[0] 'set-env') {
       set-env $parts[1] $parts[2]
     } elif (==s $parts[0] 'unset-env') {
@@ -26,7 +26,7 @@ fn asdf {|command @args|
     }
   } else {
     # forward other commands to asdf script
-    $asdf_dir'/bin/asdf' $command $@args
+    $asdf_dir'/bin/asdf' $@args
   }
 }
 

--- a/asdf.elv
+++ b/asdf.elv
@@ -1,25 +1,24 @@
-
 use re
 use str
 use path
 
 var asdf_dir = $E:HOME'/.asdf'
 if (and (has-env ASDF_DIR) (!=s $E:ASDF_DIR '')) {
-  asdf_dir = $E:ASDF_DIR
+  set asdf_dir = $E:ASDF_DIR
 } else {
   set-env ASDF_DIR $asdf_dir
 }
 
 var asdf_data_dir = $asdf_dir
 if (and (has-env ASDF_DATA_DIR) (!=s $E:ASDF_DATA_DIR '')) {
-  asdf_data_dir = $E:ASDF_DATA_DIR
+  set asdf_data_dir = $E:ASDF_DATA_DIR
 }
 
 # Add function wrapper so we can export variables
-fn asdf [command @args]{
+fn asdf {|command @args|
   if (==s $command 'shell') {
     # set environment variables
-    parts = [($asdf_dir'/bin/asdf' export-shell-version elvish $@args)]
+    var parts = [($asdf_dir'/bin/asdf' export-shell-version elvish $@args)]
     if (==s $parts[0] 'set-env') {
       set-env $parts[1] $parts[2]
     } elif (==s $parts[0] 'unset-env') {
@@ -31,16 +30,16 @@ fn asdf [command @args]{
   }
 }
 
-fn match [argz @pats]{
-  var matched = $true;
+fn match {|argz @pats|
+  var matched = $true
   if (!= (count $argz) (count $pats)) {
-    matched = $false
+    set matched = $false
   } else {
     for i [(range (count $pats))] {
-      pat = '^'$pats[$i]'$'
-      arg = $argz[$i]
+      var pat = '^'$pats[$i]'$'
+      var arg = $argz[$i]
       if (not (re:match $pat $arg)) {
-        matched = $false
+        set matched = $false
         break
       }
     }
@@ -48,14 +47,14 @@ fn match [argz @pats]{
   put $matched
 }
 
-fn ls-shims []{
+fn ls-shims {
   ls $asdf_data_dir'/shims'
 }
 
-fn ls-executables []{
+fn ls-executables {
   # Print all executable files and links in path
   try {
-    find $@paths '(' -type f -o -type l ')' -print 2>/dev/null | each [p]{
+    find $@paths '(' -type f -o -type l ')' -print 2>/dev/null | each {|p|
       try {
         if (test -x $p) {
           path:base $p
@@ -69,14 +68,14 @@ fn ls-executables []{
   }
 }
 
-fn ls-installed-versions [plugin_name]{
-  asdf list $plugin_name | each [version]{
+fn ls-installed-versions {|plugin_name|
+  asdf list $plugin_name | each {|version|
     put (re:replace '\s*(.*)\s*' '${1}' $version)
   }
 }
 
-fn ls-all-versions [plugin_name]{
-  asdf list-all $plugin_name | each [version]{
+fn ls-all-versions {|plugin_name|
+  asdf list-all $plugin_name | each {|version|
     put (re:replace '\s*(.*)\s*' '${1}' $version)
   }
 }
@@ -87,7 +86,7 @@ for path [
   $asdf_data_dir'/shims'
 ] {
   if (not (has-value $paths $path)) {
-    paths = [
+    set paths = [
       $@paths
       $path
     ]
@@ -95,12 +94,12 @@ for path [
 }
 
 # Setup argument completions
-fn arg-completer [@argz]{
-  argz = $argz[1:-1]  # strip 'asdf' and trailing empty string
+fn arg-completer {|@argz|
+  set argz = $argz[1..-1]  # strip 'asdf' and trailing empty string
   var num = (count $argz)
   if (== $num 0) {
     # list all subcommands
-    find $asdf_dir'/lib/commands' -name 'command-*' | each [cmd]{
+    find $asdf_dir'/lib/commands' -name 'command-*' | each {|cmd|
       put (re:replace '.*/command-(.*)\.bash' '${1}' $cmd)
     }
     put 'plugin'
@@ -176,7 +175,7 @@ fn arg-completer [@argz]{
       put '--parent'
     } elif (or (match $argz 'plugin-add') (match $argz 'plugin' 'add')) {
       # asdf plugin add <name>
-      asdf plugin-list-all | each [line]{
+      asdf plugin-list-all | each {|line|
         put (re:replace '([^\s]+)\s+.*' '${1}' $line)
       }
     } elif (or (match $argz 'plugin-list') (match $argz 'plugin' 'list')) {
@@ -190,13 +189,13 @@ fn arg-completer [@argz]{
     } elif (or (match $argz 'plugin-remove') (match $argz 'plugin' 'remove')) {
       # asdf plugin remove <name>
       asdf plugin-list
-    } elif (and (>= (count $argz) 3) (match $argz[:3] 'plugin-test' '.*' '.*')) {
+    } elif (and (>= (count $argz) 3) (match $argz[..3] 'plugin-test' '.*' '.*')) {
       # asdf plugin-test <plugin-name> <plugin-url> [--asdf-tool-version <version>] [--asdf-plugin-gitref <git-ref>] [test-command*]
       put '--asdf-plugin-gitref'
       put '--asdf-tool-version'
       ls-executables
       ls-shims
-    } elif (and (>= (count $argz) 4) (match $argz[:4] 'plugin' 'test' '.*' '.*')) {
+    } elif (and (>= (count $argz) 4) (match $argz[..4] 'plugin' 'test' '.*' '.*')) {
       # asdf plugin test <plugin-name> <plugin-url> [--asdf-tool-version <version>] [--asdf-plugin-gitref <git-ref>] [test-command*]
       put '--asdf-plugin-gitref'
       put '--asdf-tool-version'
@@ -208,7 +207,7 @@ fn arg-completer [@argz]{
       put '--all'
     } elif (match $argz 'plugin') {
       # list plugin-* subcommands
-      find $asdf_dir'/lib/commands' -name 'command-plugin-*' | each [cmd]{
+      find $asdf_dir'/lib/commands' -name 'command-plugin-*' | each {|cmd|
         put (re:replace '.*/command-plugin-(.*)\.bash' '${1}' $cmd)
       }
     } elif (match $argz 'reshim') {

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -166,6 +166,7 @@ Add `asdf.elv` to your `~/.elvish/rc.elv` with:
 
 ```shell:no-line-numbers
 mkdir -p ~/.elvish/lib; ln -s (brew --prefix asdf)/libexec/asdf.elv ~/.elvish/lib/asdf.elv
+echo "\n"'set-env ASDF_DIR (brew --prefix asdf)/libexec; set-env ASDF_DATA_DIR ~/.asdf' >> ~/.elvish/rc.elv
 echo "\n"'use asdf _asdf; var asdf~ = $_asdf:asdf~' >> ~/.elvish/rc.elv
 echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
 ```

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -153,7 +153,7 @@ Add `asdf.elv` to your `~/.elvish/rc.elv` with:
 ```shell:no-line-numbers
 mkdir -p ~/.elvish/lib; ln -s ~/.asdf/asdf.elv ~/.elvish/lib/asdf.elv
 echo "\n"'use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}' >> ~/.elvish/rc.elv
-echo "\n"'edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
+echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
 ```
 
 Completions are automatically configured.
@@ -167,7 +167,7 @@ Add `asdf.elv` to your `~/.elvish/rc.elv` with:
 ```shell:no-line-numbers
 mkdir -p ~/.elvish/lib; ln -s (brew --prefix asdf)/libexec/asdf.elv ~/.elvish/lib/asdf.elv
 echo "\n"'use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}' >> ~/.elvish/rc.elv
-echo "\n"'edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
+echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
 ```
 
 Completions are automatically configured.
@@ -180,7 +180,7 @@ Add `asdf.elv` to your `~/.elvish/rc.elv` with:
 ```shell:no-line-numbers
 mkdir -p ~/.elvish/lib; ln -s /opt/asdf-vm/asdf.elv ~/.elvish/lib/asdf.elv
 echo "\n"'use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}' >> ~/.elvish/rc.elv
-echo "\n"'edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
+echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
 ```
 
 Completions are automatically configured.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -152,7 +152,7 @@ Add `asdf.elv` to your `~/.elvish/rc.elv` with:
 
 ```shell:no-line-numbers
 mkdir -p ~/.elvish/lib; ln -s ~/.asdf/asdf.elv ~/.elvish/lib/asdf.elv
-echo "\n"'use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}' >> ~/.elvish/rc.elv
+echo "\n"'use asdf _asdf; var asdf~ = $_asdf:asdf~' >> ~/.elvish/rc.elv
 echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
 ```
 
@@ -166,7 +166,7 @@ Add `asdf.elv` to your `~/.elvish/rc.elv` with:
 
 ```shell:no-line-numbers
 mkdir -p ~/.elvish/lib; ln -s (brew --prefix asdf)/libexec/asdf.elv ~/.elvish/lib/asdf.elv
-echo "\n"'use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}' >> ~/.elvish/rc.elv
+echo "\n"'use asdf _asdf; var asdf~ = $_asdf:asdf~' >> ~/.elvish/rc.elv
 echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
 ```
 
@@ -179,7 +179,7 @@ Add `asdf.elv` to your `~/.elvish/rc.elv` with:
 
 ```shell:no-line-numbers
 mkdir -p ~/.elvish/lib; ln -s /opt/asdf-vm/asdf.elv ~/.elvish/lib/asdf.elv
-echo "\n"'use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}' >> ~/.elvish/rc.elv
+echo "\n"'use asdf _asdf; var asdf~ = $_asdf:asdf~' >> ~/.elvish/rc.elv
 echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
 ```
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -148,12 +148,12 @@ Completions are automatically configured on installation by the AUR package.
 
 ::: details Elvish & Git
 
-Add `asdf.elv` to your `~/.elvish/rc.elv` with:
+Add `asdf.elv` to your [RC file][elvish rc] such as `~/.config/elvish/rc.elv` with:
 
 ```shell:no-line-numbers
-mkdir -p ~/.elvish/lib; ln -s ~/.asdf/asdf.elv ~/.elvish/lib/asdf.elv
-echo "\n"'use asdf _asdf; var asdf~ = $_asdf:asdf~' >> ~/.elvish/rc.elv
-echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
+mkdir -p ~/.config/elvish/lib; ln -s ~/.asdf/asdf.elv ~/.config/elvish/lib/asdf.elv
+echo "\n"'use asdf _asdf; var asdf~ = $_asdf:asdf~' >> ~/.config/elvish/rc.elv
+echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.config/elvish/rc.elv
 ```
 
 Completions are automatically configured.
@@ -162,13 +162,13 @@ Completions are automatically configured.
 
 ::: details Elvish & Homebrew
 
-Add `asdf.elv` to your `~/.elvish/rc.elv` with:
+Add `asdf.elv` to your [RC file][elvish rc] such as `~/.config/elvish/rc.elv` with:
 
 ```shell:no-line-numbers
-mkdir -p ~/.elvish/lib; ln -s (brew --prefix asdf)/libexec/asdf.elv ~/.elvish/lib/asdf.elv
-echo "\n"'set-env ASDF_DIR (brew --prefix asdf)/libexec; set-env ASDF_DATA_DIR ~/.asdf' >> ~/.elvish/rc.elv
-echo "\n"'use asdf _asdf; var asdf~ = $_asdf:asdf~' >> ~/.elvish/rc.elv
-echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
+mkdir -p ~/.config/elvish/lib; ln -s (brew --prefix asdf)/libexec/asdf.elv ~/.config/elvish/lib/asdf.elv
+echo "\n"'set-env ASDF_DIR (brew --prefix asdf)/libexec; set-env ASDF_DATA_DIR ~/.asdf' >> ~/.config/elvish/rc.elv
+echo "\n"'use asdf _asdf; var asdf~ = $_asdf:asdf~' >> ~/.config/elvish/rc.elv
+echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.config/elvish/rc.elv
 ```
 
 Completions are automatically configured.
@@ -176,12 +176,12 @@ Completions are automatically configured.
 
 ::: details Elvish & Pacman
 
-Add `asdf.elv` to your `~/.elvish/rc.elv` with:
+Add `asdf.elv` to your [RC file][elvish rc] such as `~/.config/elvish/rc.elv` with:
 
 ```shell:no-line-numbers
-mkdir -p ~/.elvish/lib; ln -s /opt/asdf-vm/asdf.elv ~/.elvish/lib/asdf.elv
-echo "\n"'use asdf _asdf; var asdf~ = $_asdf:asdf~' >> ~/.elvish/rc.elv
-echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
+mkdir -p ~/.config/elvish/lib; ln -s /opt/asdf-vm/asdf.elv ~/.config/elvish/lib/asdf.elv
+echo "\n"'use asdf _asdf; var asdf~ = $_asdf:asdf~' >> ~/.config/elvish/rc.elv
+echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.config/elvish/rc.elv
 ```
 
 Completions are automatically configured.
@@ -344,3 +344,5 @@ That completes the Getting Started guide for `asdf` :tada: You can now manage `n
 - [core `asdf`](/manage/core.md)
 - [plugins](/manage/plugins.md)
 - [versions (of tools)](/manage/versions.md)
+
+[elvish rc]: https://elv.sh/ref/command.html#rc-file

--- a/docs/manage/core.md
+++ b/docs/manage/core.md
@@ -262,7 +262,7 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 1. In your `~/.elvish/rc.elv` remove the lines that use the `asdf` module:
 
 ```shell
-use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}
+use asdf _asdf; var asdf~ = $_asdf:asdf~
 set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
 ```
 
@@ -291,7 +291,7 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 1. In your `~/.elvish/rc.elv` remove the lines that use the `asdf` module:
 
 ```shell
-use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}
+use asdf _asdf; var asdf~ = $_asdf:asdf~
 set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
 ```
 
@@ -320,7 +320,7 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 1. In your `~/.elvish/rc.elv` remove the lines that use the `asdf` module:
 
 ```shell
-use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}
+use asdf _asdf; var asdf~ = $_asdf:asdf~
 set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
 ```
 

--- a/docs/manage/core.md
+++ b/docs/manage/core.md
@@ -259,7 +259,7 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 
 ::: details Elvish & Git
 
-1. In your `~/.elvish/rc.elv` remove the lines that use the `asdf` module:
+1. In your `~/.config/elvish/rc.elv` remove the lines that use the `asdf` module:
 
 ```shell
 use asdf _asdf; var asdf~ = $_asdf:asdf~
@@ -269,7 +269,7 @@ set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
 and uninstall the `asdf` module with this command:
 
 ```shell:no-line-numbers
-rm -f ~/.elvish/lib/asdf.elv
+rm -f ~/.config/elvish/lib/asdf.elv
 ```
 
 2. Remove the `$HOME/.asdf` dir:
@@ -288,7 +288,7 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 
 ::: details Elvish & Homebrew
 
-1. In your `~/.elvish/rc.elv` remove the lines that use the `asdf` module:
+1. In your `~/.config/elvish/rc.elv` remove the lines that use the `asdf` module:
 
 ```shell
 set-env ASDF_DIR (brew --prefix asdf)/libexec; set-env ASDF_DATA_DIR ~/.asdf
@@ -299,7 +299,7 @@ set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
 and uninstall the `asdf` module with this command:
 
 ```shell:no-line-numbers
-rm -f ~/.elvish/lib/asdf.elv
+rm -f ~/.config/elvish/lib/asdf.elv
 ```
 
 2. Uninstall with your package manager:
@@ -318,7 +318,7 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 
 ::: details Elvish & Pacman
 
-1. In your `~/.elvish/rc.elv` remove the lines that use the `asdf` module:
+1. In your `~/.config/elvish/rc.elv` remove the lines that use the `asdf` module:
 
 ```shell
 use asdf _asdf; var asdf~ = $_asdf:asdf~
@@ -328,7 +328,7 @@ set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
 and uninstall the `asdf` module with this command:
 
 ```shell:no-line-numbers
-rm -f ~/.elvish/lib/asdf.elv
+rm -f ~/.config/elvish/lib/asdf.elv
 ```
 
 2. Uninstall with your package manager:

--- a/docs/manage/core.md
+++ b/docs/manage/core.md
@@ -291,6 +291,7 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 1. In your `~/.elvish/rc.elv` remove the lines that use the `asdf` module:
 
 ```shell
+set-env ASDF_DIR (brew --prefix asdf)/libexec; set-env ASDF_DATA_DIR ~/.asdf
 use asdf _asdf; var asdf~ = $_asdf:asdf~
 set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
 ```

--- a/docs/manage/core.md
+++ b/docs/manage/core.md
@@ -263,7 +263,7 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 
 ```shell
 use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}
-edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
+set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
 ```
 
 and uninstall the `asdf` module with this command:
@@ -292,7 +292,7 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 
 ```shell
 use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}
-edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
+set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
 ```
 
 and uninstall the `asdf` module with this command:
@@ -321,7 +321,7 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 
 ```shell
 use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}
-edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
+set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
 ```
 
 and uninstall the `asdf` module with this command:

--- a/docs/pt-br/guide/getting-started.md
+++ b/docs/pt-br/guide/getting-started.md
@@ -166,6 +166,7 @@ Add `asdf.elv` to your `~/.elvish/rc.elv` with:
 
 ```shell:no-line-numbers
 mkdir -p ~/.elvish/lib; ln -s (brew --prefix asdf)/libexec/asdf.elv ~/.elvish/lib/asdf.elv
+echo "\n"'set-env ASDF_DIR (brew --prefix asdf)/libexec; set-env ASDF_DATA_DIR ~/.asdf' >> ~/.elvish/rc.elv
 echo "\n"'use asdf _asdf; var asdf~ = $_asdf:asdf~' >> ~/.elvish/rc.elv
 echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
 ```

--- a/docs/pt-br/guide/getting-started.md
+++ b/docs/pt-br/guide/getting-started.md
@@ -148,12 +148,12 @@ O auto completar é configurado automaticamente durante a instalação do pacote
 
 ::: details Elvish & Git
 
-Add `asdf.elv` to your `~/.elvish/rc.elv` with:
+Add `asdf.elv` to your [RC file][elvish rc] such as `~/.config/elvish/rc.elv` with:
 
 ```shell:no-line-numbers
-mkdir -p ~/.elvish/lib; ln -s ~/.asdf/asdf.elv ~/.elvish/lib/asdf.elv
-echo "\n"'use asdf _asdf; var asdf~ = $_asdf:asdf~' >> ~/.elvish/rc.elv
-echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
+mkdir -p ~/.config/elvish/lib; ln -s ~/.asdf/asdf.elv ~/.config/elvish/lib/asdf.elv
+echo "\n"'use asdf _asdf; var asdf~ = $_asdf:asdf~' >> ~/.config/elvish/rc.elv
+echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.config/elvish/rc.elv
 ```
 
 Completions are automatically configured.
@@ -162,13 +162,13 @@ Completions are automatically configured.
 
 ::: details Elvish & Homebrew
 
-Add `asdf.elv` to your `~/.elvish/rc.elv` with:
+Add `asdf.elv` to your [RC file][elvish rc] such as `~/.config/elvish/rc.elv` with:
 
 ```shell:no-line-numbers
-mkdir -p ~/.elvish/lib; ln -s (brew --prefix asdf)/libexec/asdf.elv ~/.elvish/lib/asdf.elv
-echo "\n"'set-env ASDF_DIR (brew --prefix asdf)/libexec; set-env ASDF_DATA_DIR ~/.asdf' >> ~/.elvish/rc.elv
-echo "\n"'use asdf _asdf; var asdf~ = $_asdf:asdf~' >> ~/.elvish/rc.elv
-echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
+mkdir -p ~/.config/elvish/lib; ln -s (brew --prefix asdf)/libexec/asdf.elv ~/.config/elvish/lib/asdf.elv
+echo "\n"'set-env ASDF_DIR (brew --prefix asdf)/libexec; set-env ASDF_DATA_DIR ~/.asdf' >> ~/.config/elvish/rc.elv
+echo "\n"'use asdf _asdf; var asdf~ = $_asdf:asdf~' >> ~/.config/elvish/rc.elv
+echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.config/elvish/rc.elv
 ```
 
 Completions are automatically configured.
@@ -176,12 +176,12 @@ Completions are automatically configured.
 
 ::: details Elvish & Pacman
 
-Add `asdf.elv` to your `~/.elvish/rc.elv` with:
+Add `asdf.elv` to your [RC file][elvish rc] such as `~/.config/elvish/rc.elv` with:
 
 ```shell:no-line-numbers
-mkdir -p ~/.elvish/lib; ln -s /opt/asdf-vm/asdf.elv ~/.elvish/lib/asdf.elv
-echo "\n"'use asdf _asdf; var asdf~ = $_asdf:asdf~' >> ~/.elvish/rc.elv
-echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
+mkdir -p ~/.config/elvish/lib; ln -s /opt/asdf-vm/asdf.elv ~/.config/elvish/lib/asdf.elv
+echo "\n"'use asdf _asdf; var asdf~ = $_asdf:asdf~' >> ~/.config/elvish/rc.elv
+echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.config/elvish/rc.elv
 ```
 
 Completions are automatically configured.
@@ -338,3 +338,5 @@ O `asdf` possui diversos outros comandos para se acustomar ainda, você pode ver
 - [núcleo `asdf`](/pt-br/manage/core.md)
 - [plugins](/pt-br/manage/plugins.md)
 - [versões (de ferramentas)](/pt-br/manage/versions.md)
+
+[elvish rc]: https://elv.sh/ref/command.html#rc-file

--- a/docs/pt-br/guide/getting-started.md
+++ b/docs/pt-br/guide/getting-started.md
@@ -153,7 +153,7 @@ Add `asdf.elv` to your `~/.elvish/rc.elv` with:
 ```shell:no-line-numbers
 mkdir -p ~/.elvish/lib; ln -s ~/.asdf/asdf.elv ~/.elvish/lib/asdf.elv
 echo "\n"'use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}' >> ~/.elvish/rc.elv
-echo "\n"'edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
+echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
 ```
 
 Completions are automatically configured.
@@ -167,7 +167,7 @@ Add `asdf.elv` to your `~/.elvish/rc.elv` with:
 ```shell:no-line-numbers
 mkdir -p ~/.elvish/lib; ln -s (brew --prefix asdf)/libexec/asdf.elv ~/.elvish/lib/asdf.elv
 echo "\n"'use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}' >> ~/.elvish/rc.elv
-echo "\n"'edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
+echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
 ```
 
 Completions are automatically configured.
@@ -180,7 +180,7 @@ Add `asdf.elv` to your `~/.elvish/rc.elv` with:
 ```shell:no-line-numbers
 mkdir -p ~/.elvish/lib; ln -s /opt/asdf-vm/asdf.elv ~/.elvish/lib/asdf.elv
 echo "\n"'use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}' >> ~/.elvish/rc.elv
-echo "\n"'edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
+echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
 ```
 
 Completions are automatically configured.

--- a/docs/pt-br/guide/getting-started.md
+++ b/docs/pt-br/guide/getting-started.md
@@ -152,7 +152,7 @@ Add `asdf.elv` to your `~/.elvish/rc.elv` with:
 
 ```shell:no-line-numbers
 mkdir -p ~/.elvish/lib; ln -s ~/.asdf/asdf.elv ~/.elvish/lib/asdf.elv
-echo "\n"'use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}' >> ~/.elvish/rc.elv
+echo "\n"'use asdf _asdf; var asdf~ = $_asdf:asdf~' >> ~/.elvish/rc.elv
 echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
 ```
 
@@ -166,7 +166,7 @@ Add `asdf.elv` to your `~/.elvish/rc.elv` with:
 
 ```shell:no-line-numbers
 mkdir -p ~/.elvish/lib; ln -s (brew --prefix asdf)/libexec/asdf.elv ~/.elvish/lib/asdf.elv
-echo "\n"'use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}' >> ~/.elvish/rc.elv
+echo "\n"'use asdf _asdf; var asdf~ = $_asdf:asdf~' >> ~/.elvish/rc.elv
 echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
 ```
 
@@ -179,7 +179,7 @@ Add `asdf.elv` to your `~/.elvish/rc.elv` with:
 
 ```shell:no-line-numbers
 mkdir -p ~/.elvish/lib; ln -s /opt/asdf-vm/asdf.elv ~/.elvish/lib/asdf.elv
-echo "\n"'use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}' >> ~/.elvish/rc.elv
+echo "\n"'use asdf _asdf; var asdf~ = $_asdf:asdf~' >> ~/.elvish/rc.elv
 echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
 ```
 

--- a/docs/pt-br/manage/core.md
+++ b/docs/pt-br/manage/core.md
@@ -293,6 +293,7 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 1. Em seu `~/.elvish/rc.elv` remova as linhas que importa o módulo `asdf`:
 
 ```shell
+set-env ASDF_DIR (brew --prefix asdf)/libexec; set-env ASDF_DATA_DIR ~/.asdf
 use asdf _asdf; var asdf~ = $_asdf:asdf~
 set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
 ```

--- a/docs/pt-br/manage/core.md
+++ b/docs/pt-br/manage/core.md
@@ -261,7 +261,7 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 
 ::: details Elvish & Git
 
-1. Em seu `~/.elvish/rc.elv` remova as linhas que importa o módulo `asdf`:
+1. Em seu `~/.config/elvish/rc.elv` remova as linhas que importa o módulo `asdf`:
 
 ```shell
 use asdf _asdf; var asdf~ = $_asdf:asdf~
@@ -271,7 +271,7 @@ set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
 e desinstale o módulo `asdf` com este comando:
 
 ```shell:no-line-numbers
-rm -f ~/.elvish/lib/asdf.elv
+rm -f ~/.config/elvish/lib/asdf.elv
 ```
 
 2. Remova o diretório `$HOME/.asdf`:
@@ -290,7 +290,7 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 
 ::: details Elvish & Homebrew
 
-1. Em seu `~/.elvish/rc.elv` remova as linhas que importa o módulo `asdf`:
+1. Em seu `~/.config/elvish/rc.elv` remova as linhas que importa o módulo `asdf`:
 
 ```shell
 set-env ASDF_DIR (brew --prefix asdf)/libexec; set-env ASDF_DATA_DIR ~/.asdf
@@ -301,7 +301,7 @@ set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
 e desinstale o módulo `asdf` com este comando:
 
 ```shell:no-line-numbers
-rm -f ~/.elvish/lib/asdf.elv
+rm -f ~/.config/elvish/lib/asdf.elv
 ```
 
 2. Desinstale com seu gerenciador de pacotes:
@@ -320,7 +320,7 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 
 ::: details Elvish & Pacman
 
-1. Em seu `~/.elvish/rc.elv` remova as linhas que importa o módulo `asdf`:
+1. Em seu `~/.config/elvish/rc.elv` remova as linhas que importa o módulo `asdf`:
 
 ```shell
 use asdf _asdf; var asdf~ = $_asdf:asdf~
@@ -330,7 +330,7 @@ set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
 e desinstale o módulo `asdf` com este comando:
 
 ```shell:no-line-numbers
-rm -f ~/.elvish/lib/asdf.elv
+rm -f ~/.config/elvish/lib/asdf.elv
 ```
 
 2. Desinstale com seu gerenciador de pacotes:

--- a/docs/pt-br/manage/core.md
+++ b/docs/pt-br/manage/core.md
@@ -265,7 +265,7 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 
 ```shell
 use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}
-edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
+set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
 ```
 
 e desinstale o módulo `asdf` com este comando:
@@ -294,7 +294,7 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 
 ```shell
 use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}
-edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
+set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
 ```
 
 e desinstale o módulo `asdf` com este comando:
@@ -323,7 +323,7 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 
 ```shell
 use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}
-edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
+set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
 ```
 
 e desinstale o módulo `asdf` com este comando:

--- a/docs/pt-br/manage/core.md
+++ b/docs/pt-br/manage/core.md
@@ -264,7 +264,7 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 1. Em seu `~/.elvish/rc.elv` remova as linhas que importa o módulo `asdf`:
 
 ```shell
-use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}
+use asdf _asdf; var asdf~ = $_asdf:asdf~
 set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
 ```
 
@@ -293,7 +293,7 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 1. Em seu `~/.elvish/rc.elv` remova as linhas que importa o módulo `asdf`:
 
 ```shell
-use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}
+use asdf _asdf; var asdf~ = $_asdf:asdf~
 set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
 ```
 
@@ -322,7 +322,7 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 1. Em seu `~/.elvish/rc.elv` remova as linhas que importa o módulo `asdf`:
 
 ```shell
-use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}
+use asdf _asdf; var asdf~ = $_asdf:asdf~
 set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
 ```
 

--- a/docs/zh-hans/guide/getting-started.md
+++ b/docs/zh-hans/guide/getting-started.md
@@ -166,6 +166,7 @@ echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/
 
 ```shell:no-line-numbers
 mkdir -p ~/.elvish/lib; ln -s (brew --prefix asdf)/libexec/asdf.elv ~/.elvish/lib/asdf.elv
+echo "\n"'set-env ASDF_DIR (brew --prefix asdf)/libexec; set-env ASDF_DATA_DIR ~/.asdf' >> ~/.elvish/rc.elv
 echo "\n"'use asdf _asdf; var asdf~ = $_asdf:asdf~' >> ~/.elvish/rc.elv
 echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
 ```

--- a/docs/zh-hans/guide/getting-started.md
+++ b/docs/zh-hans/guide/getting-started.md
@@ -148,12 +148,12 @@ source /opt/asdf-vm/asdf.fish
 
 ::: details Elvish & Git
 
-使用以下命令将 `asdf.elv` 加入到 `~/.elvish/rc.elv` 文件中：
+使用以下命令将 `asdf.elv` 加入到 `~/.config/elvish/rc.elv` 文件中：
 
 ```shell:no-line-numbers
-mkdir -p ~/.elvish/lib; ln -s ~/.asdf/asdf.elv ~/.elvish/lib/asdf.elv
-echo "\n"'use asdf _asdf; var asdf~ = $_asdf:asdf~' >> ~/.elvish/rc.elv
-echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
+mkdir -p ~/.config/elvish/lib; ln -s ~/.asdf/asdf.elv ~/.config/elvish/lib/asdf.elv
+echo "\n"'use asdf _asdf; var asdf~ = $_asdf:asdf~' >> ~/.config/elvish/rc.elv
+echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.config/elvish/rc.elv
 ```
 
 补全功能将会自动配置。
@@ -162,13 +162,13 @@ echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/
 
 ::: details Elvish & Homebrew
 
-使用以下命令将 `asdf.elv` 加入到 `~/.elvish/rc.elv` 文件中：
+使用以下命令将 `asdf.elv` 加入到 `~/.config/elvish/rc.elv` 文件中：
 
 ```shell:no-line-numbers
-mkdir -p ~/.elvish/lib; ln -s (brew --prefix asdf)/libexec/asdf.elv ~/.elvish/lib/asdf.elv
-echo "\n"'set-env ASDF_DIR (brew --prefix asdf)/libexec; set-env ASDF_DATA_DIR ~/.asdf' >> ~/.elvish/rc.elv
-echo "\n"'use asdf _asdf; var asdf~ = $_asdf:asdf~' >> ~/.elvish/rc.elv
-echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
+mkdir -p ~/.config/elvish/lib; ln -s (brew --prefix asdf)/libexec/asdf.elv ~/.config/elvish/lib/asdf.elv
+echo "\n"'set-env ASDF_DIR (brew --prefix asdf)/libexec; set-env ASDF_DATA_DIR ~/.asdf' >> ~/.config/elvish/rc.elv
+echo "\n"'use asdf _asdf; var asdf~ = $_asdf:asdf~' >> ~/.config/elvish/rc.elv
+echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.config/elvish/rc.elv
 ```
 
 补全功能将会自动配置。
@@ -177,12 +177,12 @@ echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/
 
 ::: details Elvish & Pacman
 
-使用以下命令将 `asdf.elv` 加入到 `~/.elvish/rc.elv` 文件中：
+使用以下命令将 `asdf.elv` 加入到 `~/.config/elvish/rc.elv` 文件中：
 
 ```shell:no-line-numbers
-mkdir -p ~/.elvish/lib; ln -s /opt/asdf-vm/asdf.elv ~/.elvish/lib/asdf.elv
-echo "\n"'use asdf _asdf; var asdf~ = $_asdf:asdf~' >> ~/.elvish/rc.elv
-echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
+mkdir -p ~/.config/elvish/lib; ln -s /opt/asdf-vm/asdf.elv ~/.config/elvish/lib/asdf.elv
+echo "\n"'use asdf _asdf; var asdf~ = $_asdf:asdf~' >> ~/.config/elvish/rc.elv
+echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.config/elvish/rc.elv
 ```
 
 补全功能将会自动配置。

--- a/docs/zh-hans/guide/getting-started.md
+++ b/docs/zh-hans/guide/getting-started.md
@@ -152,7 +152,7 @@ source /opt/asdf-vm/asdf.fish
 
 ```shell:no-line-numbers
 mkdir -p ~/.elvish/lib; ln -s ~/.asdf/asdf.elv ~/.elvish/lib/asdf.elv
-echo "\n"'use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}' >> ~/.elvish/rc.elv
+echo "\n"'use asdf _asdf; var asdf~ = $_asdf:asdf~' >> ~/.elvish/rc.elv
 echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
 ```
 
@@ -166,7 +166,7 @@ echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/
 
 ```shell:no-line-numbers
 mkdir -p ~/.elvish/lib; ln -s (brew --prefix asdf)/libexec/asdf.elv ~/.elvish/lib/asdf.elv
-echo "\n"'use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}' >> ~/.elvish/rc.elv
+echo "\n"'use asdf _asdf; var asdf~ = $_asdf:asdf~' >> ~/.elvish/rc.elv
 echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
 ```
 
@@ -180,7 +180,7 @@ echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/
 
 ```shell:no-line-numbers
 mkdir -p ~/.elvish/lib; ln -s /opt/asdf-vm/asdf.elv ~/.elvish/lib/asdf.elv
-echo "\n"'use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}' >> ~/.elvish/rc.elv
+echo "\n"'use asdf _asdf; var asdf~ = $_asdf:asdf~' >> ~/.elvish/rc.elv
 echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
 ```
 

--- a/docs/zh-hans/guide/getting-started.md
+++ b/docs/zh-hans/guide/getting-started.md
@@ -153,7 +153,7 @@ source /opt/asdf-vm/asdf.fish
 ```shell:no-line-numbers
 mkdir -p ~/.elvish/lib; ln -s ~/.asdf/asdf.elv ~/.elvish/lib/asdf.elv
 echo "\n"'use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}' >> ~/.elvish/rc.elv
-echo "\n"'edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
+echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
 ```
 
 补全功能将会自动配置。
@@ -167,7 +167,7 @@ echo "\n"'edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elv
 ```shell:no-line-numbers
 mkdir -p ~/.elvish/lib; ln -s (brew --prefix asdf)/libexec/asdf.elv ~/.elvish/lib/asdf.elv
 echo "\n"'use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}' >> ~/.elvish/rc.elv
-echo "\n"'edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
+echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
 ```
 
 补全功能将会自动配置。
@@ -181,7 +181,7 @@ echo "\n"'edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elv
 ```shell:no-line-numbers
 mkdir -p ~/.elvish/lib; ln -s /opt/asdf-vm/asdf.elv ~/.elvish/lib/asdf.elv
 echo "\n"'use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}' >> ~/.elvish/rc.elv
-echo "\n"'edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
+echo "\n"'set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~' >> ~/.elvish/rc.elv
 ```
 
 补全功能将会自动配置。

--- a/docs/zh-hans/manage/core.md
+++ b/docs/zh-hans/manage/core.md
@@ -263,7 +263,7 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 
 ```shell
 use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}
-edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
+set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
 ```
 
 以及使用以下命令卸载 `asdf` 模块：
@@ -292,7 +292,7 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 
 ```shell
 use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}
-edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
+set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
 ```
 
 以及使用以下命令卸载 `asdf` 模块：
@@ -321,7 +321,7 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 
 ```shell
 use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}
-edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
+set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
 ```
 
 以及使用以下命令卸载 `asdf` 模块：

--- a/docs/zh-hans/manage/core.md
+++ b/docs/zh-hans/manage/core.md
@@ -291,6 +291,7 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 1. 在 `~/.elvish/rc.elv` 配置文件中移除使用 `asdf` 模块的行：
 
 ```shell
+set-env ASDF_DIR (brew --prefix asdf)/libexec; set-env ASDF_DATA_DIR ~/.asdf
 use asdf _asdf; var asdf~ = $_asdf:asdf~
 set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
 ```

--- a/docs/zh-hans/manage/core.md
+++ b/docs/zh-hans/manage/core.md
@@ -259,7 +259,7 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 
 ::: details Elvish & Git
 
-1. 在 `~/.elvish/rc.elv` 配置文件中移除使用 `asdf` 模块的行：
+1. 在 `~/.config/elvish/rc.elv` 配置文件中移除使用 `asdf` 模块的行：
 
 ```shell
 use asdf _asdf; var asdf~ = $_asdf:asdf~
@@ -269,7 +269,7 @@ set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
 以及使用以下命令卸载 `asdf` 模块：
 
 ```shell:no-line-numbers
-rm -f ~/.elvish/lib/asdf.elv
+rm -f ~/.config/elvish/lib/asdf.elv
 ```
 
 2. 移除 `$HOME/.asdf` 目录：
@@ -288,7 +288,7 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 
 ::: details Elvish & Homebrew
 
-1. 在 `~/.elvish/rc.elv` 配置文件中移除使用 `asdf` 模块的行：
+1. 在 `~/.config/elvish/rc.elv` 配置文件中移除使用 `asdf` 模块的行：
 
 ```shell
 set-env ASDF_DIR (brew --prefix asdf)/libexec; set-env ASDF_DATA_DIR ~/.asdf
@@ -299,7 +299,7 @@ set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
 以及使用以下命令卸载 `asdf` 模块：
 
 ```shell:no-line-numbers
-rm -f ~/.elvish/lib/asdf.elv
+rm -f ~/.config/elvish/lib/asdf.elv
 ```
 
 2. 用包管理器卸载：
@@ -318,7 +318,7 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 
 ::: details Elvish & Pacman
 
-1. 在 `~/.elvish/rc.elv` 配置文件中移除使用 `asdf` 模块的行：
+1. 在 `~/.config/elvish/rc.elv` 配置文件中移除使用 `asdf` 模块的行：
 
 ```shell
 use asdf _asdf; var asdf~ = $_asdf:asdf~
@@ -328,7 +328,7 @@ set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
 以及使用以下命令卸载 `asdf` 模块：
 
 ```shell:no-line-numbers
-rm -f ~/.elvish/lib/asdf.elv
+rm -f ~/.config/elvish/lib/asdf.elv
 ```
 
 2. 用包管理器卸载：

--- a/docs/zh-hans/manage/core.md
+++ b/docs/zh-hans/manage/core.md
@@ -262,7 +262,7 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 1. 在 `~/.elvish/rc.elv` 配置文件中移除使用 `asdf` 模块的行：
 
 ```shell
-use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}
+use asdf _asdf; var asdf~ = $_asdf:asdf~
 set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
 ```
 
@@ -291,7 +291,7 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 1. 在 `~/.elvish/rc.elv` 配置文件中移除使用 `asdf` 模块的行：
 
 ```shell
-use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}
+use asdf _asdf; var asdf~ = $_asdf:asdf~
 set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
 ```
 
@@ -320,7 +320,7 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 1. 在 `~/.elvish/rc.elv` 配置文件中移除使用 `asdf` 模块的行：
 
 ```shell
-use asdf _asdf; fn asdf [@args]{_asdf:asdf $@args}
+use asdf _asdf; var asdf~ = $_asdf:asdf~
 set edit:completion:arg-completer[asdf] = $_asdf:arg-completer~
 ```
 

--- a/test/asdf_elvish.bats
+++ b/test/asdf_elvish.bats
@@ -4,12 +4,12 @@ load test_helpers
 
 setup() {
   cd $(dirname "$BATS_TEST_DIRNAME")
-  mkdir -p $HOME/.elvish/lib
-  cp ./asdf.elv $HOME/.elvish/lib/asdftest.elv
+  mkdir -p $HOME/.config/elvish/lib
+  cp ./asdf.elv $HOME/.config/elvish/lib/asdftest.elv
 }
 
 teardown() {
-  rm $HOME/.elvish/lib/asdftest.elv
+  rm $HOME/.config/elvish/lib/asdftest.elv
 }
 
 cleaned_path() {


### PR DESCRIPTION
# Summary

Some fixes and improvements for the Elvish support.

- Updates Elvish script to prevent deprecation warnings on Elvish v0.17.0. This is breaking as it won't work for Elvish versions prior to v0.17.0 (released in December 2021).
- Support calling `asdf` with no arguments. Previously, this would happen:
  ```
  ~> asdf
  Exception: arity mismatch: arguments must be 1 or more values, but is 0 values
  ```
- Add `set-env ASDF_DIR (brew --prefix asdf)/libexec; set-env ASDF_DATA_DIR ~/.asdf` to the `rc.elv` for Homebrew (the Elvish script sets `ASDF_DIR` to `~/.asdf` by default and `ASDF_DATA_DIR` to `ASDF_DIR`, which is incorrect for Homebrew installations)
- Update docs to reflect changes to the [Elvish RC file location](https://elv.sh/ref/command.html#rc-file) in v0.17.0. The new location depends on `$XDG_CONFIG_HOME` on Unix and `%AppData%` on Windows, so I linked to the docs and used `~/.config/elvish/rc.elv` in the installation script. I haven't updated the Chinese docs properly as I don't know Chinese and instead replaced `~/.elvish/rc.elv` with `~/.config/elvish/rc.elv` without the link to the Elvish docs.

These are some more subjective and minor changes as well (please let me know I should undo the commit):
- Use [tilde expansion](elv.sh/ref/language.html#tilde-expansion) instead of `$E:HOME`
- Set `asdf~` variable instead of creating a `fn asdf` and explicitly passing arguments (see [docs on the `~` variable suffix](elv.sh/ref/language.html#variable-suffix))
- Use some destructuring in the `asdf` function using a [rest variable](elv.sh/ref/language.html#var)

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->

Sorry if this PR does too many things at once; I just noticed a few things I could improve with the Elvish support when updating it to work for the latest Elvish version. I'm very happy to split up this PR into smaller ones.