### PR TITLE
fix(elvish): prepend asdf paths to `$PATH`

### DIFF
--- a/asdf.elv
+++ b/asdf.elv
@@ -88,8 +88,8 @@ for path [
 ] {
   if (not (has-value $paths $path)) {
     set paths = [
-      $@paths
       $path
+      $@paths
     ]
   }
 }

--- a/asdf.elv
+++ b/asdf.elv
@@ -1,9 +1,8 @@
-
+use path
 use re
 use str
-use path
 
-var asdf_dir = $E:HOME'/.asdf'
+var asdf_dir = ~'/.asdf'
 if (and (has-env ASDF_DIR) (!=s $E:ASDF_DIR '')) {
   set asdf_dir = $E:ASDF_DIR
 } else {
@@ -32,7 +31,7 @@ fn asdf {|command @args|
 }
 
 fn match {|argz @pats|
-  var matched = $true;
+  var matched = $true
   if (!= (count $argz) (count $pats)) {
     set matched = $false
   } else {


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

Prepends `~/.asdf/bin` and `~/.asdf/shims` to the `PATH` environment variable (instead of appending them). This is consistent with the other shell integrations.

While I was at it, I also sorted the imports alphabetically, used [tilde expansion](https://elv.sh/ref/language.html#tilde-expansion) instead of `$E:HOME`, and removed an unnecessary semicolon.

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->
