### PR TITLE
docs: remove github discussion reference

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,9 +1,6 @@
 # Force users to use one of our predefined issue templates
 blank_issues_enabled: false
 contact_links:
-  - name: Question (GitHub Discussions)
-    url: https://github.com/asdf-vm/asdf/discussions/
-    about: Ask new or browse existing questions in GitHub Discussions.
   - name: Question (StackOverflow)
     url: https://stackoverflow.com/questions/tagged/asdf-vm
     about: Ask new or browse existing questions on StackOverflow.

--- a/docs/.vuepress/navbar.js
+++ b/docs/.vuepress/navbar.js
@@ -110,10 +110,6 @@ const en = [
             link: "https://github.com/asdf-vm/asdf/issues"
           },
           {
-            text: "GitHub Discussions",
-            link: "https://github.com/asdf-vm/asdf/discussions"
-          },
-          {
             text: "StackOverflow Tag",
             link: "https://stackoverflow.com/questions/tagged/asdf-vm"
           }
@@ -242,10 +238,6 @@ const pt_br = [
             link: "https://github.com/asdf-vm/asdf/issues"
           },
           {
-            text: "GitHub Discussions",
-            link: "https://github.com/asdf-vm/asdf/discussions"
-          },
-          {
             text: "StackOverflow Tag",
             link: "https://stackoverflow.com/questions/tagged/asdf-vm"
           }
@@ -372,10 +364,6 @@ const zh_hans = [
           {
             text: "GitHub Issues",
             link: "https://github.com/asdf-vm/asdf/issues"
-          },
-          {
-            text: "GitHub Discussions",
-            link: "https://github.com/asdf-vm/asdf/discussions"
           },
           {
             text: "StackOverflow Tag",

--- a/docs/.vuepress/sidebar.js
+++ b/docs/.vuepress/sidebar.js
@@ -89,10 +89,6 @@ const en = {
           link: "https://github.com/asdf-vm/asdf/issues"
         },
         {
-          text: "GitHub Discussions",
-          link: "https://github.com/asdf-vm/asdf/discussions"
-        },
-        {
           text: "StackOverflow Tag",
           link: "https://stackoverflow.com/questions/tagged/asdf-vm"
         }

--- a/docs/.vuepress/sidebar.js
+++ b/docs/.vuepress/sidebar.js
@@ -195,10 +195,6 @@ const pt_br = {
           link: "https://github.com/asdf-vm/asdf/issues"
         },
         {
-          text: "GitHub Discussions",
-          link: "https://github.com/asdf-vm/asdf/discussions"
-        },
-        {
           text: "StackOverflow Tag",
           link: "https://stackoverflow.com/questions/tagged/asdf-vm"
         }
@@ -307,10 +303,6 @@ const zh_hans = {
         {
           text: "GitHub Issues",
           link: "https://github.com/asdf-vm/asdf/issues"
-        },
-        {
-          text: "GitHub Discussions",
-          link: "https://github.com/asdf-vm/asdf/discussions"
         },
         {
           text: "StackOverflow Tag",


### PR DESCRIPTION
# Summary

Github Discussions seems to have been disabled, removing it from documentation


