### PR TITLE
feat: Support for changing the location of plugin scripts

### DIFF
--- a/docs/manage/configuration.md
+++ b/docs/manage/configuration.md
@@ -57,6 +57,7 @@ legacy_version_file = no
 use_release_candidates = no
 always_keep_download = no
 plugin_repository_last_check_duration = 60
+use_asdf_plugin_configuration = no
 ```
 
 ### `legacy_version_file`
@@ -95,6 +96,18 @@ Configure the duration since the last asdf plugin repository sync to the next. C
 | integer in range `1` to `999999999` <br/> `60` is <Badge type="tip" text="default" vertical="middle" /> | Sync on trigger event if duration since last sync has passed |
 | `0`                                                                                                     | Sync on each trigger event                                   |
 | `never`                                                                                                 | Never sync                                                   |
+
+### `use_asdf_plugin_configuration`
+
+Settings to use the configuration file `.asdf-plugin` provided by the plugin.
+
+When using a plugin that requires this setting, set to yes.
+
+| Options                                                    | Description                                                            |
+| :--------------------------------------------------------- |:-----------------------------------------------------------------------|
+| `no` <Badge type="tip" text="default" vertical="middle" /> | Do not use the .asdf-plugin configuration file provided by the plugin. |
+| `yes`                                                      | Use the configuration file .asdf-plugin provided by the plugin.        |
+
 
 ## Environment Variables
 

--- a/docs/plugins/create.md
+++ b/docs/plugins/create.md
@@ -300,3 +300,20 @@ cmd="$cmd $releases_path"
 To make it easier on your users, you can add your plugin to the official plugins repository to have your plugin listed and easily installable using a shorter command, e.g. `asdf plugin add my-plugin`.
 
 Follow the instruction at the plugins repository: [asdf-vm/asdf-plugins](https://github.com/asdf-vm/asdf-plugins).
+
+## Plugin configuration
+
+Add an `.asdf-plugin` file to your plugin root directory and asdf will use the settings specified in the file. The file below shows the required format with the default values to demonstrate:
+
+```:no-line-numbers
+plugin_directory =
+```
+
+### `plugin_directory`
+
+If you want to place plugin scripts (e.g. bin, lib) in a subdirectory, specify a path relative to the repository root.
+For example, to place asdf plugin scripts under `contrib/asdf`, adding the following to .asdf-plugin:
+
+```:no-line-numbers
+plugin_directory = contrib/asdf
+```

--- a/docs/plugins/create.md
+++ b/docs/plugins/create.md
@@ -309,6 +309,14 @@ Add an `.asdf-plugin` file to your plugin root directory and asdf will use the s
 plugin_directory =
 ```
 
+To enable this, add the following to your `asdf` configuration file `$HOME/.asdfrc`:
+
+```
+use_asdf_plugin_configuration = yes
+```
+
+See the [configuration](/manage/configuration.md) reference page for more config options.
+
 ### `plugin_directory`
 
 If you want to place plugin scripts (e.g. bin, lib) in a subdirectory, specify a path relative to the repository root.

--- a/lib/commands/command-plugin-remove.bash
+++ b/lib/commands/command-plugin-remove.bash
@@ -17,7 +17,10 @@ plugin_remove_command() {
     )
   fi
 
-  rm -rf "$plugin_path"
+  local plugin_root
+  plugin_root=$(get_plugin_root "${plugin_name}")
+
+  rm -rf "$plugin_root"
   rm -rf "$(asdf_data_dir)/installs/${plugin_name}"
   rm -rf "$(asdf_data_dir)/downloads/${plugin_name}"
 

--- a/lib/commands/command-plugin-test.bash
+++ b/lib/commands/command-plugin-test.bash
@@ -155,7 +155,7 @@ plugin_test_command() {
     fi
 
     # Assert the scripts in bin are executable by asdf
-    for filename in "$ASDF_DIR/plugins/$plugin_name/bin"/*; do
+    for filename in "$plugin_path/bin"/*; do
       if [ ! -x "$filename" ]; then
         fail_test "Incorrect permissions on $filename. Must be executable by asdf"
       fi

--- a/lib/functions/plugins.bash
+++ b/lib/functions/plugins.bash
@@ -74,21 +74,24 @@ plugin_add_command() {
     exit 1
   fi
 
-  local plugin_path
-  plugin_path=$(get_plugin_path "$plugin_name")
+  local plugin_root
+  plugin_root=$(get_plugin_root "$plugin_name")
 
   mkdir -p "$(asdf_data_dir)/plugins"
 
-  if [ -d "$plugin_path" ]; then
+  if [ -d "$plugin_root" ]; then
     display_error "Plugin named $plugin_name already added"
     exit 2
   else
     asdf_run_hook "pre_asdf_plugin_add" "$plugin_name"
     asdf_run_hook "pre_asdf_plugin_add_${plugin_name}"
 
-    if ! git clone -q "$source_url" "$plugin_path"; then
+    if ! git clone -q "$source_url" "$plugin_root"; then
       exit 1
     fi
+
+    local plugin_path
+    plugin_path=$(get_plugin_path "$plugin_name")
 
     if [ -f "${plugin_path}/bin/post-plugin-add" ]; then
       (
@@ -122,10 +125,10 @@ plugin_update_command() {
       wait
     fi
   else
-    local plugin_path
-    plugin_path="$(get_plugin_path "$plugin_name")"
+    local plugin_root
+    plugin_root="$(get_plugin_root "$plugin_name")"
     check_if_plugin_exists "$plugin_name"
-    update_plugin "$plugin_name" "$plugin_path" "$gitref"
+    update_plugin "$plugin_name" "$plugin_root" "$gitref"
   fi
 }
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -138,11 +138,32 @@ version_not_installed_text() {
   printf "version %s is not installed for %s\\n" "$version" "$plugin_name"
 }
 
-get_plugin_path() {
+get_plugin_root() {
   if test -n "$1"; then
     printf "%s\\n" "$(asdf_data_dir)/plugins/$1"
   else
     printf "%s\\n" "$(asdf_data_dir)/plugins"
+  fi
+}
+
+get_plugin_path() {
+  local plugins_dir=
+  plugins_dir="$(asdf_data_dir)/plugins"
+
+  if test -n "$1"; then
+    local config_file=
+    config_file="$plugins_dir/$1/.asdf-plugin"
+    if [ -f "$config_file" ]; then
+      local plugin_directory=
+      plugin_directory=$(get_asdf_config_value_from_file "$config_file" plugin_directory)
+      if [ -n "$plugin_directory" ] && [ -d "$plugins_dir/$1/$plugin_directory" ]; then
+        printf "%s\\n" "$plugins_dir/$1/$plugin_directory"
+        return
+      fi
+    fi
+    printf "%s\\n" "$plugins_dir/$1"
+  else
+    printf "%s\\n" "$plugins_dir"
   fi
 }
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -151,14 +151,16 @@ get_plugin_path() {
   plugins_dir="$(asdf_data_dir)/plugins"
 
   if test -n "$1"; then
-    local config_file=
-    config_file="$plugins_dir/$1/.asdf-plugin"
-    if [ -f "$config_file" ]; then
-      local plugin_directory=
-      plugin_directory=$(get_asdf_config_value_from_file "$config_file" plugin_directory)
-      if [ -n "$plugin_directory" ] && [ -d "$plugins_dir/$1/$plugin_directory" ]; then
-        printf "%s\\n" "$plugins_dir/$1/$plugin_directory"
-        return
+    if [ "$(get_asdf_config_value "use_asdf_plugin_configuration")" = "yes" ]; then
+      local config_file=
+      config_file="$plugins_dir/$1/.asdf-plugin"
+      if [ -f "$config_file" ]; then
+        local plugin_directory=
+        plugin_directory=$(get_asdf_config_value_from_file "$config_file" plugin_directory)
+        if [ -n "$plugin_directory" ] && [ -d "$plugins_dir/$1/$plugin_directory" ]; then
+          printf "%s\\n" "$plugins_dir/$1/$plugin_directory"
+          return
+        fi
       fi
     fi
     printf "%s\\n" "$plugins_dir/$1"

--- a/test/fixtures/dummy_subdir_plugin/.asdf-plugin
+++ b/test/fixtures/dummy_subdir_plugin/.asdf-plugin
@@ -1,0 +1,1 @@
+plugin_directory = asdf-plugin

--- a/test/fixtures/dummy_subdir_plugin/LICENSE
+++ b/test/fixtures/dummy_subdir_plugin/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Akash Manohar J
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/test/fixtures/dummy_subdir_plugin/asdf-plugin/bin/download
+++ b/test/fixtures/dummy_subdir_plugin/asdf-plugin/bin/download
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+exit 0

--- a/test/fixtures/dummy_subdir_plugin/asdf-plugin/bin/get-version-from-legacy-file
+++ b/test/fixtures/dummy_subdir_plugin/asdf-plugin/bin/get-version-from-legacy-file
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+get_legacy_version() {
+  current_directory=$1
+  version_file="$current_directory/.dummy-version"
+
+  if [ -f "$version_file" ]; then
+    cat "$version_file"
+  fi
+}
+
+get_legacy_version "$1"

--- a/test/fixtures/dummy_subdir_plugin/asdf-plugin/bin/help.overview
+++ b/test/fixtures/dummy_subdir_plugin/asdf-plugin/bin/help.overview
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+echo "Dummy plugin documentation"
+echo
+echo "Dummy plugin is a plugin only used for unit tests"
+
+if [ -n "$ASDF_INSTALL_VERSION" ]; then
+  echo
+  echo "Details specific for version $ASDF_INSTALL_VERSION"
+fi

--- a/test/fixtures/dummy_subdir_plugin/asdf-plugin/bin/install
+++ b/test/fixtures/dummy_subdir_plugin/asdf-plugin/bin/install
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# We want certain versions to fail installation for various reasons in the tests
+check_dummy_versions() {
+  local bad_versions=" other-dummy "
+  if [[ "$bad_versions" == *" $ASDF_INSTALL_VERSION "* ]]; then
+    echo "Dummy couldn't install version: $ASDF_INSTALL_VERSION (on purpose)"
+    exit 1
+  fi
+}
+
+check_dummy_versions
+mkdir -p "$ASDF_INSTALL_PATH"
+env >"$ASDF_INSTALL_PATH/env"
+echo "$ASDF_INSTALL_VERSION" >"$ASDF_INSTALL_PATH/version"
+
+# create the dummy executable
+mkdir -p "$ASDF_INSTALL_PATH/bin"
+cat <<EOF >"$ASDF_INSTALL_PATH/bin/dummy"
+echo This is Dummy ${ASDF_INSTALL_VERSION}! \$2 \$1
+EOF
+chmod +x "$ASDF_INSTALL_PATH/bin/dummy"
+mkdir -p "$ASDF_INSTALL_PATH/bin/subdir"
+cat <<EOF >"$ASDF_INSTALL_PATH/bin/subdir/other_bin"
+echo This is Other Bin ${ASDF_INSTALL_VERSION}! \$2 \$1
+EOF
+chmod +x "$ASDF_INSTALL_PATH/bin/subdir/other_bin"

--- a/test/fixtures/dummy_subdir_plugin/asdf-plugin/bin/latest-stable
+++ b/test/fixtures/dummy_subdir_plugin/asdf-plugin/bin/latest-stable
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+get_latest_stable() {
+  query=$1
+
+  version_list=(1.0.0 1.1.0 2.0.0)
+  printf "%s\n" "${version_list[@]}" | grep -E "^\\s*$query" | tail -1
+}
+
+get_latest_stable "$1"

--- a/test/fixtures/dummy_subdir_plugin/asdf-plugin/bin/list-all
+++ b/test/fixtures/dummy_subdir_plugin/asdf-plugin/bin/list-all
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+versions_list=(1.0.0 1.1.0 2.0.0)
+echo "${versions_list[@]}"
+# Sending message to STD error to ensure that it is ignored
+echo "ignore this error" >&2

--- a/test/fixtures/dummy_subdir_plugin/asdf-plugin/bin/list-legacy-filenames
+++ b/test/fixtures/dummy_subdir_plugin/asdf-plugin/bin/list-legacy-filenames
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo ".dummy-version .dummyrc"

--- a/test/fixtures/dummy_subdir_plugin/asdf-plugin/bin/parse-legacy-file
+++ b/test/fixtures/dummy_subdir_plugin/asdf-plugin/bin/parse-legacy-file
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC2020
+tr <"$1" -d "dummy-"

--- a/test/fixtures/dummy_subdir_plugin/asdf-plugin/bin/post-plugin-add
+++ b/test/fixtures/dummy_subdir_plugin/asdf-plugin/bin/post-plugin-add
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "plugin add path=${ASDF_PLUGIN_PATH} source_url=${ASDF_PLUGIN_SOURCE_URL}"

--- a/test/fixtures/dummy_subdir_plugin/asdf-plugin/bin/post-plugin-update
+++ b/test/fixtures/dummy_subdir_plugin/asdf-plugin/bin/post-plugin-update
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "plugin updated path=${ASDF_PLUGIN_PATH} old git-ref=${ASDF_PLUGIN_PREV_REF} new git-ref=${ASDF_PLUGIN_POST_REF}"

--- a/test/fixtures/dummy_subdir_plugin/asdf-plugin/bin/pre-plugin-remove
+++ b/test/fixtures/dummy_subdir_plugin/asdf-plugin/bin/pre-plugin-remove
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "plugin-remove ${ASDF_PLUGIN_PATH}"

--- a/test/plugin_subdir.bats
+++ b/test/plugin_subdir.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+
+load test_helpers
+
+setup() {
+  setup_asdf_dir
+}
+
+teardown() {
+  clean_asdf_dir
+}
+
+@test "plugin_add install subdirectory plugin" {
+  install_mock_subdir_plugin "dummy-subdir"
+
+  run asdf plugin-list
+  # whitespace between 'elixir' and url is from printf %-15s %s format
+  [ "$output" = "dummy-subdir" ]
+}
+
+@test "plugin_remove command removes the subdirectory plugin directory" {
+  install_mock_subdir_plugin "dummy-subdir"
+
+  run asdf plugin-remove "dummy-subdir"
+  [ "$status" -eq 0 ]
+  [ ! -d "$ASDF_DIR/plugins/dummy-subdir" ]
+}
+
+@test "list_all_command lists available versions" {
+  install_mock_subdir_plugin "dummy-subdir"
+
+  run asdf list-all dummy-subdir
+  [ "$(echo -e "1.0.0\n1.1.0\n2.0.0")" == "$output" ]
+  [ "$status" -eq 0 ]
+}
+
+@test "install_command installs the correct version" {
+  install_mock_subdir_plugin "dummy-subdir"
+
+  run asdf install dummy-subdir 1.1.0
+  # whitespace between 'elixir' and url is from printf %-15s %s format
+  [ "$(cat "$ASDF_DIR/installs/dummy-subdir/1.1.0/version")" = "1.1.0" ]
+}
+
+@test "list_command should list plugins with installed versions" {
+  install_mock_subdir_plugin "dummy-subdir"
+
+  run asdf install dummy-subdir 1.0.0
+  run asdf install dummy-subdir 1.1.0
+  run asdf list
+  [[ "$output" == "$(echo -e "dummy-subdir\n  1.0.0\n  1.1.0")"* ]]
+  [ "$status" -eq 0 ]
+}
+
+@test "[latest_command - dummy_plugin] shows latest stable version" {
+  install_mock_subdir_plugin "dummy-subdir"
+
+  run asdf latest "dummy-subdir"
+  [ "2.0.0" == "$output" ]
+  [ "$status" -eq 0 ]
+}
+
+@test "plugin_test_command works with no options provided for subdirectory plugin" {
+  install_mock_subdir_plugin_repo dummy-subdir
+
+  run asdf plugin-test dummy-subdir "${BASE_DIR}/repo-dummy-subdir"
+  echo "status = ${status}"
+  echo "output = ${output}"
+  [ "$status" -eq 0 ]
+}
+
+@test "asdf plugin-update should pull latest default branch (refs/remotes/origin/HEAD) for subdirectory plugin" {
+  install_mock_subdir_plugin_repo dummy-subdir
+  run asdf plugin add "dummy-subdir" "${BASE_DIR}/repo-dummy-subdir"
+
+  run asdf plugin-update dummy-subdir
+  repo_head="$(git --git-dir "$ASDF_DIR/plugins/dummy-subdir/.git" --work-tree "$ASDF_DIR/plugins/dummy-subdir" rev-parse --abbrev-ref HEAD)"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "Updating dummy-subdir to master"* ]]
+  [ "$repo_head" = "master" ]
+}

--- a/test/plugin_subdir.bats
+++ b/test/plugin_subdir.bats
@@ -4,6 +4,7 @@ load test_helpers
 
 setup() {
   setup_asdf_dir
+  echo 'use_asdf_plugin_configuration = yes' >$HOME/.asdfrc
 }
 
 teardown() {

--- a/test/test_helpers.bash
+++ b/test/test_helpers.bash
@@ -43,10 +43,27 @@ install_mock_broken_plugin() {
   cp -r "$BATS_TEST_DIRNAME/fixtures/dummy_broken_plugin" "$location/plugins/$plugin_name"
 }
 
+install_mock_subdir_plugin() {
+  local plugin_name=$1
+  local location="${2:-$ASDF_DIR}"
+  cp -r "$BATS_TEST_DIRNAME/fixtures/dummy_subdir_plugin" "$location/plugins/$plugin_name"
+}
+
 install_mock_plugin_repo() {
   local plugin_name=$1
   local location="${BASE_DIR}/repo-${plugin_name}"
   cp -r "$BATS_TEST_DIRNAME/fixtures/dummy_plugin" "${location}"
+  git -C "${location}" init -q
+  git -C "${location}" config user.name "Test"
+  git -C "${location}" config user.email "test@example.com"
+  git -C "${location}" add -A
+  git -C "${location}" commit -q -m "asdf ${plugin_name} plugin"
+}
+
+install_mock_subdir_plugin_repo() {
+  local plugin_name=$1
+  local location="${BASE_DIR}/repo-${plugin_name}"
+  cp -r "$BATS_TEST_DIRNAME/fixtures/dummy_subdir_plugin" "${location}"
   git -C "${location}" init -q
   git -C "${location}" config user.name "Test"
   git -C "${location}" config user.email "test@example.com"


### PR DESCRIPTION
# Summary

I would like to be able to install the tools I am creating with asdf.

I also want to provide the tool itself and the asdf plugin in the same git repository to simplify source code management.
However, since `bin` and `lib` are also used for other purposes, I would like to put the asdf plugin in a separate directory to avoid confusion.

I have tried to implement this by placing a configuration file `.asdf-plugin` in the root of the repository and writing the path to the asdf plugin in it.

Of course, if the `.asdf-plugin` file does not exist, the behavior will be the same as before.

For example, to place the script in `contrib/asdf`, I would configure it as follows:

.asdf-plugin
```
plugin_directory = contrib/asdf
```

```bash
$ ls contrib/asdf/bin
list-all
install
download
```

