### PR TITLE
fix: silence plugin missing lib/commands/ error

### DIFF
--- a/bin/asdf
+++ b/bin/asdf
@@ -7,6 +7,10 @@ find_cmd() {
   local cmd_dir="$1"
   shift
 
+  if [ ! -d "$cmd_dir" ]; then
+    return
+  fi
+
   local cmd_name
   local args_offset="$#"
   cmd_name="command-$(tr ' ' '-' <<<"${@:1:${args_offset}}").bash"


### PR DESCRIPTION
# Summary

When runnning `asdf`, plugins that do not have lib/commands dirs result in a `find` error that is output.

Based on the plugins I have installed, this is not a requirement for functionality and/or a new convention not yet adopted globally.

```
$ asdf
...
PLUGIN nodejs
  asdf nodejs nodebuild
  asdf nodejs update nodebuild
find: /Users/mcor/.asdf/plugins/postgres/lib/commands: No such file or directory
find: /Users/mcor/.asdf/plugins/python/lib/commands: No such file or directory
find: /Users/mcor/.asdf/plugins/ruby/lib/commands: No such file or directory
find: /Users/mcor/.asdf/plugins/shellcheck/lib/commands: No such file or directory
find: /Users/mcor/.asdf/plugins/shfmt/lib/commands: No such file or directory
find: /Users/mcor/.asdf/plugins/terraform/lib/commands: No such file or directory
```

The fix here is to return in the `find_cmd()` function if the lib/comands dir does not exist. 

Not sure where a test would fit in here looking at the test suite, but can add one if deemed necessary.

This is really just to not get "warnings" and really just a cleanup (assuming nothing else breaks).