### PR TITLE
fix: instead /tmp, use TMPDIR if defined

### DIFF
--- a/lib/commands/reshim.bash
+++ b/lib/commands/reshim.bash
@@ -145,12 +145,15 @@ remove_obsolete_shims() {
   local formatted_shims
   local formatted_exec_names
 
+  local temp_dir
+  temp_dir=${TMPDIR:-/tmp}
+
   # comm only takes to files, so we write this data to temp files so we can
   # pass it to comm.
-  formatted_shims=$(mktemp /tmp/asdf-command-reshim-formatted-shims.XXXXXX)
+  formatted_shims=$(mktemp $temp_dir/asdf-command-reshim-formatted-shims.XXXXXX)
   printf "%s\\n" "$shims" >"$formatted_shims"
 
-  formatted_exec_names=$(mktemp /tmp/asdf-command-reshim-formatted-exec-names.XXXXXX)
+  formatted_exec_names=$(mktemp $temp_dir/asdf-command-reshim-formatted-exec-names.XXXXXX)
   printf "%s\\n" "$exec_names" >"$formatted_exec_names"
 
   obsolete_shims=$(comm -23 "$formatted_shims" "$formatted_exec_names")

--- a/lib/functions/versions.bash
+++ b/lib/functions/versions.bash
@@ -74,9 +74,12 @@ list_all_command() {
   plugin_path=$(get_plugin_path "$plugin_name")
   check_if_plugin_exists "$plugin_name"
 
+  local temp_dir
+  temp_dir=${TMPDIR:-/tmp}
+
   # Capture return code to allow error handling
-  std_out_file="$(mktemp "/tmp/asdf-command-list-all-${plugin_name}.stdout.XXXXXX")"
-  std_err_file="$(mktemp "/tmp/asdf-command-list-all-${plugin_name}.stderr.XXXXXX")"
+  std_out_file="$(mktemp "$temp_dir/asdf-command-list-all-${plugin_name}.stdout.XXXXXX")"
+  std_err_file="$(mktemp "$temp_dir/asdf-command-list-all-${plugin_name}.stderr.XXXXXX")"
   return_code=0 && "${plugin_path}/bin/list-all" >"$std_out_file" 2>"$std_err_file" || return_code=$?
 
   if [[ $return_code -ne 0 ]]; then


### PR DESCRIPTION
# Summary

This PR will allow to asdf to work in environments where the tmp dir is not /tmp and it is defined in the $TMPDIR variable. ie: [Termux](https://github.com/termux/termux-app).
