### PR TITLE
fix: asdf latest --all report wrong runtimes (#1180)

### DIFF
--- a/test/fixtures/dummy_distro_plugin/bin/download
+++ b/test/fixtures/dummy_distro_plugin/bin/download
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+exit 0

--- a/test/fixtures/dummy_distro_plugin/bin/install
+++ b/test/fixtures/dummy_distro_plugin/bin/install
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# We want certain versions to fail installation for various reasons in the tests
+check_dummy_versions() {
+  local bad_versions=" other-dummy "
+  if [[ "$bad_versions" == *" $ASDF_INSTALL_VERSION "* ]]; then
+    echo "Dummy couldn't install version: $ASDF_INSTALL_VERSION (on purpose)"
+    exit 1
+  fi
+}
+
+check_dummy_versions
+mkdir -p "$ASDF_INSTALL_PATH"
+env >"$ASDF_INSTALL_PATH/env"
+echo "$ASDF_INSTALL_VERSION" >"$ASDF_INSTALL_PATH/version"
+
+# create the dummy executable
+mkdir -p "$ASDF_INSTALL_PATH/bin"
+cat <<EOF >"$ASDF_INSTALL_PATH/bin/dummy"
+echo This is Dummy ${ASDF_INSTALL_VERSION}! \$2 \$1
+EOF
+chmod +x "$ASDF_INSTALL_PATH/bin/dummy"
+mkdir -p "$ASDF_INSTALL_PATH/bin/subdir"
+cat <<EOF >"$ASDF_INSTALL_PATH/bin/subdir/other_bin"
+echo This is Other Bin ${ASDF_INSTALL_VERSION}! \$2 \$1
+EOF
+chmod +x "$ASDF_INSTALL_PATH/bin/subdir/other_bin"

--- a/test/fixtures/dummy_distro_plugin/bin/list-all
+++ b/test/fixtures/dummy_distro_plugin/bin/list-all
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-versions_list=(acme-1.0.0 acme-1.1.0 distro-2.0.0)
+versions_list=(1.0 2.0 dist-1.0.0 dist-1.1.0 other-dist-1.0 other-dist-2.0-src rc1 rc1-beta)
 echo "${versions_list[@]}"
 # Sending message to STD error to ensure that it is ignored
 echo "ignore this error" >&2

--- a/test/fixtures/dummy_distro_plugin/bin/list-all
+++ b/test/fixtures/dummy_distro_plugin/bin/list-all
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+versions_list=(acme-1.0.0 acme-1.1.0 distro-2.0.0)
+echo "${versions_list[@]}"
+# Sending message to STD error to ensure that it is ignored
+echo "ignore this error" >&2

--- a/test/latest_command.bats
+++ b/test/latest_command.bats
@@ -115,15 +115,19 @@ teardown() {
 @test "[latest_command - all plugins] shows the latest stable version of all plugins" {
   run asdf install dummy 2.0.0
   run asdf install legacy-dummy 4.0.0
-  run asdf install distro-dummy acme-1.0.0
-  run asdf install distro-dummy distro-2.0.0
+  run asdf install distro-dummy 1.0
+  run asdf install distro-dummy dist-1.0.0
+  run asdf install distro-dummy other-dist-1.0
+  run asdf install distro-dummy rc1
   run asdf latest --all
 
   echo "status: $status"
   echo "output: $output"
 
-  [ "$(printf "%s\\t%s\\t%s\\n" "distro-dummy" "acme-1.1.0" "missing"
-       printf "%s\\t%s\\t%s\\n" "distro-dummy" "distro-2.0.0" "installed"
+  [ "$(printf "%s\\t%s\\t%s\\n" "distro-dummy" "2.0" "missing"
+       printf "%s\\t%s\\t%s\\n" "distro-dummy" "dist-1.1.0" "missing"
+       printf "%s\\t%s\\t%s\\n" "distro-dummy" "other-dist-2.0-src" "missing"
+       printf "%s\\t%s\\t%s\\n" "distro-dummy" "rc1" "installed"
        printf "%s\\t%s\\t%s\\n" "dummy" "2.0.0" "installed"
        printf "%s\\t%s\\t%s\\n" "legacy-dummy" "5.1.0" "missing")" == "$output" ]
   [ "$status" -eq 0 ]
@@ -135,7 +139,7 @@ teardown() {
   echo "status: $status"
   echo "output: $output"
 
-  [ "$(printf "%s\\t%s\\t%s\\n" "distro-dummy" "distro-2.0.0" "missing"
+  [ "$(printf "%s\\t%s\\t%s\\n" "distro-dummy" "2.0" "missing"
        printf "%s\\t%s\\t%s\\n" "dummy" "2.0.0" "missing"
        printf "%s\\t%s\\t%s\\n" "legacy-dummy" "5.1.0" "missing")" == "$output" ]
   [ "$status" -eq 0 ]

--- a/test/latest_command.bats
+++ b/test/latest_command.bats
@@ -6,6 +6,7 @@ setup() {
   setup_asdf_dir
   install_dummy_plugin
   install_dummy_legacy_plugin
+  install_dummy_distro_plugin
 }
 
 teardown() {
@@ -17,18 +18,30 @@ teardown() {
 ####################################################
 @test "[latest_command - dummy_plugin] shows latest stable version" {
   run asdf latest dummy
+
+  echo "status: $status"
+  echo "output: $output"
+
   [ "$(echo "2.0.0")" == "$output" ]
   [ "$status" -eq 0 ]
 }
 
 @test "[latest_command - dummy_plugin] shows latest stable version that matches the given string" {
   run asdf latest dummy 1
+
+  echo "status: $status"
+  echo "output: $output"
+
   [ "$(echo "1.1.0")" == "$output" ]
   [ "$status" -eq 0 ]
 }
 
 @test "[latest_command - dummy_plugin] an invalid version should return an error" {
   run asdf latest dummy 3
+
+  echo "status: $status"
+  echo "output: $output"
+
   [ "$(echo "No compatible versions available (dummy 3)")" == "$output" ]
   [ "$status" -eq 1 ]
 }
@@ -38,48 +51,60 @@ teardown() {
 ####################################################
 @test "[latest_command - dummy_legacy_plugin] shows latest stable version" {
   run asdf latest legacy-dummy
+
   echo "status: $status"
   echo "output: $output"
+
   [ "$(echo "5.1.0")" == "$output" ]
   [ "$status" -eq 0 ]
 }
 
 @test "[latest_command - dummy_legacy_plugin] shows latest stable version that matches the given string" {
   run asdf latest legacy-dummy 1
+
   echo "status: $status"
   echo "output: $output"
+
   [ "$(echo "1.1.0")" == "$output" ]
   [ "$status" -eq 0 ]
 }
 
 @test "[latest_command - dummy_legacy_plugin] No stable version should return an error" {
   run asdf latest legacy-dummy 3
+
   echo "status: $status"
   echo "output: $output"
+
   [ -z "$output" ]
   [ "$status" -eq 1 ]
 }
 
 @test "[latest_command - dummy_legacy_plugin] do not show latest unstable version that matches the given string" {
   run asdf latest legacy-dummy 4
+
   echo "status: $status"
   echo "output: $output"
+
   [ "$(echo "4.0.0")" == "$output" ]
   [ "$status" -eq 0 ]
 }
 
 @test "[latest_command - dummy_legacy_plugin] do not show latest unstable version with capital characters that matches the given string" {
   run asdf latest legacy-dummy 5
+
   echo "status: $status"
   echo "output: $output"
+
   [ "$(echo "5.1.0")" == "$output" ]
   [ "$status" -eq 0 ]
 }
 
 @test "[latest_command - dummy_legacy_plugin] an invalid version should return an error" {
   run asdf latest legacy-dummy 6
+
   echo "status: $status"
   echo "output: $output"
+
   [ "$(echo "No compatible versions available (legacy-dummy 6)")" == "$output" ]
   [ "$status" -eq 1 ]
 }
@@ -90,14 +115,28 @@ teardown() {
 @test "[latest_command - all plugins] shows the latest stable version of all plugins" {
   run asdf install dummy 2.0.0
   run asdf install legacy-dummy 4.0.0
+  run asdf install distro-dummy acme-1.0.0
+  run asdf install distro-dummy distro-2.0.0
   run asdf latest --all
-  echo "output $output"
-  [ "$(echo -e "dummy\t2.0.0\tinstalled\nlegacy-dummy\t5.1.0\tmissing\n")" == "$output" ]
+
+  echo "status: $status"
+  echo "output: $output"
+
+  [ "$(printf "%s\\t%s\\t%s\\n" "distro-dummy" "acme-1.1.0" "missing"
+       printf "%s\\t%s\\t%s\\n" "distro-dummy" "distro-2.0.0" "installed"
+       printf "%s\\t%s\\t%s\\n" "dummy" "2.0.0" "installed"
+       printf "%s\\t%s\\t%s\\n" "legacy-dummy" "5.1.0" "missing")" == "$output" ]
   [ "$status" -eq 0 ]
 }
 
 @test "[latest_command - all plugins] not installed plugin should return missing" {
   run asdf latest --all
-  [ "$(echo -e "dummy\t2.0.0\tmissing\nlegacy-dummy\t5.1.0\tmissing\n")" == "$output" ]
+
+  echo "status: $status"
+  echo "output: $output"
+
+  [ "$(printf "%s\\t%s\\t%s\\n" "distro-dummy" "distro-2.0.0" "missing"
+       printf "%s\\t%s\\t%s\\n" "dummy" "2.0.0" "missing"
+       printf "%s\\t%s\\t%s\\n" "legacy-dummy" "5.1.0" "missing")" == "$output" ]
   [ "$status" -eq 0 ]
 }

--- a/test/test_helpers.bash
+++ b/test/test_helpers.bash
@@ -37,6 +37,12 @@ install_mock_legacy_plugin() {
   cp -r "$BATS_TEST_DIRNAME/fixtures/dummy_legacy_plugin" "$location/plugins/$plugin_name"
 }
 
+install_mock_distro_plugin() {
+  local plugin_name=$1
+  local location="${2:-$ASDF_DIR}"
+  cp -r "$BATS_TEST_DIRNAME/fixtures/dummy_distro_plugin" "$location/plugins/$plugin_name"
+}
+
 install_mock_broken_plugin() {
   local plugin_name=$1
   local location="${2:-$ASDF_DIR}"
@@ -69,6 +75,9 @@ install_dummy_legacy_plugin() {
   install_mock_legacy_plugin "legacy-dummy"
 }
 
+install_dummy_distro_plugin() {
+  install_mock_distro_plugin "distro-dummy"
+}
 install_dummy_broken_plugin() {
   install_mock_broken_plugin "dummy-broken"
 }


### PR DESCRIPTION
# Summary

Revisites the logic for command `latest --all` which returns wrong version numbers if the plugin uses multiple distros/variants (e.g. Java, Python, Ruby, ...).

Instead of falling back to use the latest available version (`tail -1`) from all the available versions via `list all`, the code tries to list specific versions for installed distros. This is done by getting a distinct list of installed distros assuming the format <distro>-<version> and then getting the latest version for that specific distro via additional version query. If a plugin has no installed versions, the old behaviour showing the latest from all available versions is used.

Additionally if multiple distros are installed (e.g. Java; opendjdk, zulu) the output lists each installed one with its latest version and status.

```shell
  ❯ asdf list
direnv
  2.31.0
golang
  1.17
  1.18
java
  openjdk-11.0.2
  openjdk-17.0.2
  openjdk-18
  zulu-17.32.13
nodejs
  16.14.2
  lts
ruby
  No versions installed

  ❯ asdf latest --all
direnv              2.31.0                        installed
golang              1.18                          installed
java                openjdk-18                    installed
java                zulu-18.28.13                 missing
nodejs              lts                           installed
ruby                truffleruby+graalvm-22.0.0.2  missing
```


Fixes: #1180

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->
