### PR TITLE
fix: Highlight or mark installed versions when running asdf list all <name>

### DIFF
--- a/lib/functions/versions.bash
+++ b/lib/functions/versions.bash
@@ -106,8 +106,16 @@ list_all_command() {
 
   IFS=' ' read -r -a versions_list <<<"$output"
 
+  mapfile -t installed_versions < <(list_installed_versions "$plugin_name")
+
   for version in "${versions_list[@]}"; do
-    printf "%s\\n" "${version}"
+    # exact match version
+    # shellcheck disable=SC2076
+    if [[ " ${installed_versions[*]} " =~ " ${version} " ]]; then
+      printf "%s\tinstalled\\n" "${version}"
+    else
+      printf "%s\\n" "${version}"
+    fi
   done
 
   # Remove temp files if they still exist
@@ -141,16 +149,18 @@ latest_command() {
     fi
   else
     # pattern from xxenv-latest (https://github.com/momo-lab/xxenv-latest)
-    versions=$(list_all_command "$plugin_name" "$query" |
+    versions=$(list_all_versions "$plugin_name" "$query" |
       grep -ivE "(^Available versions:|-src|-dev|-latest|-stm|[-\\.]rc|-alpha|-beta|[-\\.]pre|-next|(a|b|c)[0-9]+|snapshot|master)" |
       sed 's/^[[:space:]]\+//' |
       tail -1)
+
     if [ -z "${versions}" ]; then
+      display_error "No compatible versions available ($plugin_name $query)"
       exit 1
     fi
   fi
 
-  printf "%s\\n" "$versions"
+  printf "%s\n" "$versions"
 }
 
 latest_all() {
@@ -172,7 +182,7 @@ latest_all() {
         fi
       else
         # pattern from xxenv-latest (https://github.com/momo-lab/xxenv-latest)
-        version=$(list_all_command "$plugin_name" |
+        version=$(list_all_versions "$plugin_name" |
           grep -ivE "(^Available version:|-src|-dev|-latest|-stm|[-\\.]rc|-alpha|-beta|[-\\.]pre|-next|(a|b|c)[0-9]+|snapshot|master)" |
           sed 's/^[[:space:]]\+//' |
           tail -1)

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -86,6 +86,43 @@ get_download_path() {
   fi
 }
 
+list_all_versions() {
+  local plugin_name=$1
+  local query=$2
+  local plugin_path
+  local std_out_file
+  local std_err_file
+  local output
+  plugin_path=$(get_plugin_path "$plugin_name")
+  check_if_plugin_exists "$plugin_name"
+
+  # Capture return code to allow error handling
+  std_out_file="$(mktemp "/tmp/asdf-command-list-all-${plugin_name}.stdout.XXXXXX")"
+  std_err_file="$(mktemp "/tmp/asdf-command-list-all-${plugin_name}.stderr.XXXXXX")"
+  return_code=0 && "${plugin_path}/bin/list-all" >"$std_out_file" 2>"$std_err_file" || return_code=$?
+
+  if [[ $return_code -ne 0 ]]; then
+    # Printing all output to allow plugin to handle error formatting
+    printf "Plugin %s's list-all callback script failed with output:\\n" "${plugin_name}"
+    printf "%s\\n" "$(cat "$std_err_file")"
+    printf "%s\\n" "$(cat "$std_out_file")"
+    rm "$std_out_file" "$std_err_file"
+    exit 1
+  fi
+
+  if [[ $query ]]; then
+    # shellcheck disable=SC2046
+    printf "%s\\n" $(tr ' ' '\n' <"$std_out_file" |
+      grep -E "^\\s*$query" |
+      tr '\n' ' ')
+  else
+    printf "%s\\n" "$(tr ' ' '\n' <"$std_out_file")"
+  fi
+
+  # Remove temp files if they still exist
+  rm "$std_out_file" "$std_err_file" || true
+}
+
 list_installed_versions() {
   local plugin_name=$1
   local plugin_path

--- a/test/latest_command.bats
+++ b/test/latest_command.bats
@@ -56,7 +56,7 @@ teardown() {
   run asdf latest legacy-dummy 3
   echo "status: $status"
   echo "output: $output"
-  [ -z "$output" ]
+  [ "$(echo "No compatible versions available (legacy-dummy 3)")" == "$output" ]
   [ "$status" -eq 1 ]
 }
 

--- a/test/list_command.bats
+++ b/test/list_command.bats
@@ -66,6 +66,13 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
+@test "list_all_command lists available versions with installed status" {
+  run asdf install dummy 1.0.0
+  run asdf list-all dummy
+  [ "$(echo -e "1.0.0\tinstalled\n1.1.0\n2.0.0")" == "$output" ]
+  [ "$status" -eq 0 ]
+}
+
 @test "list_all_command with version filters available versions" {
   run asdf list-all dummy 1
   [ "$(echo -e "1.0.0\n1.1.0")" == "$output" ]
@@ -80,6 +87,7 @@ teardown() {
 
 @test "list_all_command fails when list-all script exits with non-zero code" {
   run asdf list-all dummy-broken
+  echo $status
   echo $output
   [ "$status" -eq 1 ]
   [[ "$output" == "Plugin dummy-broken's list-all callback script failed with output:"* ]]


### PR DESCRIPTION
# Summary

Color highlight installed versions of the `list-all` command.

> Note: It seems asdf does not use colors anywhere, hence we might decide to use another indicator (e.g. `▶ `). Simply appending `(installed)` is visually not distinctive enough IMO. If an icon like indicator is used we might have to think about consistent output formatting. 

Uses the internal function `list_installed_versions` to get all installed versions and adds a color highlight during output iteration.

Since the command `latest [--all]` uses the command `list-all` as fallback to get versions, any output format change breaks this functionality. Hence i decided to create an (internal) function `list_all_versions` which can be used by both commands. 

The change lead the test `[latest_command - dummy_legacy_plugin] No stable version should return an error` to fail which i could not figure out why. It's expecting no output even though the code actually outputs an error `"No compatible versions available ($plugin_name $query)"`. For now i came to the conclusion that maybe previous behaviour might have been faulty.


Fixes: #1152 
