### PR TITLE
Update elvish to 0.18.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,11 +38,11 @@ jobs:
           sudo apt-get -y install fish curl
 
           # Download elvish binary and add to path
-          curl https://dl.elv.sh/linux-amd64/elvish-v0.17.0.tar.gz -o elvish-v0.17.0.tar.gz
-          tar xzf elvish-v0.17.0.tar.gz
-          rm elvish-v0.17.0.tar.gz
+          curl https://dl.elv.sh/linux-amd64/elvish-v0.18.0.tar.gz -o elvish-v0.18.0.tar.gz
+          tar xzf elvish-v0.18.0.tar.gz
+          rm elvish-v0.18.0.tar.gz
           mkdir -p "$HOME/bin"
-          mv elvish-v0.17.0 "$HOME/bin/elvish"
+          mv elvish-v0.18.0 "$HOME/bin/elvish"
           echo "$HOME/bin" >>"$GITHUB_PATH"
 
       - name: Install bats

--- a/asdf.elv
+++ b/asdf.elv
@@ -59,11 +59,11 @@ fn ls-executables {
         if (test -x $p) {
           path:base $p
         }
-      } except {
+      } catch {
         # don't fail if permission denied
       }
     }
-  } except {
+  } catch {
     # silence default non-zero exit status
   }
 }


### PR DESCRIPTION
# Summary

This PR replaces the newly deprecated 'except' with 'catch' to fix deprecation warnings in elvish 0.18.

This is a breaking change, as it drops support for elvish <0.18

Fixes: N/A

## Other Information

Upstream change: elves/elvish#1497
