### PR TITLE
fix: local plugin in then clause too

### DIFF
--- a/lib/commands/command-current.bash
+++ b/lib/commands/command-current.bash
@@ -44,6 +44,7 @@ plugin_current_command() {
 current_command() {
   local terminal_format="%-15s %-15s %-10s\\n"
   local exit_status=0
+  local plugin
 
   # printf "$terminal_format" "PLUGIN" "VERSION" "SET BY CONFIG" # disbale this until we release headings across the board
   if [ $# -eq 0 ]; then
@@ -51,7 +52,7 @@ current_command() {
       plugin_current_command "$plugin" "$terminal_format"
     done
   else
-    local plugin=$1
+    plugin=$1
     plugin_current_command "$plugin" "$terminal_format"
     exit_status="$?"
   fi


### PR DESCRIPTION
Replaces https://github.com/asdf-vm/asdf/pull/1202

# Summary

I think `plugin` variable should be `local` not only in `else` clause but `then` clause too.
