### PR TITLE
feat: plugin-add command can take git branch name.

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -1,64 +1,66 @@
 MANAGE PLUGINS
-asdf plugin add <name> [<git-url>]      Add a plugin from the plugin repo OR,
-                                        add a Git repo as a plugin by
-                                        specifying the name and repo url
-asdf plugin list [--urls] [--refs]      List installed plugins. Optionally show
-                                        git urls and git-ref
-asdf plugin list all                    List plugins registered on asdf-plugins
-                                        repository with URLs
-asdf plugin remove <name>               Remove plugin and package versions
-asdf plugin update <name> [<git-ref>]   Update a plugin to latest commit on
-                                        default branch or a particular git-ref
-asdf plugin update --all                Update all plugins to latest commit on
-                                        default branch
+asdf plugin add <name> [<git-url>] [<git-ref>]  Add a plugin from the plugin repo OR,
+                                                add a Git repo as a plugin by
+                                                specifying the name and repo url.
+                                                It's also possible to specify a particular
+                                                branch/tag by using the git-ref argument.
+asdf plugin list [--urls] [--refs]              List installed plugins. Optionally show
+                                                git urls and git-ref
+asdf plugin list all                            List plugins registered on asdf-plugins
+                                                repository with URLs
+asdf plugin remove <name>                       Remove plugin and package versions
+asdf plugin update <name> [<git-ref>]           Update a plugin to latest commit on
+                                                default branch or a particular git-ref
+asdf plugin update --all                        Update all plugins to latest commit on
+                                                default branch
 
 
 MANAGE PACKAGES
-asdf install                            Install all the package versions listed
-                                        in the .tool-versions file
-asdf install <name>                     Install one tool at the version
-                                        specified in the .tool-versions file
-asdf install <name> <version>           Install a specific version of a package
-asdf install <name> latest[:<version>]  Install the latest stable version of a
-                                        package, or with optional version,
-                                        install the latest stable version that
-                                        begins with the given string
-asdf uninstall <name> <version>         Remove a specific version of a package
-asdf current                            Display current version set or being
-                                        used for all packages
-asdf current <name>                     Display current version set or being
-                                        used for package
-asdf where <name> [<version>]           Display install path for an installed
-                                        or current version
-asdf which <command>                    Display the path to an executable
-asdf local <name> <version>             Set the package local version
-asdf local <name> latest[:<version>]    Set the package local version to the
-                                        latest provided version
-asdf global <name> <version>            Set the package global version
-asdf global <name> latest[:<version>]   Set the package global version to the
-                                        latest provided version
-asdf shell <name> <version>             Set the package version to
-                                        `ASDF_${LANG}_VERSION` in the current shell
-asdf latest <name> [<version>]          Show latest stable version of a package
-asdf latest --all                       Show latest stable version of all the
-                                        packages and if they are installed
-asdf list <name> [version]              List installed versions of a package and
-                                        optionally filter the versions
-asdf list all <name> [<version>]        List all versions of a package and
-                                        optionally filter the returned versions
-asdf help <name> [<version>]            Output documentation for plugin and tool
+asdf install                                    Install all the package versions listed
+                                                in the .tool-versions file
+asdf install <name>                             Install one tool at the version
+                                                specified in the .tool-versions file
+asdf install <name> <version>                   Install a specific version of a package
+asdf install <name> latest[:<version>]          Install the latest stable version of a
+                                                package, or with optional version,
+                                                install the latest stable version that
+                                                begins with the given string
+asdf uninstall <name> <version>                 Remove a specific version of a package
+asdf current                                    Display current version set or being
+                                                used for all packages
+asdf current <name>                             Display current version set or being
+                                                used for package
+asdf where <name> [<version>]                   Display install path for an installed
+                                                or current version
+asdf which <command>                            Display the path to an executable
+asdf local <name> <version>                     Set the package local version
+asdf local <name> latest[:<version>]            Set the package local version to the
+                                                latest provided version
+asdf global <name> <version>                    Set the package global version
+asdf global <name> latest[:<version>]           Set the package global version to the
+                                                latest provided version
+asdf shell <name> <version>                     Set the package version to
+                                                `ASDF_${LANG}_VERSION` in the current shell
+asdf latest <name> [<version>]                  Show latest stable version of a package
+asdf latest --all                               Show latest stable version of all the
+                                                packages and if they are installed
+asdf list <name> [version]                      List installed versions of a package and
+                                                optionally filter the versions
+asdf list all <name> [<version>]                List all versions of a package and
+                                                optionally filter the returned versions
+asdf help <name> [<version>]                    Output documentation for plugin and tool
 
 
 UTILS
-asdf exec <command> [args...]           Executes the command shim for current version
-asdf env <command> [util]               Runs util (default: `env`) inside the
-                                        environment used for command shim execution.
-asdf info                               Print OS, Shell and ASDF debug information.
-asdf reshim <name> <version>            Recreate shims for version of a package
-asdf shim-versions <command>            List the plugins and versions that
-                                        provide a command
-asdf update                             Update asdf to the latest stable release
-asdf update --head                      Update asdf to the latest on the master branch
+asdf exec <command> [args...]                   Executes the command shim for current version
+asdf env <command> [util]                       Runs util (default: `env`) inside the
+                                                environment used for command shim execution.
+asdf info                                       Print OS, Shell and ASDF debug information.
+asdf reshim <name> <version>                    Recreate shims for version of a package
+asdf shim-versions <command>                    List the plugins and versions that
+                                                provide a command
+asdf update                                     Update asdf to the latest stable release
+asdf update --head                              Update asdf to the latest on the master branch
 
 RESOURCES
 GitHub: https://github.com/asdf-vm/asdf

--- a/lib/commands/command-plugin-add.bash
+++ b/lib/commands/command-plugin-add.bash
@@ -1,8 +1,8 @@
 # -*- sh -*-
 
 plugin_add_command() {
-  if [[ $# -lt 1 || $# -gt 2 ]]; then
-    display_error "usage: asdf plugin add <name> [<git-url>]"
+  if [[ $# -lt 1 || $# -gt 3 ]]; then
+    display_error "usage: asdf plugin add <name> [<git-url>] [<git-ref>]"
     exit 1
   fi
 
@@ -26,6 +26,8 @@ plugin_add_command() {
     exit 1
   fi
 
+  local git_ref="$3"
+
   local plugin_path
   plugin_path=$(get_plugin_path "$plugin_name")
 
@@ -38,7 +40,13 @@ plugin_add_command() {
     asdf_run_hook "pre_asdf_plugin_add" "$plugin_name"
     asdf_run_hook "pre_asdf_plugin_add_${plugin_name}"
 
-    if ! git clone -q "$source_url" "$plugin_path"; then
+    declare -a git_clone_opts
+    git_clone_opts+=("-q")
+    if [ -n "$git_ref" ]; then
+      git_clone_opts+=("-b" "$git_ref")
+    fi
+
+    if ! git clone "${git_clone_opts[@]}" "$source_url" "$plugin_path"; then
       exit 1
     fi
 

--- a/test/plugin_add_command.bats
+++ b/test/plugin_add_command.bats
@@ -52,6 +52,20 @@ teardown() {
   [ "$output" = "dummy" ]
 }
 
+@test "plugin_add command with URL and git-ref specified adds a plugin at branch" {
+  install_mock_plugin_repo "dummy" "develop"
+
+  run asdf plugin add "dummy" "${BASE_DIR}/repo-dummy" "develop"
+  [ "$status" -eq 0 ]
+
+  run asdf plugin-list
+  [ "$output" = "dummy" ]
+
+ # Make sure asdf info reports dummy plugin on develop branch
+  run asdf info
+  echo "$output" | grep dummy | grep develop
+}
+
 @test "plugin_add command with URL specified run twice returns error second time" {
   install_mock_plugin_repo "dummy"
 

--- a/test/test_helpers.bash
+++ b/test/test_helpers.bash
@@ -45,9 +45,10 @@ install_mock_broken_plugin() {
 
 install_mock_plugin_repo() {
   local plugin_name=$1
+  local branch_name="${2:-master}"
   local location="${BASE_DIR}/repo-${plugin_name}"
   cp -r "$BATS_TEST_DIRNAME/fixtures/dummy_plugin" "${location}"
-  git -C "${location}" init -q
+  git -C "${location}" init -q -b "$branch_name"
   git -C "${location}" config user.name "Test"
   git -C "${location}" config user.email "test@example.com"
   git -C "${location}" add -A


### PR DESCRIPTION
## Summary

Previously it was only possible to clone plugin repos on their default branch.
This pull-request allows the `plugin-add` command to take an aditional
argument for specifying a git-ref used for `git clone`.

Note: The `plugin-update` command already was able to take a `git-ref`,
but this feature eliminates the need of doing `plugin-add` and immediatly
`plugin-update` just for setting the git-ref to use.

## Motivation

Sometimes it's convenient to specify another plugin-repo branch or release-tag,
instead of using the repos' default branch.

For example, if a plugin becomes unstable on its default branch because
a bug was introduced, or if the fix is only available at an experimental
branch, people might want to try those changes.

Also, some advanced plugins, like
[asdf-direnv](https://github.com/asdf-community/asdf-direnv) can have
tagged releases or `develop` branches that can potentially be
more *experimental* but more feature-forward than the `master` branch.

## Other information

Added a test that exercises clonning using an specific branch name.

Documented on help.txt and had keep all other commands help aligned.

Closes #1201
Closes #166 