### PR TITLE
fix: more robust SHELL checks

### DIFF
--- a/lib/commands/command-info.bash
+++ b/lib/commands/command-info.bash
@@ -2,9 +2,21 @@
 # shellcheck source=lib/functions/plugins.bash
 . "$(dirname "$(dirname "$0")")/lib/functions/plugins.bash"
 
+get_shell() {
+  if [[ -z $FISH_VERSION ]]; then
+    echo "fish"
+  elif [[ -z $ZSH_VERSION ]]; then
+    echo "zsh"
+  elif [[ -z $BASH_VERSION ]]; then
+    echo "bash"
+  else
+    echo $SHELL --version
+  fi
+}
+
 info_command() {
   printf "%s:\\n%s\\n\\n" "OS" "$(uname -a)"
-  printf "%s:\\n%s\\n\\n" "SHELL" "$($SHELL --version)"
+  printf "%s:\\n%s\\n\\n" "SHELL" "$(get_shell)"
   printf "%s:\\n%s\\n\\n" "ASDF VERSION" "$(asdf_version)"
   printf "%s:\\n%s\\n\\n" "ASDF ENVIRONMENT VARIABLES" "$(env | grep -E "ASDF_DIR|ASDF_DATA_DIR|ASDF_CONFIG_FILE|ASDF_DEFAULT_TOOL_VERSIONS_FILENAME")"
   printf "%s:\\n%s\\n\\n" "ASDF INSTALLED PLUGINS" "$(plugin_list_command --urls --refs)"

--- a/lib/commands/command-info.bash
+++ b/lib/commands/command-info.bash
@@ -4,11 +4,11 @@
 
 get_shell() {
   if [[ -z $FISH_VERSION ]]; then
-    echo "fish, version $FISH_VERSION"
+    printf "fish, version %s" "$FISH_VERSION"
   elif [[ -z $ZSH_VERSION ]]; then
-    echo "zsh, version $ZSH_VERSION"
+    printf "zsh, version %s" "$ZSH_VERSION"
   elif [[ -z $BASH_VERSION ]]; then
-    echo "bash, $BASH_VERSION"
+    printf "bash, version %s" "$BASH_VERSION"
   else
     $SHELL --version
   fi

--- a/lib/commands/command-info.bash
+++ b/lib/commands/command-info.bash
@@ -10,7 +10,7 @@ get_shell() {
   elif [[ -z $BASH_VERSION ]]; then
     echo "bash, $BASH_VERSION"
   else
-    echo $($SHELL --version)
+    $SHELL --version
   fi
 }
 

--- a/lib/commands/command-info.bash
+++ b/lib/commands/command-info.bash
@@ -4,13 +4,13 @@
 
 get_shell() {
   if [[ -z $FISH_VERSION ]]; then
-    echo "fish"
+    echo "fish, version $FISH_VERSION"
   elif [[ -z $ZSH_VERSION ]]; then
-    echo "zsh"
+    echo "zsh, version $ZSH_VERSION"
   elif [[ -z $BASH_VERSION ]]; then
-    echo "bash"
+    echo "bash, $BASH_VERSION"
   else
-    echo $SHELL --version
+    echo $($SHELL --version)
   fi
 }
 


### PR DESCRIPTION
While debugging an unrelated issue, I found that my `$SHELL --version`
output was returning as zsh but I actually run `fish` via nix. Instead
of using `$SHELL`, which isn't accurate in some cases, I've updated this
to attempt to use the various `*_VERSION` environment variables that are
available in the shells before failing back to the previous `$SHELL`
check. Realistically, `$SHELL --version` should be replaced with
something else but this should improve the current situation with
misidentifying shells in use.