### PR TITLE
docs: ASDF_DIR/ASDF_DATA_DIR absolute paths

### DIFF
--- a/docs/manage/configuration.md
+++ b/docs/manage/configuration.md
@@ -100,8 +100,8 @@ Configure the duration since the last asdf plugin repository sync to the next. C
 
 - `ASDF_CONFIG_FILE` - Defaults to `~/.asdfrc` as described above. Can be set to any location.
 - `ASDF_DEFAULT_TOOL_VERSIONS_FILENAME` - The filename of the file storing the tool names and versions. Defaults to `.tool-versions`. Can be any valid filename. Typically you should not override the default value unless you know you want asdf to ignore `.tool-versions` files.
-- `ASDF_DIR` - Defaults to `~/.asdf` - Location of the `asdf` scripts. If you install `asdf` to some other directory, set this to that directory. For example, if you are installing via the AUR, you should set this to `/opt/asdf-vm`.
-- `ASDF_DATA_DIR` - Defaults to `~/.asdf` - Location where `asdf` install plugins, shims and installs. Can be set to any location before sourcing `asdf.sh` or `asdf.fish` mentioned in the section above. For Elvish, this can be set above `use asdf`.
+- `ASDF_DIR` - Defaults to `~/.asdf` - Location of the `asdf` scripts. If you install `asdf` to some other directory, set this to that directory. For example, if you are installing via the AUR, you should set this to `/opt/asdf-vm`. Please set to a absolute path like `~/.asdf`, `${HOME}/.asdf`, `/home/my/working/dir/.asdf`.
+- `ASDF_DATA_DIR` - Defaults to `~/.asdf` - Location where `asdf` install plugins, shims and installs. Can be set to any location before sourcing `asdf.sh` or `asdf.fish` mentioned in the section above. For Elvish, this can be set above `use asdf`. Please set to a absolute path like `~/.asdf`, `${HOME}/.asdf`, `/home/my/working/dir/.asdf`.
 
 ## Internal Configuration
 


### PR DESCRIPTION
This PR updates the documentation for environment variables `ASDF_DIR` and `ASDF_DATA_DIR`.

Both variables should be set to _absolute_ paths to avoid issues with plugins changing the current working directory.

For example, the ruby plugin fails if ASDF_DIR and ASDF_DATA_DIR are set to a relative path:

```console
$ echo '#!/bin/sh
mkdir -p "/tmp/my-project"
cd "/tmp/my-project"

export ASDF_DIR=".asdf"
export ASDF_DATA_DIR=".asdf"
git clone --depth=1 https://github.com/asdf-vm/asdf.git "${ASDF_DIR}" --branch v0.10.0
source .asdf/asdf.sh
asdf plugin add ruby
echo "### ASDF_DIR and ASDF_DATA_DIR with relative path"
asdf install ruby 3.1.2

echo "### ASDF_DIR and ASDF_DATA_DIR with absolute path"
export ASDF_DIR="/tmp/my-project/.asdf"
export ASDF_DATA_DIR="/tmp/my-project/.asdf"
asdf install ruby 3.1.2' > test.sh

$ bash ./test.sh
Note: switching to '77fd510bdc56be317b31fff27b8a3b948e1d65f9'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

initializing plugin repository...Cloning into '.asdf/repository'...
remote: Enumerating objects: 3796, done.
remote: Counting objects: 100% (777/777), done.
remote: Compressing objects: 100% (69/69), done.
remote: Total 3796 (delta 712), reused 708 (delta 708), pack-reused 3019
Receiving objects: 100% (3796/3796), 846.12 KiB | 6.99 MiB/s, done.
Resolving deltas: 100% (1959/1959), done.
### ASDF_DIR and ASDF_DATA_DIR with relative path
Downloading ruby-build...
.asdf/plugins/ruby/bin/install: line 47: .asdf/plugins/ruby/ruby-build/bin/ruby-build: No such file or directory
Version not found
### ASDF_DIR and ASDF_DATA_DIR with absolute path
Downloading ruby-build...
Downloading openssl-1.1.1n.tar.gz...
-> https://dqw8nmjcqpjn7.cloudfront.net/40dceb51a4f6a5275bde0e6bf20ef4b91bfc32ed57c0552e2e8e15463372b17a
Installing openssl-1.1.1n...
Installed openssl-1.1.1n to /tmp/my-project/.asdf/installs/ruby/3.1.2

Downloading ruby-3.1.2.tar.gz...
-> https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.1.2.tar.gz
Installing ruby-3.1.2...
ruby-build: using readline from homebrew
Installed ruby-3.1.2 to /tmp/my-project/.asdf/installs/ruby/3.1.2
```

# Summary

<!-- Provide a general description of the code changes in your pull request. -->

Fixes: List issue numbers here

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->
