### PR TITLE
fix: only iterate over directories in the plugins/ directory

### DIFF
--- a/lib/commands/command-help.bash
+++ b/lib/commands/command-help.bash
@@ -18,7 +18,7 @@ EOF
 asdf_extension_cmds() {
   local plugins_path plugin_path ext_cmd_path ext_cmds plugin
   plugins_path="$(get_plugin_path)"
-  for plugin_path in "$plugins_path"/*; do
+  for plugin_path in "$plugins_path"/*/; do
     plugin="$(basename "$plugin_path")"
     ext_cmd_path="$plugin_path/lib/commands"
     ext_cmds="$(find "$ext_cmd_path" -name "command*.bash" 2>/dev/null)"

--- a/lib/commands/command-list.bash
+++ b/lib/commands/command-list.bash
@@ -9,7 +9,7 @@ list_command() {
     plugins_path=$(get_plugin_path)
 
     if find "$plugins_path" -mindepth 1 -type d &>/dev/null; then
-      for plugin_path in "$plugins_path"/*; do
+      for plugin_path in "$plugins_path"/*/; do
         plugin_name=$(basename "$plugin_path")
         printf "%s\\n" "$plugin_name"
         display_installed_versions "$plugin_name" "$query"

--- a/lib/commands/command-plugin-push.bash
+++ b/lib/commands/command-plugin-push.bash
@@ -3,7 +3,7 @@
 plugin_push_command() {
   local plugin_name=$1
   if [ "$plugin_name" = "--all" ]; then
-    for dir in "$(asdf_data_dir)"/plugins/*; do
+    for dir in "$(asdf_data_dir)"/plugins/*/; do
       printf "Pushing %s...\\n" "$(basename "$dir")"
       (cd "$dir" && git push)
     done

--- a/lib/commands/reshim.bash
+++ b/lib/commands/reshim.bash
@@ -33,7 +33,7 @@ reshim_command() {
     plugins_path=$(get_plugin_path)
 
     if find "$plugins_path" -mindepth 1 -type d &>/dev/null; then
-      for plugin_path in "$plugins_path"/*; do
+      for plugin_path in "$plugins_path"/*/; do
         plugin_name=$(basename "$plugin_path")
         reshim_command "$plugin_name"
       done

--- a/lib/functions/installs.bash
+++ b/lib/functions/installs.bash
@@ -77,7 +77,7 @@ install_local_tool_versions() {
   # Locate all the plugins installed in the system
   local plugins_installed
   if find "$plugins_path" -mindepth 1 -type d &>/dev/null; then
-    for plugin_path in "$plugins_path"/*; do
+    for plugin_path in "$plugins_path"/*/; do
       local plugin_name
       plugin_name=$(basename "$plugin_path")
       plugins_installed="$plugins_installed $plugin_name"

--- a/lib/functions/plugins.bash
+++ b/lib/functions/plugins.bash
@@ -23,7 +23,7 @@ plugin_list_command() {
 
   if find "$plugins_path" -mindepth 1 -type d &>/dev/null; then
     (
-      for plugin_path in "$plugins_path"/*; do
+      for plugin_path in "$plugins_path"/*/; do
         plugin_name=$(basename "$plugin_path")
         printf "%s" "$plugin_name"
 

--- a/lib/functions/versions.bash
+++ b/lib/functions/versions.bash
@@ -158,7 +158,7 @@ latest_all() {
   plugins_path=$(get_plugin_path)
 
   if find "$plugins_path" -mindepth 1 -type d &>/dev/null; then
-    for plugin_path in "$plugins_path"/*; do
+    for plugin_path in "$plugins_path"/*/; do
       plugin_name=$(basename "$plugin_path")
 
       # Retrieve the version of the plugin

--- a/test/list_command.bats
+++ b/test/list_command.bats
@@ -16,8 +16,8 @@ teardown() {
   run asdf install dummy 1.0.0
   run asdf install dummy 1.1.0
   run asdf list
-  [[ "$output" == "$(echo -e "dummy\n  1.0.0\n  1.1.0")"* ]]
-  [[ "$output" == *"$(echo -e "dummy-broken\n  No versions installed")" ]]
+  [[ "$output" == *"$(echo -e "dummy\n  1.0.0\n  1.1.0")"* ]]
+  [[ "$output" == *"$(echo -e "dummy-broken\n  No versions installed")"* ]]
   [ "$status" -eq 0 ]
 }
 
@@ -28,10 +28,10 @@ teardown() {
   run asdf install dummy 1.0.0
   run asdf install tummy 2.0.0
   run asdf list
-  [[ "$output" == "$(echo -e "dummy\n  1.0.0")"* ]]
+  [[ "$output" == *"$(echo -e "dummy\n  1.0.0")"* ]]
   [[ "$output" == *"$(echo -e "dummy-broken\n  No versions installed")"* ]]
   [[ "$output" == *"$(echo -e "mummy\n  No versions installed")"* ]]
-  [[ "$output" == *"$(echo -e "tummy\n  2.0.0")" ]]
+  [[ "$output" == *"$(echo -e "tummy\n  2.0.0")"* ]]
   [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
Fixes part of #1029

The shell glob pattern `dir/*` matches any files in `dir/`, `dir/*/` matches only directories in `dir`. When iterating over the plugins directory we only care about directories, since only they can represent plugins.
