### PR TITLE
fix: update event trigger for doc-version workflow

### DIFF
--- a/.github/workflows/docs-version.yml
+++ b/.github/workflows/docs-version.yml
@@ -1,9 +1,9 @@
 name: "Docs Version Update"
 
 on:
-  create:
+  push:
     tags:
-      - "*"
+      - '*'
 
 jobs:
   bump-version-in-docs:


### PR DESCRIPTION
Possible fix for https://github.com/asdf-vm/asdf/issues/1230

@jthegedus I based this off of https://github.community/t/how-to-run-github-actions-workflow-only-for-new-tags/16075/10. I haven't been able to test it yet.