### PR TITLE
fix: Remove static paths to asdf for shims

### DIFF
--- a/lib/commands/reshim.bash
+++ b/lib/commands/reshim.bash
@@ -89,7 +89,9 @@ write_shim_script() {
   shim_path="$(asdf_data_dir)/shims/$executable_name"
 
   # Temporary fix for #1231
+  # shellcheck disable=SC2016
   if ! grep '^exec \${ASDF_DIR}' "$shim_path" >/dev/null; then
+    # shellcheck disable=SC2016
     sed -i.bak -e 's/^exec .*\/bin\/asdf /exec ${ASDF_DIR}\/bin\/asdf /' "$shim_path"
     rm -rf "$shim_path".bak
   fi

--- a/lib/commands/reshim.bash
+++ b/lib/commands/reshim.bash
@@ -88,6 +88,12 @@ write_shim_script() {
   local shim_path
   shim_path="$(asdf_data_dir)/shims/$executable_name"
 
+  # Temporary fix for #1231
+  if ! grep '^exec \${ASDF_DIR}' "$shim_path" >/dev/null; then
+    sed -i.bak -e 's/^exec .*\/bin\/asdf /exec ${ASDF_DIR}\/bin\/asdf /' "$shim_path"
+    rm -rf "$shim_path".bak
+  fi
+
   if [ -f "$shim_path" ]; then
     if ! grep -x "# asdf-plugin: ${plugin_name} ${version}" "$shim_path" >/dev/null; then
       sed -i.bak -e "s/exec /# asdf-plugin: ${plugin_name} ${version}\\"$'\n''exec /' "$shim_path"
@@ -97,7 +103,7 @@ write_shim_script() {
     cat <<EOF >"$shim_path"
 #!/usr/bin/env bash
 # asdf-plugin: ${plugin_name} ${version}
-exec $(asdf_dir)/bin/asdf exec "${executable_name}" "\$@" # asdf_allow: ' asdf '
+exec \${ASDF_DIR}/bin/asdf exec "${executable_name}" "\$@" # asdf_allow: ' asdf '
 EOF
   fi
 


### PR DESCRIPTION
# Summary
Switch from generating static paths to asdf exec file to using user's ASDF_DIR
env variable to dynamically determine asdf location.

It ensures that regardless of updates for asdf installed on user system path
won't rely on single correct path to asdf. Since the path might contain version
number (e. g. `/opt/homebrew/Cellar/asdf/0.9.0/libexec/bin/asdf`), asdf
installation would break as soon as new release is installed.

Fixes: #1231