### PR TITLE
fix: update plugin-add regex to support other languages

### DIFF
--- a/lib/functions/plugins.bash
+++ b/lib/functions/plugins.bash
@@ -56,8 +56,9 @@ plugin_add_command() {
 
   local plugin_name=$1
 
-  if ! printf "%s" "$plugin_name" | grep -q -E "^[a-zA-Z0-9_-]+$"; then
-    display_error "$plugin_name is invalid. Name must match regex ^[a-zA-Z0-9_-]+$"
+  local regex="^[[:alpha:][:digit:]_-]+$"
+  if ! printf "%s" "$plugin_name" | grep -q -E "$regex"; then
+    display_error "$plugin_name is invalid. Name must match regex $regex"
     exit 1
   fi
 

--- a/test/plugin_add_command.bats
+++ b/test/plugin_add_command.bats
@@ -20,16 +20,32 @@ teardown() {
   [ "$output" = "plugin_with-all-valid-CHARS-123" ]
 }
 
+@test "plugin_add command with LANG=sv_SE.UTF-8 and plugin name matching all valid regex chars succeeds" {
+  ORIGINAL_LANG="$LANG"
+  LANG=sv_SE.UTF-8
+
+  install_mock_plugin_repo "plugin-with-w"
+
+  # https://stackoverflow.com/questions/52570103/regular-expression-a-za-z-seems-to-not-include-letter-w-and-wA
+  # https://github.com/asdf-vm/asdf/issues/1237
+  run asdf plugin add "plugin-with-w" "${BASE_DIR}/repo-plugin-with-w"
+  [ "$status" -eq 0 ]
+
+  run asdf plugin-list
+  [ "$output" = "plugin-with-w" ]
+
+  LANG="$ORIGINAL_LANG"
+}
 @test "plugin_add command with plugin name not matching valid regex fails" {
   run asdf plugin add "invalid\$plugin\$name"
   [ "$status" -eq 1 ]
-  [ "$output" = "invalid\$plugin\$name is invalid. Name must match regex ^[a-zA-Z0-9_-]+$" ]
+  [ "$output" = "invalid\$plugin\$name is invalid. Name must match regex ^[[:alpha:][:digit:]_-]+$" ]
 }
 
 @test "plugin_add command with plugin name not matching valid regex fails again" {
   run asdf plugin add "#invalid#plugin#name"
   [ "$status" -eq 1 ]
-  [ "$output" = "#invalid#plugin#name is invalid. Name must match regex ^[a-zA-Z0-9_-]+$" ]
+  [ "$output" = "#invalid#plugin#name is invalid. Name must match regex ^[[:alpha:][:digit:]_-]+$" ]
 }
 
 @test "plugin_add command with no URL specified adds a plugin using repo" {


### PR DESCRIPTION
[:alpha:] and [:digit:] character classes support characters from other
languages whereas ranges like a-z and 0-9 may not.

Fixes #1237
