### PR TITLE
ci: add latest OSs to testing matrix, bump BATS, shfmt, shellcheck

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
           - ubuntu-18.04
           - ubuntu-20.04
           - ubuntu-22.04
-  runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  BATS_VERSION: v1.3.0
+  BATS_VERSION: v1.7.0
 
 jobs:
   nix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,10 +16,12 @@ jobs:
       matrix:
         os:
           - macos-10.15
-          # - macos-11 - enable once out of private preview: https://github.com/actions/virtual-environments#available-environments
+          - macos-11
+          - macos-12
           - ubuntu-18.04
           - ubuntu-20.04
-    runs-on: ${{ matrix.os }}
+          - ubuntu-22.04
+  runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 bats 1.7.0
-shellcheck 0.7.2
-shfmt 3.3.0
+shellcheck 0.8.0
+shfmt 3.5.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-bats 1.3.0
+bats 1.7.0
 shellcheck 0.7.2
 shfmt 3.3.0

--- a/test/asdf_fish.bats
+++ b/test/asdf_fish.bats
@@ -25,18 +25,18 @@ cleaned_path() {
 }
 
 @test "adds asdf dirs to PATH" {
- result=$(fish -c "
-   set -e asdf
-   set -e ASDF_DIR
-   set -e ASDF_DATA_DIR
-   set PATH $(cleaned_path)
+  result=$(fish -c "
+    set -e asdf
+    set -e ASDF_DIR
+    set -e ASDF_DATA_DIR
+    set PATH $(cleaned_path)
 
-   . (pwd)/asdf.fish  # if the full path is not passed, status -f will return the relative path
-   echo \$PATH
+    . (pwd)/asdf.fish  # if the full path is not passed, status -f will return the relative path
+    echo \$PATH
  ")
- [ "$?" -eq 0 ]
- output=$(echo "$result" | grep "asdf")
- [ "$output" != "" ]
+  [ "$?" -eq 0 ]
+  output=$(echo "$result" | grep "asdf")
+  [ "$output" != "" ]
 }
 
 @test "does not add paths to PATH more than once" {
@@ -81,4 +81,3 @@ cleaned_path() {
   output=$(echo "$result" | grep "ASDF INSTALLED PLUGINS:")
   [ "$output" != "" ]
 }
-

--- a/test/banned_commands.bats
+++ b/test/banned_commands.bats
@@ -3,50 +3,50 @@
 load test_helpers
 
 banned_commands=(
-    # Process substitution isn't POSIX compliant and cause trouble
-    "<("
-    # Command isn't included in the Ubuntu packages asdf depends on. Also not
-    # defined in POSIX
-    column
-    # echo isn't consistent across operating systems, and sometimes output can
-    # be confused with echo flags. printf does everything echo does and more.
-    echo
-    # It's best to avoid eval as it makes it easier to accidentally execute
-    # arbitrary strings
-    eval
-    # realpath not available by default on OSX.
-    realpath
-    # readlink on OSX behaves differently from readlink on other Unix systems
-    readlink
-    # source isn't POSIX compliant. . behaves the same and is POSIX compliant
-    # Except in fish, where . is deprecated, and will be removed in the future.
-    source
+  # Process substitution isn't POSIX compliant and cause trouble
+  "<("
+  # Command isn't included in the Ubuntu packages asdf depends on. Also not
+  # defined in POSIX
+  column
+  # echo isn't consistent across operating systems, and sometimes output can
+  # be confused with echo flags. printf does everything echo does and more.
+  echo
+  # It's best to avoid eval as it makes it easier to accidentally execute
+  # arbitrary strings
+  eval
+  # realpath not available by default on OSX.
+  realpath
+  # readlink on OSX behaves differently from readlink on other Unix systems
+  readlink
+  # source isn't POSIX compliant. . behaves the same and is POSIX compliant
+  # Except in fish, where . is deprecated, and will be removed in the future.
+  source
 )
 
 banned_commands_regex=(
-    # grep -y does not work on alpine and should be "grep -i" either way
-    "grep.* -y"
-    # grep -P is not a valid option in OSX.
-    "grep.* -P"
-    # Ban grep long commands as they do not work on alpine
-    "grep[^|]+--\w{2,}"
-    # sort --sort-version isn't supported everywhere
-    "sort.*-V"
-    "sort.*--sort-versions"
+  # grep -y does not work on alpine and should be "grep -i" either way
+  "grep.* -y"
+  # grep -P is not a valid option in OSX.
+  "grep.* -P"
+  # Ban grep long commands as they do not work on alpine
+  "grep[^|]+--\w{2,}"
+  # sort --sort-version isn't supported everywhere
+  "sort.*-V"
+  "sort.*--sort-versions"
 
-    # ls often gets used when we want to glob for files that match a pattern
-    # or when we want to find all files/directories that match a pattern or are
-    # found in a certain location. Using shell globs is preferred over ls, and
-    # find is better at locating files that are in a certain location or that
-    # match certain filename patterns.
-    # https://github-wiki-see.page/m/koalaman/shellcheck/wiki/SC2012
-    '\bls '
+  # ls often gets used when we want to glob for files that match a pattern
+  # or when we want to find all files/directories that match a pattern or are
+  # found in a certain location. Using shell globs is preferred over ls, and
+  # find is better at locating files that are in a certain location or that
+  # match certain filename patterns.
+  # https://github-wiki-see.page/m/koalaman/shellcheck/wiki/SC2012
+  '\bls '
 
-    # Ban recusive asdf calls as they are inefficient and may introduce bugs.
-    # If you find yourself needing to invoke an `asdf` command from within
-    # asdf code, please source the appropriate file and invoke the
-    # corresponding function.
-    '\basdf '
+  # Ban recusive asdf calls as they are inefficient and may introduce bugs.
+  # If you find yourself needing to invoke an `asdf` command from within
+  # asdf code, please source the appropriate file and invoke the
+  # corresponding function.
+  '\basdf '
 )
 
 setup() {
@@ -64,36 +64,36 @@ teardown() {
   # followed by an underscore (indicating it's a variable and not a
   # command).
   for cmd in "${banned_commands[@]}"; do
-      run bash -c "grep -nHR --include \*.bash --include \*.sh '$cmd' asdf.* lib bin\
+    run bash -c "grep -nHR --include \*.bash --include \*.sh '$cmd' asdf.* lib bin\
         | grep -v '#.*$cmd'\
         | grep -v '\".*$cmd.*\"' \
         | grep -v '${cmd}_'\
         | grep -v '# asdf_allow: $cmd'"
 
-      # Only print output if we've found a banned command
-      #if [ "$status" -ne 1 ]; then
-      if [ "" != "$output" ]; then
-        echo "banned command $cmd: $output"
-      fi
+    # Only print output if we've found a banned command
+    #if [ "$status" -ne 1 ]; then
+    if [ "" != "$output" ]; then
+      echo "banned command $cmd: $output"
+    fi
 
-      [ "$status" -eq 1 ]
-      [ "" == "$output" ]
+    [ "$status" -eq 1 ]
+    [ "" == "$output" ]
   done
 
   for cmd in "${banned_commands_regex[@]}"; do
-      run bash -c "grep -nHRE --include \*.bash --include \*.sh '$cmd' asdf.* lib bin\
+    run bash -c "grep -nHRE --include \*.bash --include \*.sh '$cmd' asdf.* lib bin\
         | grep -v '#.*$cmd'\
         | grep -v '\".*$cmd.*\"' \
         | grep -v '${cmd}_'\
         | grep -v '# asdf_allow: $cmd'"
 
-      # Only print output if we've found a banned command
-      #if [ "$status" -ne 1 ]; then
-      if [ "" != "$output" ]; then
-        echo "banned command $cmd: $output"
-      fi
+    # Only print output if we've found a banned command
+    #if [ "$status" -ne 1 ]; then
+    if [ "" != "$output" ]; then
+      echo "banned command $cmd: $output"
+    fi
 
-      [ "$status" -eq 1 ]
-      [ "" == "$output" ]
+    [ "$status" -eq 1 ]
+    [ "" == "$output" ]
   done
 }

--- a/test/get_asdf_config_value.bats
+++ b/test/get_asdf_config_value.bats
@@ -3,15 +3,15 @@
 load test_helpers
 
 setup() {
-    cd $BATS_TMPDIR
-    ASDF_CONFIG_FILE=$BATS_TMPDIR/asdfrc
-    cat > $ASDF_CONFIG_FILE <<-EOM
+  cd $BATS_TMPDIR
+  ASDF_CONFIG_FILE=$BATS_TMPDIR/asdfrc
+  cat >$ASDF_CONFIG_FILE <<-EOM
 key1 = value1
 legacy_version_file = yes
 EOM
 
-    ASDF_CONFIG_DEFAULT_FILE=$BATS_TMPDIR/asdfrc_defaults
-    cat > $ASDF_CONFIG_DEFAULT_FILE <<-EOM
+  ASDF_CONFIG_DEFAULT_FILE=$BATS_TMPDIR/asdfrc_defaults
+  cat >$ASDF_CONFIG_DEFAULT_FILE <<-EOM
 # i have  a comment, it's ok
 key2 = value2
 legacy_version_file = no
@@ -19,30 +19,30 @@ EOM
 }
 
 teardown() {
-    rm $ASDF_CONFIG_FILE
-    rm $ASDF_CONFIG_DEFAULT_FILE
-    unset ASDF_CONFIG_DEFAULT_FILE
-    unset ASDF_CONFIG_FILE
+  rm $ASDF_CONFIG_FILE
+  rm $ASDF_CONFIG_DEFAULT_FILE
+  unset ASDF_CONFIG_DEFAULT_FILE
+  unset ASDF_CONFIG_FILE
 }
 
 @test "get_config returns default when config file does not exist" {
-    result=$(ASDF_CONFIG_FILE="/some/fake/path" get_asdf_config_value "legacy_version_file")
-    [ "$result" = "no" ]
+  result=$(ASDF_CONFIG_FILE="/some/fake/path" get_asdf_config_value "legacy_version_file")
+  [ "$result" = "no" ]
 }
 
 @test "get_config returns default value when the key does not exist" {
-    [ $(get_asdf_config_value "key2") = "value2" ]
+  [ $(get_asdf_config_value "key2") = "value2" ]
 }
 
 @test "get_config returns config file value when key exists" {
-    [ $(get_asdf_config_value "key1") = "value1" ]
-    [ $(get_asdf_config_value "legacy_version_file") = "yes" ]
+  [ $(get_asdf_config_value "key1") = "value1" ]
+  [ $(get_asdf_config_value "legacy_version_file") = "yes" ]
 }
 
 @test "get_config returns config file complete value including '=' symbols" {
-  cat >> $ASDF_CONFIG_FILE <<-'EOM'
+  cat >>$ASDF_CONFIG_FILE <<-'EOM'
 key3 = VAR=val
 EOM
 
-    [ $(get_asdf_config_value "key3") = "VAR=val" ]
+  [ $(get_asdf_config_value "key3") = "VAR=val" ]
 }

--- a/test/help_command.bats
+++ b/test/help_command.bats
@@ -22,12 +22,13 @@ teardown() {
 
   run asdf help "dummy"
 
-  expected_output="$(cat <<EOF
+  expected_output="$(
+    cat <<EOF
 Dummy plugin documentation
 
 Dummy plugin is a plugin only used for unit tests
 EOF
-)"
+  )"
   [ "$status" -eq 0 ]
   [ "$output" = "$expected_output" ]
 }
@@ -37,14 +38,15 @@ EOF
 
   run asdf help "dummy" "1.2.3"
 
-  expected_output="$(cat <<EOF
+  expected_output="$(
+    cat <<EOF
 Dummy plugin documentation
 
 Dummy plugin is a plugin only used for unit tests
 
 Details specific for version 1.2.3
 EOF
-)"
+  )"
   [ "$status" -eq 0 ]
   echo $output
   [ "$output" = "$expected_output" ]

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -30,7 +30,7 @@ teardown() {
 
 @test "install_command without arguments installs even if the user is terrible and does not use newlines" {
   cd $PROJECT_DIR
-  echo -n 'dummy 1.2.0' > ".tool-versions"
+  echo -n 'dummy 1.2.0' >".tool-versions"
   run asdf install
   [ "$status" -eq 0 ]
   [ $(cat $ASDF_DIR/installs/dummy/1.2.0/version) = "1.2.0" ]
@@ -38,7 +38,7 @@ teardown() {
 
 @test "install_command with only name installs the version in .tool-versions" {
   cd $PROJECT_DIR
-  echo -n 'dummy 1.2.0' > ".tool-versions"
+  echo -n 'dummy 1.2.0' >".tool-versions"
   run asdf install dummy
   [ "$status" -eq 0 ]
   [ $(cat $ASDF_DIR/installs/dummy/1.2.0/version) = "1.2.0" ]
@@ -56,7 +56,7 @@ teardown() {
   WHITESPACE_DIR="$PROJECT_DIR/whitespace\ dir"
   mkdir -p "$WHITESPACE_DIR"
   cd "$WHITESPACE_DIR"
-  echo 'dummy 1.2.0' >> "$WHITESPACE_DIR/.tool-versions"
+  echo 'dummy 1.2.0' >>"$WHITESPACE_DIR/.tool-versions"
 
   run asdf install
 
@@ -104,7 +104,7 @@ teardown() {
 
 @test "install_command without arguments should not generate shim for subdir" {
   cd $PROJECT_DIR
-  echo 'dummy 1.0.0' > $PROJECT_DIR/.tool-versions
+  echo 'dummy 1.0.0' >$PROJECT_DIR/.tool-versions
 
   run asdf install
   [ "$status" -eq 0 ]
@@ -117,7 +117,7 @@ teardown() {
   cp -rf $BATS_TEST_DIRNAME/../{bin,lib} $ASDF_DIR/
 
   cd $PROJECT_DIR
-  echo 'dummy 1.0.0' > $PROJECT_DIR/.tool-versions
+  echo 'dummy 1.0.0' >$PROJECT_DIR/.tool-versions
   run asdf install
 
   # execute the generated shim
@@ -135,24 +135,24 @@ teardown() {
 
 @test "install_command fails if the plugin is not installed" {
   cd $PROJECT_DIR
-  echo 'other_dummy 1.0.0' > $PROJECT_DIR/.tool-versions
+  echo 'other_dummy 1.0.0' >$PROJECT_DIR/.tool-versions
 
   run asdf install
   [ "$status" -eq 1 ]
-  [ "$output" =  "other_dummy plugin is not installed" ]
+  [ "$output" = "other_dummy plugin is not installed" ]
 }
 
 @test "install_command fails if the plugin is not installed without collisions" {
   cd $PROJECT_DIR
-  printf "dummy 1.0.0\ndum 1.0.0" > $PROJECT_DIR/.tool-versions
+  printf "dummy 1.0.0\ndum 1.0.0" >$PROJECT_DIR/.tool-versions
 
   run asdf install
   [ "$status" -eq 1 ]
-  [ "$output" =  "dum plugin is not installed" ]
+  [ "$output" = "dum plugin is not installed" ]
 }
 
 @test "install_command fails when tool is specified but no version of the tool is configured in config file" {
-  echo 'dummy 1.0.0' > $PROJECT_DIR/.tool-versions
+  echo 'dummy 1.0.0' >$PROJECT_DIR/.tool-versions
   run asdf install other-dummy
   [ "$status" -eq 1 ]
   [ "$output" = "No versions specified for other-dummy in config files or environment" ]
@@ -160,7 +160,7 @@ teardown() {
 }
 
 @test "install_command fails when two tools are specified with no versions" {
-  printf 'dummy 1.0.0\nother-dummy 2.0.0' > $PROJECT_DIR/.tool-versions
+  printf 'dummy 1.0.0\nother-dummy 2.0.0' >$PROJECT_DIR/.tool-versions
   run asdf install dummy other-dummy
   [ "$status" -eq 1 ]
   [ "$output" = "Dummy couldn't install version: other-dummy (on purpose)" ]
@@ -172,7 +172,7 @@ teardown() {
   # asdf lib needed to run generated shims
   cp -rf $BATS_TEST_DIRNAME/../{bin,lib} $ASDF_DIR/
 
-  echo 'dummy 1.0.0' > $PROJECT_DIR/.tool-versions
+  echo 'dummy 1.0.0' >$PROJECT_DIR/.tool-versions
   mkdir -p $PROJECT_DIR/child
 
   cd $PROJECT_DIR/child
@@ -185,7 +185,7 @@ teardown() {
 }
 
 @test "install_command installs multiple tool versions when they are specified in a .tool-versions file" {
-  echo 'dummy 1.0.0 1.2.0' > $PROJECT_DIR/.tool-versions
+  echo 'dummy 1.0.0 1.2.0' >$PROJECT_DIR/.tool-versions
   cd $PROJECT_DIR
 
   run asdf install
@@ -203,7 +203,7 @@ teardown() {
 }
 
 @test "install command executes configured pre plugin install hook" {
-  cat > $HOME/.asdfrc <<-'EOM'
+  cat >$HOME/.asdfrc <<-'EOM'
 pre_asdf_install_dummy = echo will install dummy $1
 EOM
 
@@ -212,7 +212,7 @@ EOM
 }
 
 @test "install command executes configured post plugin install hook" {
-  cat > $HOME/.asdfrc <<-'EOM'
+  cat >$HOME/.asdfrc <<-'EOM'
 post_asdf_install_dummy = echo HEY $version FROM $plugin_name
 EOM
 
@@ -221,8 +221,8 @@ EOM
 }
 
 @test "install command without arguments installs versions from legacy files" {
-  echo 'legacy_version_file = yes' > $HOME/.asdfrc
-  echo '1.2.0' >> $PROJECT_DIR/.dummy-version
+  echo 'legacy_version_file = yes' >$HOME/.asdfrc
+  echo '1.2.0' >>$PROJECT_DIR/.dummy-version
   cd $PROJECT_DIR
   run asdf install
   [ "$status" -eq 0 ]
@@ -231,8 +231,8 @@ EOM
 }
 
 @test "install command without arguments installs versions from legacy files in parent directories" {
-  echo 'legacy_version_file = yes' > $HOME/.asdfrc
-  echo '1.2.0' >> $PROJECT_DIR/.dummy-version
+  echo 'legacy_version_file = yes' >$HOME/.asdfrc
+  echo '1.2.0' >>$PROJECT_DIR/.dummy-version
 
   mkdir -p $PROJECT_DIR/child
   cd $PROJECT_DIR/child
@@ -270,7 +270,7 @@ EOM
 }
 
 @test "install_command keeps the download directory when always_keep_download setting is true" {
-  echo 'always_keep_download = yes' > $HOME/.asdfrc
+  echo 'always_keep_download = yes' >$HOME/.asdfrc
   run asdf install dummy 1.1.0
   echo $output
   [ "$status" -eq 0 ]

--- a/test/plugin_add_command.bats
+++ b/test/plugin_add_command.bats
@@ -93,7 +93,7 @@ teardown() {
 @test "plugin_add command executes configured pre hook (generic)" {
   install_mock_plugin_repo "dummy"
 
-  cat > $HOME/.asdfrc <<-'EOM'
+  cat >$HOME/.asdfrc <<-'EOM'
 pre_asdf_plugin_add = echo ADD ${@}
 EOM
 
@@ -107,7 +107,7 @@ plugin add path=${ASDF_DIR}/plugins/dummy source_url=${BASE_DIR}/repo-dummy"
 @test "plugin_add command executes configured pre hook (specific)" {
   install_mock_plugin_repo "dummy"
 
-  cat > $HOME/.asdfrc <<-'EOM'
+  cat >$HOME/.asdfrc <<-'EOM'
 pre_asdf_plugin_add_dummy = echo ADD
 EOM
 
@@ -121,7 +121,7 @@ plugin add path=${ASDF_DIR}/plugins/dummy source_url=${BASE_DIR}/repo-dummy"
 @test "plugin_add command executes configured post hook (generic)" {
   install_mock_plugin_repo "dummy"
 
-  cat > $HOME/.asdfrc <<-'EOM'
+  cat >$HOME/.asdfrc <<-'EOM'
 post_asdf_plugin_add = echo ADD ${@}
 EOM
 
@@ -135,7 +135,7 @@ ADD dummy"
 @test "plugin_add command executes configured post hook (specific)" {
   install_mock_plugin_repo "dummy"
 
-  cat > $HOME/.asdfrc <<-'EOM'
+  cat >$HOME/.asdfrc <<-'EOM'
 post_asdf_plugin_add_dummy = echo ADD
 EOM
 

--- a/test/plugin_extension_command.bats
+++ b/test/plugin_extension_command.bats
@@ -54,7 +54,7 @@ teardown() {
   plugin_path="$(get_plugin_path dummy)"
 
   # this plugin defines a new `asdf dummy foo` command
-  cat <<'EOF' > "$plugin_path/lib/commands/command-foo.bash"
+  cat <<'EOF' >"$plugin_path/lib/commands/command-foo.bash"
 #!/usr/bin/env bash
 echo this is an executable $*
 EOF
@@ -71,7 +71,7 @@ EOF
   plugin_path="$(get_plugin_path dummy)"
 
   # this plugin defines a new `asdf dummy foo` command
-  echo 'echo sourced script has asdf utils $(get_plugin_path dummy) $*' > "$plugin_path/lib/commands/command-foo.bash"
+  echo 'echo sourced script has asdf utils $(get_plugin_path dummy) $*' >"$plugin_path/lib/commands/command-foo.bash"
 
   expected="sourced script has asdf utils $plugin_path bar"
 
@@ -84,7 +84,7 @@ EOF
   plugin_path="$(get_plugin_path dummy)"
 
   # this plugin defines a new `asdf dummy` command
-  cat <<'EOF' > "$plugin_path/lib/commands/command.bash"
+  cat <<'EOF' >"$plugin_path/lib/commands/command.bash"
 #!/usr/bin/env bash
 echo hello
 EOF
@@ -101,7 +101,7 @@ EOF
   plugin_path="$(get_plugin_path dummy)"
 
   # this plugin defines a new `asdf dummy` command
-  cat <<'EOF' > "$plugin_path/lib/commands/command.bash"
+  cat <<'EOF' >"$plugin_path/lib/commands/command.bash"
 #!/usr/bin/env bash
 echo hello $*
 EOF

--- a/test/plugin_list_all_command.bats
+++ b/test/plugin_list_all_command.bats
@@ -13,7 +13,7 @@ teardown() {
 }
 
 @test "plugin_list_all should sync repo when check_duration set to 0" {
-  echo 'plugin_repository_last_check_duration = 0' > $HOME/.asdfrc
+  echo 'plugin_repository_last_check_duration = 0' >$HOME/.asdfrc
   run asdf plugin-list-all
   local expected_plugin_repo_sync="updating plugin repository..."
   local expected_plugins_list="\
@@ -27,7 +27,7 @@ foo                           http://example.com/foo"
 }
 
 @test "plugin_list_all no immediate repo sync expected because check_duration is greater than 0" {
-  echo 'plugin_repository_last_check_duration = 10' > $HOME/.asdfrc
+  echo 'plugin_repository_last_check_duration = 10' >$HOME/.asdfrc
   run asdf plugin-list-all
   local expected="\
 bar                           http://example.com/bar
@@ -39,7 +39,7 @@ foo                           http://example.com/foo"
 }
 
 @test "plugin_list_all skips repo sync because check_duration is set to never" {
-  echo 'plugin_repository_last_check_duration = never' > $HOME/.asdfrc
+  echo 'plugin_repository_last_check_duration = never' >$HOME/.asdfrc
   run asdf plugin-list-all
   local expected="\
 bar                           http://example.com/bar

--- a/test/plugin_remove_command.bats
+++ b/test/plugin_remove_command.bats
@@ -16,7 +16,6 @@ teardown() {
   [ "$status" -eq 0 ]
   [ -d "$ASDF_DIR/downloads/dummy" ]
 
-
   run asdf plugin-remove "dummy"
   [ "$status" -eq 0 ]
   [ ! -d "$ASDF_DIR/downloads/dummy" ]

--- a/test/remove_command.bats
+++ b/test/remove_command.bats
@@ -57,7 +57,7 @@ teardown() {
   run asdf install dummy 1.0
 
   # make an unrelated shim
-  echo "# asdf-plugin: gummy" > $ASDF_DIR/shims/gummy
+  echo "# asdf-plugin: gummy" >$ASDF_DIR/shims/gummy
 
   run asdf plugin-remove dummy
   [ "$status" -eq 0 ]
@@ -77,7 +77,7 @@ teardown() {
 @test "plugin_remove_command executes configured pre hook (generic)" {
   install_dummy_plugin
 
-  cat > $HOME/.asdfrc <<-'EOM'
+  cat >$HOME/.asdfrc <<-'EOM'
 pre_asdf_plugin_remove = echo REMOVE ${@}
 EOM
 
@@ -91,7 +91,7 @@ plugin-remove ${ASDF_DIR}/plugins/dummy"
 @test "plugin_remove_command executes configured pre hook (specific)" {
   install_dummy_plugin
 
-  cat > $HOME/.asdfrc <<-'EOM'
+  cat >$HOME/.asdfrc <<-'EOM'
 pre_asdf_plugin_remove_dummy = echo REMOVE
 EOM
 
@@ -105,7 +105,7 @@ plugin-remove ${ASDF_DIR}/plugins/dummy"
 @test "plugin_remove_command executes configured post hook (generic)" {
   install_dummy_plugin
 
-  cat > $HOME/.asdfrc <<-'EOM'
+  cat >$HOME/.asdfrc <<-'EOM'
 post_asdf_plugin_remove = echo REMOVE ${@}
 EOM
 
@@ -119,7 +119,7 @@ REMOVE dummy"
 @test "plugin_remove_command executes configured post hook (specific)" {
   install_dummy_plugin
 
-  cat > $HOME/.asdfrc <<-'EOM'
+  cat >$HOME/.asdfrc <<-'EOM'
 post_asdf_plugin_remove_dummy = echo REMOVE
 EOM
 

--- a/test/reshim_command.bats
+++ b/test/reshim_command.bats
@@ -14,7 +14,6 @@ teardown() {
   clean_asdf_dir
 }
 
-
 @test "reshim should allow prefixes of other versions" {
   run asdf install dummy 1.0.1
   run asdf install dummy 1.0
@@ -123,7 +122,7 @@ teardown() {
 @test "reshim command executes configured pre hook" {
   run asdf install dummy 1.0
 
-  cat > "$HOME/.asdfrc" <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 pre_asdf_reshim_dummy = echo RESHIM
 EOM
 
@@ -134,7 +133,7 @@ EOM
 @test "reshim command executes configured post hook" {
   run asdf install dummy 1.0
 
-  cat > "$HOME/.asdfrc" <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 post_asdf_reshim_dummy = echo RESHIM
 EOM
 

--- a/test/shim_env_command.bats
+++ b/test/shim_env_command.bats
@@ -25,7 +25,7 @@ teardown() {
 }
 
 @test "asdf env should execute under the environment used for a shim" {
-  echo "dummy 1.0" > $PROJECT_DIR/.tool-versions
+  echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
   run asdf install
 
   run asdf env dummy which dummy
@@ -33,12 +33,11 @@ teardown() {
   [ "$output" == "$ASDF_DIR/installs/dummy/1.0/bin/dummy" ]
 }
 
-
 @test "asdf env should execute under plugin custom environment used for a shim" {
-  echo "dummy 1.0" > $PROJECT_DIR/.tool-versions
+  echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
   run asdf install
 
-  echo "export FOO=bar" > $ASDF_DIR/plugins/dummy/bin/exec-env
+  echo "export FOO=bar" >$ASDF_DIR/plugins/dummy/bin/exec-env
   chmod +x $ASDF_DIR/plugins/dummy/bin/exec-env
 
   run asdf env dummy
@@ -47,13 +46,13 @@ teardown() {
 }
 
 @test "asdf env should ignore plugin custom environment on system version" {
-  echo "dummy 1.0" > $PROJECT_DIR/.tool-versions
+  echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
   run asdf install
 
-  echo "export FOO=bar" > $ASDF_DIR/plugins/dummy/bin/exec-env
+  echo "export FOO=bar" >$ASDF_DIR/plugins/dummy/bin/exec-env
   chmod +x $ASDF_DIR/plugins/dummy/bin/exec-env
 
-  echo "dummy system" > $PROJECT_DIR/.tool-versions
+  echo "dummy system" >$PROJECT_DIR/.tool-versions
 
   run asdf env dummy
   [ "$status" -eq 0 ]
@@ -68,7 +67,7 @@ teardown() {
 }
 
 @test "asdf env should set PATH correctly" {
-  echo "dummy 1.0" > $PROJECT_DIR/.tool-versions
+  echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
   run asdf install
 
   run asdf env dummy

--- a/test/uninstall_command.bats
+++ b/test/uninstall_command.bats
@@ -25,14 +25,14 @@ teardown() {
   [ "$status" -eq 0 ]
   [ $(cat $ASDF_DIR/installs/dummy/1.1.0/version) = "1.1.0" ]
   run asdf uninstall dummy 1.1.0
-  [ ! -f  $ASDF_DIR/installs/dummy/1.1.0/version ]
+  [ ! -f $ASDF_DIR/installs/dummy/1.1.0/version ]
 }
 
 @test "uninstall_command should invoke the plugin bin/uninstall if available" {
   run asdf install dummy 1.1.0
   [ "$status" -eq 0 ]
   mkdir -p $ASDF_DIR/plugins/dummy/bin
-  echo "echo custom uninstall" > $ASDF_DIR/plugins/dummy/bin/uninstall
+  echo "echo custom uninstall" >$ASDF_DIR/plugins/dummy/bin/uninstall
   chmod 755 $ASDF_DIR/plugins/dummy/bin/uninstall
   run asdf uninstall dummy 1.1.0
   [ "$output" == "custom uninstall" ]
@@ -84,7 +84,7 @@ teardown() {
 }
 
 @test "uninstall command executes configured pre hook" {
-  cat > $HOME/.asdfrc <<-'EOM'
+  cat >$HOME/.asdfrc <<-'EOM'
 pre_asdf_uninstall_dummy = echo will uninstall dummy $1
 EOM
 
@@ -94,7 +94,7 @@ EOM
 }
 
 @test "uninstall command executes configured post hook" {
-  cat > $HOME/.asdfrc <<-'EOM'
+  cat >$HOME/.asdfrc <<-'EOM'
 post_asdf_uninstall_dummy = echo removed dummy $1
 EOM
 

--- a/test/update_command.bats
+++ b/test/update_command.bats
@@ -45,7 +45,7 @@ teardown() {
 @test "asdf update should checkout the latest tag when configured with use_release_candidates = yes" {
   local tag=$(git tag | tail -1)
   export ASDF_CONFIG_DEFAULT_FILE=$BATS_TMPDIR/asdfrc_defaults
-  echo "use_release_candidates = yes" > $ASDF_CONFIG_DEFAULT_FILE
+  echo "use_release_candidates = yes" >$ASDF_CONFIG_DEFAULT_FILE
   run asdf update
   [ "$status" -eq 0 ]
   cd $ASDF_DIR

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -110,7 +110,7 @@ teardown() {
 }
 
 @test "parse_asdf_version_file should output version" {
-  echo "dummy 0.1.0" > $PROJECT_DIR/.tool-versions
+  echo "dummy 0.1.0" >$PROJECT_DIR/.tool-versions
   run parse_asdf_version_file $PROJECT_DIR/.tool-versions dummy
   [ "$status" -eq 0 ]
   [ "$output" == "0.1.0" ]
@@ -120,22 +120,22 @@ teardown() {
   PROJECT_DIR="$PROJECT_DIR/outer space"
   mkdir -p "$PROJECT_DIR"
   cd $outer
-  echo "dummy 0.1.0" > "$PROJECT_DIR/.tool-versions"
+  echo "dummy 0.1.0" >"$PROJECT_DIR/.tool-versions"
   run parse_asdf_version_file "$PROJECT_DIR/.tool-versions" dummy
   [ "$status" -eq 0 ]
   [ "$output" == "0.1.0" ]
 }
 
 @test "parse_asdf_version_file should output path version with spaces" {
-  echo "dummy path:/some/dummy path" > $PROJECT_DIR/.tool-versions
+  echo "dummy path:/some/dummy path" >$PROJECT_DIR/.tool-versions
   run parse_asdf_version_file $PROJECT_DIR/.tool-versions dummy
   [ "$status" -eq 0 ]
   [ "$output" == "path:/some/dummy path" ]
 }
 
 @test "find_versions should return .tool-versions if legacy is disabled" {
-  echo "dummy 0.1.0" > $PROJECT_DIR/.tool-versions
-  echo "0.2.0" > $PROJECT_DIR/.dummy-version
+  echo "dummy 0.1.0" >$PROJECT_DIR/.tool-versions
+  echo "0.2.0" >$PROJECT_DIR/.dummy-version
 
   run find_versions "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
@@ -143,9 +143,9 @@ teardown() {
 }
 
 @test "find_versions should return the legacy file if supported" {
-  echo "legacy_version_file = yes" > $HOME/.asdfrc
-  echo "dummy 0.1.0" > $HOME/.tool-versions
-  echo "0.2.0" > $PROJECT_DIR/.dummy-version
+  echo "legacy_version_file = yes" >$HOME/.asdfrc
+  echo "dummy 0.1.0" >$HOME/.tool-versions
+  echo "0.2.0" >$PROJECT_DIR/.dummy-version
 
   run find_versions "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
@@ -153,8 +153,8 @@ teardown() {
 }
 
 @test "find_versions skips .tool-version file that don't list the plugin" {
-  echo "dummy 0.1.0" > $HOME/.tool-versions
-  echo "another_plugin 0.3.0" > $PROJECT_DIR/.tool-versions
+  echo "dummy 0.1.0" >$HOME/.tool-versions
+  echo "another_plugin 0.3.0" >$PROJECT_DIR/.tool-versions
 
   run find_versions "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
@@ -162,9 +162,9 @@ teardown() {
 }
 
 @test "find_versions should return .tool-versions if unsupported" {
-  echo "dummy 0.1.0" > $HOME/.tool-versions
-  echo "0.2.0" > $PROJECT_DIR/.dummy-version
-  echo "legacy_version_file = yes" > $HOME/.asdfrc
+  echo "dummy 0.1.0" >$HOME/.tool-versions
+  echo "0.2.0" >$PROJECT_DIR/.dummy-version
+  echo "legacy_version_file = yes" >$HOME/.asdfrc
   rm $ASDF_DIR/plugins/dummy/bin/list-legacy-filenames
 
   run find_versions "dummy" $PROJECT_DIR
@@ -213,7 +213,7 @@ teardown() {
 
 @test "find_versions should return \$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME if set" {
   ASDF_DEFAULT_TOOL_VERSIONS_FILENAME="$PROJECT_DIR/global-tool-versions"
-  echo "dummy 0.1.0" > $ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
+  echo "dummy 0.1.0" >$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
 
   run find_versions "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
@@ -222,9 +222,9 @@ teardown() {
 
 @test "find_versions should check \$HOME legacy files before \$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME" {
   ASDF_DEFAULT_TOOL_VERSIONS_FILENAME="$PROJECT_DIR/global-tool-versions"
-  echo "dummy 0.2.0" > $ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
-  echo "dummy 0.1.0" > $HOME/.dummy-version
-  echo "legacy_version_file = yes" > $HOME/.asdfrc
+  echo "dummy 0.2.0" >$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
+  echo "dummy 0.1.0" >$HOME/.dummy-version
+  echo "legacy_version_file = yes" >$HOME/.asdfrc
 
   run find_versions "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
@@ -233,14 +233,14 @@ teardown() {
 
 @test "get_preset_version_for returns the current version" {
   cd $PROJECT_DIR
-  echo "dummy 0.2.0" > .tool-versions
+  echo "dummy 0.2.0" >.tool-versions
   run get_preset_version_for "dummy"
   [ "$status" -eq 0 ]
   [ "$output" = "0.2.0" ]
 }
 
 @test "get_preset_version_for returns the global version from home when project is outside of home" {
-  echo "dummy 0.1.0" > $HOME/.tool-versions
+  echo "dummy 0.1.0" >$HOME/.tool-versions
   PROJECT_DIR=$BASE_DIR/project
   mkdir -p $PROJECT_DIR
   run get_preset_version_for "dummy"
@@ -250,7 +250,7 @@ teardown() {
 
 @test "get_preset_version_for returns the tool version from env if ASDF_{TOOL}_VERSION is defined" {
   cd $PROJECT_DIR
-  echo "dummy 0.2.0" > .tool-versions
+  echo "dummy 0.2.0" >.tool-versions
   ASDF_DUMMY_VERSION=3.0.0 run get_preset_version_for "dummy"
   [ "$status" -eq 0 ]
   [ "$output" = "3.0.0" ]
@@ -258,7 +258,7 @@ teardown() {
 
 @test "get_preset_version_for should return branch reference version" {
   cd $PROJECT_DIR
-  echo "dummy ref:master" > $PROJECT_DIR/.tool-versions
+  echo "dummy ref:master" >$PROJECT_DIR/.tool-versions
   run get_preset_version_for "dummy"
   [ "$status" -eq 0 ]
   [ "$output" = "ref:master" ]
@@ -266,7 +266,7 @@ teardown() {
 
 @test "get_preset_version_for should return path version" {
   cd $PROJECT_DIR
-  echo "dummy path:/some/place with spaces" > $PROJECT_DIR/.tool-versions
+  echo "dummy path:/some/place with spaces" >$PROJECT_DIR/.tool-versions
   run get_preset_version_for "dummy"
   [ "$status" -eq 0 ]
   [ "$output" = "path:/some/place with spaces" ]
@@ -316,7 +316,7 @@ teardown() {
 }
 
 @test "find_tool_versions will find a .tool-versions path if it exists in current directory" {
-  echo "dummy 0.1.0" > $PROJECT_DIR/.tool-versions
+  echo "dummy 0.1.0" >$PROJECT_DIR/.tool-versions
   cd $PROJECT_DIR
 
   run find_tool_versions
@@ -325,7 +325,7 @@ teardown() {
 }
 
 @test "find_tool_versions will find a .tool-versions path if it exists in parent directory" {
-  echo "dummy 0.1.0" > $PROJECT_DIR/.tool-versions
+  echo "dummy 0.1.0" >$PROJECT_DIR/.tool-versions
   mkdir -p $PROJECT_DIR/child
   cd $PROJECT_DIR/child
 
@@ -380,7 +380,7 @@ teardown() {
 }
 
 @test "strip_tool_version_comments removes lines that only contain comments" {
-  cat <<EOF > test_file
+  cat <<EOF >test_file
 # comment line
 ruby 2.0.0
 EOF
@@ -389,14 +389,14 @@ EOF
   [ "$output" = "ruby 2.0.0" ]
 }
 @test "strip_tool_version_comments removes lines that only contain comments even with missing newline" {
-  echo -n "# comment line" > test_file
+  echo -n "# comment line" >test_file
   run strip_tool_version_comments test_file
   [ "$status" -eq 0 ]
   [ "$output" = "" ]
 }
 
 @test "strip_tool_version_comments removes trailing comments on lines containing version information" {
-  cat <<EOF > test_file
+  cat <<EOF >test_file
 ruby 2.0.0 # inline comment
 EOF
   run strip_tool_version_comments test_file
@@ -405,23 +405,24 @@ EOF
 }
 
 @test "strip_tool_version_comments removes trailing comments on lines containing version information even with missing newline" {
-  echo -n "ruby 2.0.0 # inline comment" > test_file
+  echo -n "ruby 2.0.0 # inline comment" >test_file
   run strip_tool_version_comments test_file
   [ "$status" -eq 0 ]
   [ "$output" = "ruby 2.0.0" ]
 }
 
 @test "strip_tool_version_comments removes all comments from the version file" {
-  cat <<EOF > test_file
+  cat <<EOF >test_file
 ruby 2.0.0 # inline comment
 # comment line
 erlang 18.2.1 # inline comment
 EOF
-  expected="$(cat <<EOF
+  expected="$(
+    cat <<EOF
 ruby 2.0.0
 erlang 18.2.1
 EOF
-)"
+  )"
   run strip_tool_version_comments test_file
   [ "$status" -eq 0 ]
   [ "$output" = "$expected" ]
@@ -429,7 +430,7 @@ EOF
 
 @test "with_shim_executable doesn't crash when executable names contain dashes" {
   cd $PROJECT_DIR
-  echo "dummy 0.1.0" > $PROJECT_DIR/.tool-versions
+  echo "dummy 0.1.0" >$PROJECT_DIR/.tool-versions
   mkdir -p $ASDF_DIR/installs/dummy/0.1.0/bin
   touch $ASDF_DIR/installs/dummy/0.1.0/bin/test-dash
   chmod +x $ASDF_DIR/installs/dummy/0.1.0/bin/test-dash

--- a/test/version_commands.bats
+++ b/test/version_commands.bats
@@ -111,7 +111,7 @@ teardown() {
 }
 
 @test "local should not create a duplicate .tool-versions file if such file exists" {
-  echo 'dummy 1.0.0' >> $PROJECT_DIR/.tool-versions
+  echo 'dummy 1.0.0' >>$PROJECT_DIR/.tool-versions
 
   run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
@@ -119,7 +119,7 @@ teardown() {
 }
 
 @test "local should overwrite the existing version if it's set" {
-  echo 'dummy 1.0.0' >> $PROJECT_DIR/.tool-versions
+  echo 'dummy 1.0.0' >>$PROJECT_DIR/.tool-versions
 
   run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
@@ -167,7 +167,7 @@ teardown() {
 
 @test "local -p/--parent should overwrite the existing version if it's set" {
   cd $CHILD_DIR
-  echo 'dummy 1.0.0' >> $PROJECT_DIR/.tool-versions
+  echo 'dummy 1.0.0' >>$PROJECT_DIR/.tool-versions
   run asdf local -p "dummy" "1.1.0"
   [ "$status" -eq 0 ]
   [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0" ]
@@ -230,7 +230,7 @@ teardown() {
 }
 
 @test "global should overwrite the existing version if it's set" {
-  echo 'dummy 1.0.0' >> $HOME/.tool-versions
+  echo 'dummy 1.0.0' >>$HOME/.tool-versions
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
   [ "$(cat $HOME/.tool-versions)" = "dummy 1.1.0" ]
@@ -260,14 +260,13 @@ teardown() {
 
 @test "local should overwrite contents of ASDF_DEFAULT_TOOL_VERSIONS_FILENAME if set" {
   export ASDF_DEFAULT_TOOL_VERSIONS_FILENAME="local-tool-versions"
-  echo 'dummy 1.0.0' >> "$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME"
+  echo 'dummy 1.0.0' >>"$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME"
   run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
   [ "$(cat $ASDF_DEFAULT_TOOL_VERSIONS_FILENAME)" = "dummy 1.1.0" ]
   [ "$(cat .tool-versions)" = "" ]
   unset ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
 }
-
 
 @test "global should write to ASDF_DEFAULT_TOOL_VERSIONS_FILENAME" {
   export ASDF_DEFAULT_TOOL_VERSIONS_FILENAME="global-tool-versions"
@@ -280,7 +279,7 @@ teardown() {
 
 @test "global should overwrite contents of ASDF_DEFAULT_TOOL_VERSIONS_FILENAME if set" {
   export ASDF_DEFAULT_TOOL_VERSIONS_FILENAME="global-tool-versions"
-  echo 'dummy 1.0.0' >> "$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME"
+  echo 'dummy 1.0.0' >>"$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME"
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
   [ "$(cat $HOME/$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME)" = "dummy 1.1.0" ]
@@ -434,28 +433,28 @@ false"
 }
 
 @test "[global - dummy_plugin] should support latest" {
-  echo 'dummy 1.0.0' >> $HOME/.tool-versions
+  echo 'dummy 1.0.0' >>$HOME/.tool-versions
   run asdf global "dummy" "1.0.0" "latest"
   [ "$status" -eq 0 ]
   [ "$(cat $HOME/.tool-versions)" = "dummy 1.0.0 2.0.0" ]
 }
 
 @test "[global - dummy_legcay_plugin] should support latest" {
-  echo 'legacy-dummy 1.0.0' >> $HOME/.tool-versions
+  echo 'legacy-dummy 1.0.0' >>$HOME/.tool-versions
   run asdf global "legacy-dummy" "1.0.0" "latest"
   [ "$status" -eq 0 ]
   [ "$(cat $HOME/.tool-versions)" = "legacy-dummy 1.0.0 5.1.0" ]
 }
 
 @test "[local - dummy_plugin] should support latest" {
-  echo 'dummy 1.0.0' >> $PROJECT_DIR/.tool-versions
+  echo 'dummy 1.0.0' >>$PROJECT_DIR/.tool-versions
   run asdf local "dummy" "1.0.0" "latest"
   [ "$status" -eq 0 ]
   [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.0.0 2.0.0" ]
 }
 
 @test "[local - dummy_legacy_plugin] should support latest" {
-  echo 'legacy-dummy 1.0.0' >> $PROJECT_DIR/.tool-versions
+  echo 'legacy-dummy 1.0.0' >>$PROJECT_DIR/.tool-versions
   run asdf local "legacy-dummy" "1.0.0" "latest"
   [ "$status" -eq 0 ]
   [ "$(cat $PROJECT_DIR/.tool-versions)" = "legacy-dummy 1.0.0 5.1.0" ]

--- a/test/which_command.bats
+++ b/test/which_command.bats
@@ -10,7 +10,7 @@ setup() {
 
   PROJECT_DIR=$HOME/project
   mkdir $PROJECT_DIR
-  echo 'dummy 1.0' >> $PROJECT_DIR/.tool-versions
+  echo 'dummy 1.0' >>$PROJECT_DIR/.tool-versions
 }
 
 teardown() {
@@ -36,7 +36,7 @@ teardown() {
 @test "which should show dummy 1.0 other binary" {
   cd $PROJECT_DIR
 
-  echo "echo bin bin/subdir" > "$ASDF_DIR/plugins/dummy/bin/list-bin-paths"
+  echo "echo bin bin/subdir" >"$ASDF_DIR/plugins/dummy/bin/list-bin-paths"
   chmod +x "$ASDF_DIR/plugins/dummy/bin/list-bin-paths"
   run asdf reshim dummy 1.0
 
@@ -46,7 +46,7 @@ teardown() {
 }
 
 @test "which should show path of system version" {
-  echo 'dummy system' > $PROJECT_DIR/.tool-versions
+  echo 'dummy system' >$PROJECT_DIR/.tool-versions
   cd $PROJECT_DIR
 
   mkdir $PROJECT_DIR/sys
@@ -59,7 +59,7 @@ teardown() {
 }
 
 @test "which report when missing executable on system version" {
-  echo 'dummy system' > $PROJECT_DIR/.tool-versions
+  echo 'dummy system' >$PROJECT_DIR/.tool-versions
   cd $PROJECT_DIR
 
   run asdf which "dummy"
@@ -87,10 +87,10 @@ teardown() {
 @test "which should return the path set by the legacy file" {
   cd $PROJECT_DIR
 
-  echo 'dummy 1.0' >> $HOME/.tool-versions
-  echo '1.1' >> $PROJECT_DIR/.dummy-version
+  echo 'dummy 1.0' >>$HOME/.tool-versions
+  echo '1.1' >>$PROJECT_DIR/.dummy-version
   rm $PROJECT_DIR/.tool-versions
-  echo 'legacy_version_file = yes' > $HOME/.asdfrc
+  echo 'legacy_version_file = yes' >$HOME/.asdfrc
 
   run asdf which "dummy"
   [ "$status" -eq 0 ]
@@ -99,7 +99,7 @@ teardown() {
 
 @test "which should not return shim path" {
   cd $PROJECT_DIR
-  echo 'dummy 1.0' > $PROJECT_DIR/.tool-versions
+  echo 'dummy 1.0' >$PROJECT_DIR/.tool-versions
   rm "$ASDF_DIR/installs/dummy/1.0/bin/dummy"
 
   run env PATH=$PATH:$ASDF_DIR/shims asdf which dummy


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

- Run tests in more environments, testing the latest and capturing regressions on existing supported systems.
  - I am not sure how useful this actually would be. We do often get weird reports from people using older versions on Ubuntu. I am open to changing this to `latest` for each of Ubuntu & macOS.
- bump BATS version.
- bump Shellcheck version.
- bump Shfmt version.

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->

The large diff is from `shfmt` updating single whitespace chars.