### PR TITLE
ci: configure dependabot scanning & PR generation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
       interval: "weekly"
     reviewers:
       - "jthegedus"
+      - "stratus3d"
   # Maintain dependencies for npm used in Documentation site
   - package-ecosystem: "npm"
     directory: "/docs"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "jthegedus"
+  # Maintain dependencies for npm used in Documentation site
+  - package-ecosystem: "npm"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "jthegedus"


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->
Dependabot can be configured via YAML to control the frequency of when it scans and raises PRs

Here it is configured to scan for:
- `docs/` directory for `npm` vulnerabilites.
- GitHub Actions for updates to the Actions used in Action Workflows themselves

I also assign myself as reviewer to not spam everyone else, we will see if this overrides the config in `.github/CODEOWNERS` which automatically applies the `asdf/core` team as reviewers, hopefully it does override.

The update schedule is set to `weekly`:
>When you set a `weekly` update schedule, by default, Dependabot checks for new versions on Monday at a random set time for the repository - [quote from docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleday)

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->

>By default, Dependabot opens a maximum of five pull requests for version updates. Once there are five open pull requests, new requests are blocked until you merge or close some of the open requests, after which new pull requests can be opened on subsequent updates ....
>This option has no impact on security updates, which have a separate, internal limit of ten open pull requests. - [quote from docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit)

I also enabled "Dependabot security updates":

![image](https://user-images.githubusercontent.com/20798510/175080343-4e884d39-e656-445b-8ed4-c59c42049618.png)

**NOTE**: I expect this to be a little noisy at first because we are on an old beta of [VitePress](https://vitepress.vuejs.org/). A new major release is imminent which I will update to quickly.