### PR TITLE
fix: gitignore macOS .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ repository
 .vagrant
 keyrings
 /tmp
+.DS_Store


### PR DESCRIPTION
# Summary

macOS Finder creates these hidden files. It's common to add this entry to .gitignore.