### PR TITLE
docs: further notes on disabling plugin repo

### DIFF
--- a/defaults
+++ b/defaults
@@ -1,2 +1,7 @@
-# enables the use of .ruby-version like files used by other version managers
+# See the docs for explanations: https://asdf-vm.com/manage/configuration.html
+
 legacy_version_file = no
+use_release_candidates = no
+always_keep_download = no
+plugin_repository_last_check_duration = 60
+disable_plugin_short_name_repository = no

--- a/docs/manage/configuration.md
+++ b/docs/manage/configuration.md
@@ -100,6 +100,12 @@ Sync events occur when the following commands are executed:
 
 `asdf plugin add <name> <git-url>` does NOT trigger a plugin sync.
 
+::: warning Note
+
+Setting the value to `never` does not stop the plugin repository from being initially synced, for that behaviour see `disable_plugin_short_name_repository`.
+
+:::
+
 ### `disable_plugin_short_name_repository`
 
 Disable synchronization of the asdf plugin short-name repository. Sync events will exit early if the short-name repository is disabled.
@@ -107,7 +113,7 @@ Disable synchronization of the asdf plugin short-name repository. Sync events wi
 | Options                                                    | Description                                               |
 | :--------------------------------------------------------- | :-------------------------------------------------------- |
 | `no` <Badge type="tip" text="default" vertical="middle" /> | Clone or update the asdf plugin repository on sync events |
-| `yes`                                                      | Disable short-name plugin repository                      |
+| `yes`                                                      | Disable the plugin short-name repository                  |
 
 Sync events occur when the following commands are executed:
 
@@ -117,6 +123,8 @@ Sync events occur when the following commands are executed:
 `asdf plugin add <name> <git-url>` does NOT trigger a plugin sync.
 
 ::: warning Note
+
+Disabling the plugin short-name repository does not remove the repository if it has already synced. Remove the plugin repo with `rm --recursive --trash $ASDF_DATA_DIR/repository`.
 
 Disabling the plugin short-name repository does not remove plugins previously installed from this source. Plugins can be removed with `asdf plugin remove <name>`. Removing a plugin will remove all installed versions of the managed tool.
 

--- a/docs/manage/configuration.md
+++ b/docs/manage/configuration.md
@@ -54,13 +54,7 @@ Edit the file directly or use `asdf local` (or `asdf global`) which updates it.
 
 Add an `.asdfrc` file to your home directory and asdf will use the settings specified in the file. The file below shows the required format with the default values to demonstrate:
 
-```:no-line-numbers
-legacy_version_file = no
-use_release_candidates = no
-always_keep_download = no
-plugin_repository_last_check_duration = 60
-disable_plugin_short_name_repository = no
-```
+@[code :no-line-numbers](../../defaults)
 
 ### `legacy_version_file`
 


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->
This is a follow up to #1227 to document behaviours further as noted in https://github.com/asdf-vm/asdf/pull/1227#issuecomment-1168043995

- note that `plugin_repository_last_check_duration` does not stop initial repo sync
- note that `disable_plugin_short_name_repository` does not remove the plugin repo if it has already been synced. Document how to remove the plugin repo if the user desires.
- consolidate the `~/.asdfrc` example file contents under the repo root `defaults` file and inline file itself.

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->
