### PR TITLE
docs: manually update version to 0.10.2

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -14,7 +14,9 @@
 **Linux**:
 
 ::: tip Note
+
 `sudo` may be required depending on your system configuration.
+
 :::
 
 | Package Manager | Command                   |
@@ -37,7 +39,7 @@ We recommend using Git, though there are other platform specific methods:
 
 | Method   | Command                                                                                                                                                             |
 | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Git      | `git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.10.0`                                                                                             |
+| Git      | `git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.10.2`                                                                                             |
 | Homebrew | `brew install asdf`                                                                                                                                                 |
 | Pacman   | `git clone https://aur.archlinux.org/asdf-vm.git && cd asdf-vm && makepkg -si` or use your preferred [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers) |
 


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

Update the version in the Getting Started guide to `0.10.2`.

This is would have been corrected by #1293 with the next release, but this will get new non-homebrew users onto the latest release, instead of the apr2022 release.