### PR TITLE
feat: Allow for custom global tool-versions location

### DIFF
--- a/lib/functions/versions.bash
+++ b/lib/functions/versions.bash
@@ -20,7 +20,7 @@ version_command() {
   file_name="$(version_file_name)"
 
   if [ "$cmd" = "global" ]; then
-    file="$HOME/$file_name"
+    file="$(asdf_config_dir)/$file_name"
   elif [ "$cmd" = "local-tree" ]; then
     file=$(find_tool_versions)
   else # cmd = local

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -50,6 +50,18 @@ asdf_data_dir() {
   printf "%s\\n" "$data_dir"
 }
 
+asdf_config_dir() {
+  local config_dir="${HOME}"
+
+  if [ -n "${ASDF_CONFIG_DIR}" ]; then
+    config_dir="${ASDF_CONFIG_DIR}"
+  elif [ -n "${XDG_CONFIG_HOME}" ]; then
+    config_dir="${XDG_CONFIG_HOME}/asdf"
+  fi
+
+  printf "%s\\n" "${config_dir}"
+}
+
 get_install_path() {
   local plugin=$1
   local install_type=$2

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -446,3 +446,32 @@ EOF
   [ "$status" -eq 0 ]
   [ "$output" = "$message" ]
 }
+
+@test "asdf_config_dir should return user dir when ASDF_CONFIG_DIR is set and XDG_CONFIG_HOME is not set" {
+  export ASDF_CONFIG_DIR="/tmp/test1"
+  export XDG_CONFIG_HOME="/tmp/test2"
+
+  run asdf_config_dir
+
+  echo "${ASDF_CONFIG_DIR}:${XDG_CONFIG_HOME}:$(asdf_config_dir)"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$ASDF_CONFIG_DIR" ]
+}
+
+@test "asdf_config_dir should return user dir when XDG_CONFIG_HOME is set and ASDF_CONFIG_DIR is not set" {
+  unset ASDF_CONFIG_DIR
+  export XDG_CONFIG_HOME="/tmp/test2"
+
+  run asdf_config_dir
+  [ "$status" -eq 0 ]
+  [ "$output" = "$XDG_CONFIG_HOME/asdf" ]
+}
+
+@test "asdf_config_dir should return HOME when ASDF_CONFIG_DIR and XDG_CONFIG_HOME are not set" {
+  unset ASDF_CONFIG_DIR
+  unset XDG_CONFIG_HOME
+
+  run asdf_config_dir
+  [ "$status" -eq 0 ]
+  [ "$output" = "$HOME" ]
+}

--- a/test/version_commands.bats
+++ b/test/version_commands.bats
@@ -3,6 +3,9 @@
 load test_helpers
 
 setup() {
+  # Unset XDG_CONFIG_HOME to ensure it uses HOME for determine location
+  unset XDG_CONFIG_HOME
+
   setup_asdf_dir
   install_dummy_plugin
   install_dummy_version "1.0.0"
@@ -185,6 +188,20 @@ teardown() {
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
   [ "$(cat $HOME/.tool-versions)" = "dummy 1.1.0" ]
+}
+
+@test "global should create a global .tool-versions in ASDF_CONFIG_DIR if it doesn't exist" {
+  export ASDF_CONFIG_DIR="/tmp/test"
+  run asdf global "dummy" "1.1.0"
+  [ "$status" -eq 0 ]
+  [ "$(cat $ASDF_CONFIG_DIR/.tool-versions)" = "dummy 1.1.0" ]
+}
+
+@test "global should create a global .tool-versions in XDG_CONFIG_HOME if it doesn't exist" {
+  export XDG_CONFIG_HOME="/tmp/test"
+  run asdf global "dummy" "1.1.0"
+  [ "$status" -eq 0 ]
+  [ "$(cat $XDG_CONFIG_HOME/asdf/.tool-versions)" = "dummy 1.1.0" ]
 }
 
 @test "[global - dummy_plugin] with latest should use the latest installed version" {


### PR DESCRIPTION
# Summary

Since a recent bug fix to the behaviour around the env variable `ADSF_DEFAULT_TOOL_VERSIONS_FILENAME`, which I also abused to follow the XDG spec, I was unable to move my global `.tool-versions`. As was also reported by other people in #1248.

This PR allows the user to give a custom location via `ASDF_CONFIG_DIR` if set (for those who want it to move the file and don't follow the XDG spec), `XDG_CONFIG_HOME`, or falls back to `HOME`.

I'm open to suggestions if another approach is better.

Related issues: #687


