### PR TITLE
chore: alphabetise help txt manage packages section

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -14,6 +14,14 @@ asdf plugin update --all                Update all plugins to latest commit on
 
 
 MANAGE PACKAGES
+asdf current                            Display current version set or being
+                                        used for all packages
+asdf current <name>                     Display current version set or being
+                                        used for package
+asdf global <name> <version>            Set the package global version
+asdf global <name> latest[:<version>]   Set the package global version to the
+                                        latest provided version
+asdf help <name> [<version>]            Output documentation for plugin and tool
 asdf install                            Install all the package versions listed
                                         in the .tool-versions file
 asdf install <name>                     Install one tool at the version
@@ -23,22 +31,6 @@ asdf install <name> latest[:<version>]  Install the latest stable version of a
                                         package, or with optional version,
                                         install the latest stable version that
                                         begins with the given string
-asdf uninstall <name> <version>         Remove a specific version of a package
-asdf current                            Display current version set or being
-                                        used for all packages
-asdf current <name>                     Display current version set or being
-                                        used for package
-asdf where <name> [<version>]           Display install path for an installed
-                                        or current version
-asdf which <command>                    Display the path to an executable
-asdf local <name> <version>             Set the package local version
-asdf local <name> latest[:<version>]    Set the package local version to the
-                                        latest provided version
-asdf global <name> <version>            Set the package global version
-asdf global <name> latest[:<version>]   Set the package global version to the
-                                        latest provided version
-asdf shell <name> <version>             Set the package version to
-                                        `ASDF_${LANG}_VERSION` in the current shell
 asdf latest <name> [<version>]          Show latest stable version of a package
 asdf latest --all                       Show latest stable version of all the
                                         packages and if they are installed
@@ -46,7 +38,15 @@ asdf list <name> [version]              List installed versions of a package and
                                         optionally filter the versions
 asdf list all <name> [<version>]        List all versions of a package and
                                         optionally filter the returned versions
-asdf help <name> [<version>]            Output documentation for plugin and tool
+asdf local <name> <version>             Set the package local version
+asdf local <name> latest[:<version>]    Set the package local version to the
+                                        latest provided version
+asdf shell <name> <version>             Set the package version to
+                                        `ASDF_${LANG}_VERSION` in the current shell
+asdf uninstall <name> <version>         Remove a specific version of a package
+asdf where <name> [<version>]           Display install path for an installed
+                                        or current version
+asdf which <command>                    Display the path to an executable
 
 
 UTILS


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

The MANAGE PACKAGES section of the help text has the commands grouped based on intent and not alphabetically. It may or may not be on purpose, but all other sections are alphabetical, so this seems out of place and can be confusing.

Feel free to close if this is not agreeable.