### PR TITLE
refactor: use `fish_add_path` during fish setup if available

### DIFF
--- a/asdf.fish
+++ b/asdf.fish
@@ -2,12 +2,38 @@ if not set -q ASDF_DIR
   set -x ASDF_DIR (dirname (status -f))
 end
 
-fish_add_path --global --move $ASDF_DIR/bin
+# Add asdf to PATH
+# fish_add_path was added in fish 3.2, so we need a fallback for older version
+if type -q fish_add_path
+  fish_add_path --global --move $ASDF_DIR/bin
 
-if test -n "$ASDF_DATA_DIR"
-  fish_add_path --global --move "$ASDF_DATA_DIR/shims"
+  if test -n "$ASDF_DATA_DIR"
+    fish_add_path --global --move "$ASDF_DATA_DIR/shims"
+  else
+    fish_add_path --global --move "$HOME/.asdf/shims"
+  end
 else
-  fish_add_path --global --move "$HOME/.asdf/shims"
+  set -l asdf_user_shims (
+    if test -n "$ASDF_DATA_DIR"
+      printf "%s\n" "$ASDF_DATA_DIR/shims"
+    else
+      printf "%s\n" "$HOME/.asdf/shims"
+    end
+  )
+
+  set -l asdf_bin_dirs $ASDF_DIR/bin $asdf_user_shims
+
+  for x in $asdf_bin_dirs
+    if test -d $x
+      for i in (seq 1 (count $PATH))
+        if test $PATH[$i] = $x
+          set -e PATH[$i]
+          break
+        end
+      end
+    end
+    set PATH $x $PATH
+  end
 end
 
 # Load the asdf wrapper function

--- a/asdf.fish
+++ b/asdf.fish
@@ -5,12 +5,10 @@ end
 # Add asdf to PATH
 # fish_add_path was added in fish 3.2, so we need a fallback for older version
 if type -q fish_add_path
-  fish_add_path --global --move $ASDF_DIR/bin
-
   if test -n "$ASDF_DATA_DIR"
-    fish_add_path --global --move "$ASDF_DATA_DIR/shims"
+    fish_add_path --global --move "$ASDF_DATA_DIR/shims" "$ASDF_DIR/bin"
   else
-    fish_add_path --global --move "$HOME/.asdf/shims"
+    fish_add_path --global --move "$HOME/.asdf/shims" "$ASDF_DIR/bin"
   end
 else
   set -l asdf_user_shims (

--- a/asdf.fish
+++ b/asdf.fish
@@ -2,27 +2,12 @@ if not set -q ASDF_DIR
   set -x ASDF_DIR (dirname (status -f))
 end
 
-set -l asdf_user_shims (
-  if test -n "$ASDF_DATA_DIR"
-    printf "%s\n" "$ASDF_DATA_DIR/shims"
-  else
-    printf "%s\n" "$HOME/.asdf/shims"
-  end
-)
+fish_add_path --global --move $ASDF_DIR/bin
 
-# Add asdf to PATH
-set -l asdf_bin_dirs $ASDF_DIR/bin $asdf_user_shims
-
-for x in $asdf_bin_dirs
-  if test -d $x
-    for i in (seq 1 (count $PATH))
-      if test $PATH[$i] = $x
-        set -e PATH[$i]
-        break
-      end
-    end
-  end
-  set PATH $x $PATH
+if test -n "$ASDF_DATA_DIR"
+  fish_add_path --global --move "$ASDF_DATA_DIR/shims"
+else
+  fish_add_path --global --move "$HOME/.asdf/shims"
 end
 
 # Load the asdf wrapper function


### PR DESCRIPTION
# Summary

Instead of modifying the PATH variable directly, use `fish_add_path` utility function provided by fish.

## Other Information

`fish_add_path` documentation: https://fishshell.com/docs/current/cmds/fish_add_path.html

Use `--global` option to modify only current session.
Use `--move` option to move the paths to front of other items in the path instead of keeping them on the previous position if already in the path.
