### PR TITLE
test: use resulting PATH on duplicated source tests

### DIFF
--- a/test/asdf_elvish.bats
+++ b/test/asdf_elvish.bats
@@ -83,7 +83,7 @@ cleaned_path() {
     echo \$E:PATH
   ")
   [ "$?" -eq 0 ]
-  output=$(echo $PATH | tr ':' '\n' | grep "asdf" | sort | uniq -d)
+  output=$(echo $result | tr ':' '\n' | grep "asdf" | sort | uniq -d)
   [ "$output" = "" ]
 }
 

--- a/test/asdf_fish.bats
+++ b/test/asdf_fish.bats
@@ -51,7 +51,7 @@ cleaned_path() {
     echo \$PATH
   ")
   [ "$?" -eq 0 ]
-  output=$(echo $PATH | tr ':' '\n' | grep "asdf" | sort | uniq -d)
+  output=$(echo $result | tr ' ' '\n' | grep "asdf" | sort | uniq -d)
   [ "$output" = "" ]
 }
 

--- a/test/asdf_sh.bats
+++ b/test/asdf_sh.bats
@@ -68,7 +68,7 @@ cleaned_path() {
     echo $PATH
   )
 
-  output=$(echo $PATH | tr ':' '\n' | grep "asdf" | sort | uniq -d)
+  output=$(echo $result | tr ':' '\n' | grep "asdf" | sort | uniq -d)
   [ "$?" -eq 0 ]
   [ "$output" = "" ]
 }


### PR DESCRIPTION
# Summary

On the tests verifying if the path items are not added multiple times to PATH when asdf is sourced twice, instead of checking the resulting PATH, the tests were checking the current terminal PATH