### PR TITLE
fix: Use ${BASH_SOURCE[0]} instead of $0 to link scripts

### DIFF
--- a/bin/asdf
+++ b/bin/asdf
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # shellcheck source=lib/utils.bash
-. "$(dirname "$(dirname "$0")")/lib/utils.bash"
+. "$(dirname "$(dirname "${BASH_SOURCE[0]}")")/lib/utils.bash"
 
 find_cmd() {
   local cmd_dir="$1"

--- a/bin/private/asdf-exec
+++ b/bin/private/asdf-exec
@@ -3,7 +3,7 @@
 # remove this asdf-exec file when releasing >=0.6.5
 printf "asdf is self upgrading shims to new asdf exec ...\\n"
 
-asdf_dir="$(dirname "$(dirname "$(dirname "$0")")")"
+asdf_dir="$(dirname "$(dirname "$(dirname "${BASH_SOURCE[0]}")")")"
 # shellcheck source=lib/utils.bash
 . "$asdf_dir/lib/utils.bash"
 rm "$(asdf_data_dir)"/shims/*

--- a/lib/commands/command-current.bash
+++ b/lib/commands/command-current.bash
@@ -1,6 +1,6 @@
 # -*- sh -*-
 # shellcheck source=lib/functions/plugins.bash
-. "$(dirname "$(dirname "$0")")/lib/functions/plugins.bash"
+. "$(dirname "$(dirname "$(dirname "${BASH_SOURCE[0]}")")")/lib/functions/plugins.bash"
 
 # shellcheck disable=SC2059
 plugin_current_command() {

--- a/lib/commands/command-export-shell-version.bash
+++ b/lib/commands/command-export-shell-version.bash
@@ -1,6 +1,6 @@
 # -*- sh -*-
 # shellcheck source=lib/functions/versions.bash
-. "$(dirname "$(dirname "$0")")/lib/functions/versions.bash"
+. "$(dirname "$(dirname "$(dirname "${BASH_SOURCE[0]}")")")/lib/functions/versions.bash"
 
 # Output from this command must be executable shell code
 shell_command() {

--- a/lib/commands/command-help.bash
+++ b/lib/commands/command-help.bash
@@ -1,6 +1,6 @@
 # -*- sh -*-
 # shellcheck source=lib/functions/versions.bash
-. "$(dirname "$(dirname "$0")")/lib/functions/versions.bash"
+. "$(dirname "$(dirname "$(dirname "${BASH_SOURCE[0]}")")")/lib/functions/versions.bash"
 
 asdf_help() {
   printf "version: %s\\n\\n" "$(asdf_version)"

--- a/lib/commands/command-info.bash
+++ b/lib/commands/command-info.bash
@@ -1,6 +1,6 @@
 # -*- sh -*-
 # shellcheck source=lib/functions/plugins.bash
-. "$(dirname "$(dirname "$0")")/lib/functions/plugins.bash"
+. "$(dirname "$(dirname "$(dirname "${BASH_SOURCE[0]}")")")/lib/functions/plugins.bash"
 
 info_command() {
   printf "%s:\\n%s\\n\\n" "OS" "$(uname -a)"

--- a/lib/commands/command-install.bash
+++ b/lib/commands/command-install.bash
@@ -1,9 +1,9 @@
 # -*- sh -*-
 # shellcheck source=lib/functions/versions.bash
-. "$(dirname "$(dirname "$0")")/lib/functions/versions.bash"
+. "$(dirname "$(dirname "$(dirname "${BASH_SOURCE[0]}")")")/lib/functions/versions.bash"
 # shellcheck source=lib/commands/reshim.bash
 . "$(dirname "$ASDF_CMD_FILE")/reshim.bash"
 # shellcheck source=lib/functions/installs.bash
-. "$(dirname "$(dirname "$0")")/lib/functions/installs.bash"
+. "$(dirname "$(dirname "$(dirname "${BASH_SOURCE[0]}")")")/lib/functions/installs.bash"
 
 install_command "$@"

--- a/lib/commands/command-latest.bash
+++ b/lib/commands/command-latest.bash
@@ -1,5 +1,5 @@
 # -*- sh -*-
 # shellcheck source=lib/functions/versions.bash
-. "$(dirname "$(dirname "$0")")/lib/functions/versions.bash"
+. "$(dirname "$(dirname "$(dirname "${BASH_SOURCE[0]}")")")/lib/functions/versions.bash"
 
 latest_command "$@"

--- a/lib/commands/command-list-all.bash
+++ b/lib/commands/command-list-all.bash
@@ -1,5 +1,5 @@
 # -*- sh -*-
 # shellcheck source=lib/functions/versions.bash
-. "$(dirname "$(dirname "$0")")/lib/functions/versions.bash"
+. "$(dirname "$(dirname "$(dirname "${BASH_SOURCE[0]}")")")/lib/functions/versions.bash"
 
 list_all_command "$@"

--- a/lib/commands/command-plugin-add.bash
+++ b/lib/commands/command-plugin-add.bash
@@ -1,5 +1,5 @@
 # -*- sh -*-
 # shellcheck source=lib/functions/plugins.bash
-. "$(dirname "$(dirname "$0")")/lib/functions/plugins.bash"
+. "$(dirname "$(dirname "$(dirname "${BASH_SOURCE[0]}")")")/lib/functions/plugins.bash"
 
 plugin_add_command "$@"

--- a/lib/commands/command-plugin-list.bash
+++ b/lib/commands/command-plugin-list.bash
@@ -1,5 +1,5 @@
 # -*- sh -*-
 # shellcheck source=lib/functions/plugins.bash
-. "$(dirname "$(dirname "$0")")/lib/functions/plugins.bash"
+. "$(dirname "$(dirname "$(dirname "${BASH_SOURCE[0]}")")")/lib/functions/plugins.bash"
 
 plugin_list_command "$@"

--- a/lib/commands/command-plugin-test.bash
+++ b/lib/commands/command-plugin-test.bash
@@ -1,12 +1,12 @@
 # -*- sh -*-
 # shellcheck source=lib/functions/versions.bash
-. "$(dirname "$(dirname "$0")")/lib/functions/versions.bash"
+. "$(dirname "$(dirname "$(dirname "${BASH_SOURCE[0]}")")")/lib/functions/versions.bash"
 # shellcheck source=lib/functions/plugins.bash
-. "$(dirname "$(dirname "$0")")/lib/functions/plugins.bash"
+. "$(dirname "$(dirname "$(dirname "${BASH_SOURCE[0]}")")")/lib/functions/plugins.bash"
 # shellcheck source=lib/commands/reshim.bash
 . "$(dirname "$ASDF_CMD_FILE")/reshim.bash"
 # shellcheck source=lib/functions/installs.bash
-. "$(dirname "$(dirname "$0")")/lib/functions/installs.bash"
+. "$(dirname "$(dirname "$(dirname "${BASH_SOURCE[0]}")")")/lib/functions/installs.bash"
 
 plugin_test_command() {
 

--- a/lib/commands/command-plugin-update.bash
+++ b/lib/commands/command-plugin-update.bash
@@ -1,5 +1,5 @@
 # -*- sh -*-
 # shellcheck source=lib/functions/plugins.bash
-. "$(dirname "$(dirname "$0")")/lib/functions/plugins.bash"
+. "$(dirname "$(dirname "$(dirname "${BASH_SOURCE[0]}")")")/lib/functions/plugins.bash"
 
 plugin_update_command "$@"

--- a/lib/commands/version_commands.bash
+++ b/lib/commands/version_commands.bash
@@ -1,3 +1,3 @@
 # -*- sh -*-
 # shellcheck source=lib/functions/versions.bash
-. "$(dirname "$(dirname "$0")")/lib/functions/versions.bash"
+. "$(dirname "$(dirname "$(dirname "${BASH_SOURCE[0]}")")")/lib/functions/versions.bash"


### PR DESCRIPTION
# Summary

While trying to run `asdf` in a Jenkins kubernetes agent, we noticed the following error:

```
/home/jenkins/.asdf/bin/asdf: line 5: ./lib/utils.bash: No such file or directory
/home/jenkins/.asdf/bin/asdf: line 28: asdf_dir: command not found
/home/jenkins/.asdf/bin/asdf: line 81: asdf_dir: command not found
Unknown command: `asdf current`
```

We noticed that this stems from using `dirname "$0"` to find the path to the current script.

Depending on the context in which the script is run, `$0` seems to return different values.

Changing all occurrences by `${BASH_SOURCE[0]}` or directly using `${ASDF_DIR}` seems to fix this.

You can reproduce this by:

* creating the Dockerfile below
    ```Dockerfile
    FROM ubuntu

    RUN apt update \
      && apt install git -y \
      && git clone https://github.com/asdf-vm/asdf.git ~/.asdf

    ENV BASH_ENV=/root/.asdf/asdf.sh
    ```
* building the Docker image like with:
    ```bash
    docker buildx build --tag asdf .
    ```
* run the following command:
    ```bash
    docker run -it --rm "$IMAGE" bash asdf current
    ```

## Test the fix

I tested the fix by following the same instructions with the Docker image created from my code by putting the following Dockerfile in the repository:

```Dockerfile
FROM ubuntu

COPY . /root/.asdf

RUN apt update && apt install git -y

ENV BASH_ENV=/root/.asdf/asdf.sh
```

This was not a full test though.


Linked to #1334