### PR TITLE
refactor: Improve Bash Syntax

### DIFF
--- a/bin/asdf
+++ b/bin/asdf
@@ -16,9 +16,9 @@ find_cmd() {
   done
 
   if [ -f "$cmd_dir/$cmd_name" ]; then
-    printf "%s %s\\n" "$cmd_dir/$cmd_name" "$((args_offset + 1))"
+    printf "%s %s\n" "$cmd_dir/$cmd_name" "$((args_offset + 1))"
   elif [ -f "$cmd_dir/command.bash" ]; then
-    printf "%s %s\\n" "$cmd_dir/command.bash" 1
+    printf "%s %s\n" "$cmd_dir/command.bash" 1
   fi
 }
 
@@ -29,15 +29,15 @@ find_asdf_cmd() {
   'exec' | 'current' | 'env' | 'global' | 'install' | 'latest' | 'local' | \
     'reshim' | 'uninstall' | 'update' | 'where' | 'which' | \
     'export-shell-version')
-    printf "%s %s\\n" "$asdf_cmd_dir/command-$1.bash" 2
+    printf "%s %s\n" "$asdf_cmd_dir/command-$1.bash" 2
     ;;
 
   '' | '--help' | '-h' | 'help')
-    printf "%s %s\\n" "$asdf_cmd_dir/command-help.bash" 2
+    printf "%s %s\n" "$asdf_cmd_dir/command-help.bash" 2
     ;;
 
   '--version' | 'version')
-    printf "%s %s\\n" "$asdf_cmd_dir/command-version.bash" 2
+    printf "%s %s\n" "$asdf_cmd_dir/command-version.bash" 2
     ;;
 
   *)
@@ -52,7 +52,7 @@ find_plugin_cmd() {
     IFS=' ' read -r ASDF_CMD_FILE args_offset <<<"$(find_cmd "$(get_plugin_path "$1")/lib/commands" "${@:2}")"
     if [ -n "$ASDF_CMD_FILE" ]; then
       args_offset=$((args_offset + 1)) # since the first argument is the plugin name
-      printf "%s %s\\n" "$ASDF_CMD_FILE" "$args_offset"
+      printf "%s %s\n" "$ASDF_CMD_FILE" "$args_offset"
     fi
   fi
 }
@@ -78,7 +78,7 @@ asdf_cmd() {
   else
     local asdf_cmd_dir
     asdf_cmd_dir="$(asdf_dir)/lib/commands"
-    printf "%s\\n" "Unknown command: \`asdf ${*}\`" >&2
+    printf "%s\n" "Unknown command: \`asdf ${*}\`" >&2
     . "$asdf_cmd_dir/command-help.bash" >&2
     return 127
   fi

--- a/bin/private/asdf-exec
+++ b/bin/private/asdf-exec
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # remove this asdf-exec file when releasing >=0.6.5
-printf "asdf is self upgrading shims to new asdf exec ...\\n"
+printf "asdf is self upgrading shims to new asdf exec ...\n"
 
 asdf_dir="$(dirname "$(dirname "$(dirname "$0")")")"
 # shellcheck source=lib/utils.bash
@@ -10,6 +10,6 @@ rm "$(asdf_data_dir)"/shims/*
 "$asdf_dir"/bin/asdf reshim
 shim_name=$(basename "$2")
 
-printf "asdf: now running %s\\n" "$shim_name"
+printf "asdf: now running %s\n" "$shim_name"
 
 exec "$shim_name" "${@:3}"

--- a/lib/commands/command-current.bash
+++ b/lib/commands/command-current.bash
@@ -44,7 +44,7 @@ plugin_current_command() {
 
 # shellcheck disable=SC2059
 current_command() {
-  local terminal_format="%-15s %-15s %-10s\\n"
+  local terminal_format="%-15s %-15s %-10s\n"
   local exit_status=0
   local plugin
 
@@ -75,8 +75,8 @@ check_for_deprecated_plugin() {
   local new_script="${plugin_path}/bin/list-legacy-filenames"
 
   if [ "$legacy_config" = "yes" ] && [ -f "$deprecated_script" ] && [ ! -f "$new_script" ]; then
-    printf "Heads up! It looks like your %s plugin is out of date. You can update it with:\\n\\n" "$plugin_name"
-    printf "  asdf plugin-update %s\\n\\n" "$plugin_name"
+    printf "Heads up! It looks like your %s plugin is out of date. You can update it with:\n\n" "$plugin_name"
+    printf "  asdf plugin-update %s\n\n" "$plugin_name"
   fi
 }
 

--- a/lib/commands/command-current.bash
+++ b/lib/commands/command-current.bash
@@ -10,7 +10,7 @@ plugin_current_command() {
   check_if_plugin_exists "$plugin_name"
 
   local search_path
-  search_path=$(pwd)
+  search_path=$PWD
   local version_and_path
   version_and_path=$(find_versions "$plugin_name" "$search_path")
   local full_version

--- a/lib/commands/command-env.bash
+++ b/lib/commands/command-env.bash
@@ -6,7 +6,7 @@ shim_env_command() {
   local env_args=("${@:3}")
 
   if [ -z "$shim_name" ]; then
-    printf "usage: asdf env <command>\\n"
+    printf "usage: asdf env <command>\n"
     exit 1
   fi
 

--- a/lib/commands/command-exec.bash
+++ b/lib/commands/command-exec.bash
@@ -6,7 +6,7 @@ shim_exec_command() {
   local shim_args=("${@:2}")
 
   if [ -z "$shim_name" ]; then
-    printf "usage: asdf exec <command>\\n"
+    printf "usage: asdf exec <command>\n"
     exit 1
   fi
 
@@ -16,7 +16,7 @@ shim_exec_command() {
     local executable_path="$3"
 
     if [ ! -x "$executable_path" ]; then
-      printf "No %s executable found for %s %s\\n" "$shim_name" "$plugin_name" "$version" >&2
+      printf "No %s executable found for %s %s\n" "$shim_name" "$plugin_name" "$version" >&2
       exit 2
     fi
 

--- a/lib/commands/command-export-shell-version.bash
+++ b/lib/commands/command-export-shell-version.bash
@@ -8,8 +8,8 @@ shell_command() {
   shift
 
   if [ "$#" -lt "2" ]; then
-    printf "Usage: asdf shell <name> {<version>|--unset}\\n" >&2
-    printf "false\\n"
+    printf "Usage: asdf shell <name> {<version>|--unset}\n" >&2
+    printf "false\n"
     exit 1
   fi
 
@@ -23,7 +23,7 @@ shell_command() {
   if [ "$version" = "--unset" ]; then
     case "$asdf_shell" in
     fish)
-      printf "set -e %s\\n" "$version_env_var"
+      printf "set -e %s\n" "$version_env_var"
       ;;
     elvish)
       # Elvish doesn't have a `source` command, and eval is banned, so the
@@ -32,7 +32,7 @@ shell_command() {
       printf "unset-env\n%s" "$version_env_var"
       ;;
     *)
-      printf "unset %s\\n" "$version_env_var"
+      printf "unset %s\n" "$version_env_var"
       ;;
     esac
     exit 0
@@ -42,13 +42,13 @@ shell_command() {
   fi
   if ! (check_if_version_exists "$plugin" "$version"); then
     version_not_installed_text "$plugin" "$version" 1>&2
-    printf "false\\n"
+    printf "false\n"
     exit 1
   fi
 
   case "$asdf_shell" in
   fish)
-    printf "set -gx %s \"%s\"\\n" "$version_env_var" "$version"
+    printf "set -gx %s \"%s\"\n" "$version_env_var" "$version"
     ;;
   elvish)
     # Elvish doesn't have a `source` command, and eval is banned, so the
@@ -57,7 +57,7 @@ shell_command() {
     printf "set-env\n%s\n%s" "$version_env_var" "$version"
     ;;
   *)
-    printf "export %s=\"%s\"\\n" "$version_env_var" "$version"
+    printf "export %s=\"%s\"\n" "$version_env_var" "$version"
     ;;
   esac
 }

--- a/lib/commands/command-help.bash
+++ b/lib/commands/command-help.bash
@@ -3,7 +3,7 @@
 . "$(dirname "$(dirname "$0")")/lib/functions/versions.bash"
 
 asdf_help() {
-  printf "version: %s\\n\\n" "$(asdf_version)"
+  printf "version: %s\n\n" "$(asdf_version)"
   cat "$(asdf_dir)/help.txt"
 }
 
@@ -23,7 +23,7 @@ asdf_extension_cmds() {
     ext_cmd_path="$plugin_path/lib/commands"
     ext_cmds="$(find "$ext_cmd_path" -name "command*.bash" 2>/dev/null)"
     if [[ -n $ext_cmds ]]; then
-      printf "\\nPLUGIN %s\\n" "$plugin"
+      printf "\nPLUGIN %s\n" "$plugin"
       for ext_cmd in $ext_cmds; do
         ext_cmd_name="$(basename "$ext_cmd")"
         sed "s/-/ /g;s/.bash//;s/command-*/  asdf $plugin/;" <<<"$ext_cmd_name"
@@ -78,11 +78,11 @@ help_command() {
           (print_plugin_help "$plugin_path")
         fi
       else
-        printf "No documentation for plugin %s\\n" "$plugin_name" >&2
+        printf "No documentation for plugin %s\n" "$plugin_name" >&2
         exit 1
       fi
     else
-      printf "No plugin named %s\\n" "$plugin_name" >&2
+      printf "No plugin named %s\n" "$plugin_name" >&2
       exit 1
     fi
   else

--- a/lib/commands/command-info.bash
+++ b/lib/commands/command-info.bash
@@ -3,11 +3,11 @@
 . "$(dirname "$(dirname "$0")")/lib/functions/plugins.bash"
 
 info_command() {
-  printf "%s:\\n%s\\n\\n" "OS" "$(uname -a)"
-  printf "%s:\\n%s\\n\\n" "SHELL" "$($SHELL --version)"
-  printf "%s:\\n%s\\n\\n" "ASDF VERSION" "$(asdf_version)"
-  printf "%s:\\n%s\\n\\n" "ASDF ENVIRONMENT VARIABLES" "$(env | grep -E "ASDF_DIR|ASDF_DATA_DIR|ASDF_CONFIG_FILE|ASDF_DEFAULT_TOOL_VERSIONS_FILENAME")"
-  printf "%s:\\n%s\\n\\n" "ASDF INSTALLED PLUGINS" "$(plugin_list_command --urls --refs)"
+  printf "%s:\n%s\n\n" "OS" "$(uname -a)"
+  printf "%s:\n%s\n\n" "SHELL" "$($SHELL --version)"
+  printf "%s:\n%s\n\n" "ASDF VERSION" "$(asdf_version)"
+  printf "%s:\n%s\n\n" "ASDF ENVIRONMENT VARIABLES" "$(env | grep -E "ASDF_DIR|ASDF_DATA_DIR|ASDF_CONFIG_FILE|ASDF_DEFAULT_TOOL_VERSIONS_FILENAME")"
+  printf "%s:\n%s\n\n" "ASDF INSTALLED PLUGINS" "$(plugin_list_command --urls --refs)"
 }
 
 info_command "$@"

--- a/lib/commands/command-list.bash
+++ b/lib/commands/command-list.bash
@@ -11,11 +11,11 @@ list_command() {
     if find "$plugins_path" -mindepth 1 -type d &>/dev/null; then
       for plugin_path in "$plugins_path"/*/; do
         plugin_name=$(basename "$plugin_path")
-        printf "%s\\n" "$plugin_name"
+        printf "%s\n" "$plugin_name"
         display_installed_versions "$plugin_name" "$query"
       done
     else
-      printf "%s\\n" 'No plugins installed'
+      printf "%s\n" 'No plugins installed'
     fi
   else
     check_if_plugin_exists "$plugin_name"
@@ -49,7 +49,7 @@ display_installed_versions() {
       if [[ "$version" == "$current_version" ]]; then
         flag=" *"
       fi
-      printf "%s%s\\n" "$flag" "$version"
+      printf "%s%s\n" "$flag" "$version"
     done
   else
     display_error '  No versions installed'

--- a/lib/commands/command-list.bash
+++ b/lib/commands/command-list.bash
@@ -42,7 +42,7 @@ display_installed_versions() {
   fi
 
   if [ -n "${versions}" ]; then
-    current_version=$(cut -d '|' -f 1 <<<"$(find_versions "$plugin_name" "$(pwd)")")
+    current_version=$(cut -d '|' -f 1 <<<"$(find_versions "$plugin_name" "$PWD")")
 
     for version in $versions; do
       flag="  "

--- a/lib/commands/command-plugin-list-all.bash
+++ b/lib/commands/command-plugin-list-all.bash
@@ -18,11 +18,11 @@ plugin_list_all_command() {
 
         [[ -d "${plugins_local_path}/${index_plugin_name}" ]] && installed_flag='*'
 
-        printf "%s\\t%s\\n" "$index_plugin_name" "$installed_flag$source_url"
+        printf "%s\t%s\n" "$index_plugin_name" "$installed_flag$source_url"
       done
     ) | awk '{ printf("%-28s", $1); sub(/^[^*]/, " &", $2); $1=""; print $0 }'
   else
-    printf "%s%s\\n" "error: index of plugins not found at " "$plugins_index_path"
+    printf "%s%s\n" "error: index of plugins not found at " "$plugins_index_path"
   fi
 }
 

--- a/lib/commands/command-plugin-push.bash
+++ b/lib/commands/command-plugin-push.bash
@@ -4,14 +4,14 @@ plugin_push_command() {
   local plugin_name=$1
   if [ "$plugin_name" = "--all" ]; then
     for dir in "$(asdf_data_dir)"/plugins/*/; do
-      printf "Pushing %s...\\n" "$(basename "$dir")"
+      printf "Pushing %s...\n" "$(basename "$dir")"
       (cd "$dir" && git push)
     done
   else
     local plugin_path
     plugin_path=$(get_plugin_path "$plugin_name")
     check_if_plugin_exists "$plugin_name"
-    printf "Pushing %s...\\n" "$plugin_name"
+    printf "Pushing %s...\n" "$plugin_name"
     (cd "$plugin_path" && git push)
   fi
 }

--- a/lib/commands/command-plugin-test.bash
+++ b/lib/commands/command-plugin-test.bash
@@ -53,7 +53,7 @@ plugin_test_command() {
   local TEST_DIR
 
   fail_test() {
-    printf "FAILED: %s\\n" "$1"
+    printf "FAILED: %s\n" "$1"
     rm -rf "$TEST_DIR"
     exit 1
   }
@@ -92,20 +92,20 @@ plugin_test_command() {
     local list_all="$plugin_path/bin/list-all"
     if grep api.github.com "$list_all" >/dev/null; then
       if ! grep Authorization "$list_all" >/dev/null; then
-        printf "\\nLooks like %s/bin/list-all relies on GitHub releases\\n" "$plugin_name"
-        printf "but it does not properly sets an Authorization header to prevent\\n"
-        printf "GitHub API rate limiting.\\n\\n"
-        printf "See https://github.com/asdf-vm/asdf/blob/master/docs/creating-plugins.md#github-api-rate-limiting\\n"
+        printf "\nLooks like %s/bin/list-all relies on GitHub releases\n" "$plugin_name"
+        printf "but it does not properly sets an Authorization header to prevent\n"
+        printf "GitHub API rate limiting.\n\n"
+        printf "See https://github.com/asdf-vm/asdf/blob/master/docs/creating-plugins.md#github-api-rate-limiting\n"
 
         fail_test "$plugin_name/bin/list-all does not set GitHub Authorization token"
       fi
 
       # test for most common token names we have on plugins. If both are empty show this warning
       if [ -z "$OAUTH_TOKEN" ] && [ -z "$GITHUB_API_TOKEN" ]; then
-        printf "%s/bin/list-all is using GitHub API, just be sure you provide an API Authorization token\\n" "$plugin_name"
-        printf "via your CI env GITHUB_API_TOKEN. This is the current rate_limit:\\n\\n"
+        printf "%s/bin/list-all is using GitHub API, just be sure you provide an API Authorization token\n" "$plugin_name"
+        printf "via your CI env GITHUB_API_TOKEN. This is the current rate_limit:\n\n"
         curl -s https://api.github.com/rate_limit
-        printf "\\n"
+        printf "\n"
       fi
     fi
 

--- a/lib/commands/command-update.bash
+++ b/lib/commands/command-update.bash
@@ -7,7 +7,7 @@ update_command() {
     cd "$(asdf_dir)" || exit 1
 
     if [ -f asdf_updates_disabled ] || ! git rev-parse --is-inside-work-tree &>/dev/null; then
-      printf "Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf.\\n"
+      printf "Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf.\n"
       exit 42
     else
       do_update "$update_to_head"
@@ -23,7 +23,7 @@ do_update() {
     git fetch origin master
     git checkout master
     git reset --hard origin/master
-    printf "Updated asdf to latest on the master branch\\n"
+    printf "Updated asdf to latest on the master branch\n"
   else
     # Update to latest release
     git fetch origin --tags || exit 1
@@ -38,7 +38,7 @@ do_update() {
 
     # Update
     git checkout "$tag" || exit 1
-    printf "Updated asdf to release %s\\n" "$tag"
+    printf "Updated asdf to release %s\n" "$tag"
   fi
 }
 

--- a/lib/commands/command-where.bash
+++ b/lib/commands/command-where.bash
@@ -34,14 +34,14 @@ where_command() {
   install_path=$(get_install_path "$plugin_name" "$install_type" "$version")
 
   if [ -d "$install_path" ]; then
-    printf "%s\\n" "$install_path"
+    printf "%s\n" "$install_path"
     exit 0
   else
     if [ "$version" = "system" ]; then
-      printf "System version is selected\\n"
+      printf "System version is selected\n"
       exit 1
     else
-      printf "Version not installed\\n"
+      printf "Version not installed\n"
       exit 1
     fi
   fi

--- a/lib/commands/command-which.bash
+++ b/lib/commands/command-which.bash
@@ -5,7 +5,7 @@ which_command() {
   shim_name=$(basename "$1")
 
   if [ -z "$shim_name" ]; then
-    printf "usage: asdf which <command>\\n"
+    printf "usage: asdf which <command>\n"
     exit 1
   fi
 
@@ -15,11 +15,11 @@ which_command() {
     local executable_path="$3"
 
     if [ ! -x "$executable_path" ]; then
-      printf "No %s executable found for %s %s\\n" "$shim_name" "$plugin_name" "$version" >&2
+      printf "No %s executable found for %s %s\n" "$shim_name" "$plugin_name" "$version" >&2
       exit 1
     fi
 
-    printf "%s\\n" "$executable_path"
+    printf "%s\n" "$executable_path"
     exit 0
   }
 

--- a/lib/commands/reshim.bash
+++ b/lib/commands/reshim.bash
@@ -151,10 +151,10 @@ remove_obsolete_shims() {
   # comm only takes to files, so we write this data to temp files so we can
   # pass it to comm.
   formatted_shims="$(mktemp "$temp_dir/asdf-command-reshim-formatted-shims.XXXXXX")"
-  printf "%s\\n" "$shims" >"$formatted_shims"
+  printf "%s\n" "$shims" >"$formatted_shims"
 
   formatted_exec_names="$(mktemp "$temp_dir/asdf-command-reshim-formatted-exec-names.XXXXXX")"
-  printf "%s\\n" "$exec_names" >"$formatted_exec_names"
+  printf "%s\n" "$exec_names" >"$formatted_exec_names"
 
   obsolete_shims=$(comm -23 "$formatted_shims" "$formatted_exec_names")
   rm -f "$formatted_exec_names" "$formatted_shims"

--- a/lib/commands/reshim.bash
+++ b/lib/commands/reshim.bash
@@ -44,7 +44,7 @@ reshim_command() {
   check_if_plugin_exists "$plugin_name"
   ensure_shims_dir
 
-  if [ "$full_version" != "" ]; then
+  if [ -n "$full_version" ]; then
     # generate for the whole package version
     asdf_run_hook "pre_asdf_reshim_$plugin_name" "$full_version"
     generate_shims_for_version "$plugin_name" "$full_version"

--- a/lib/functions/installs.bash
+++ b/lib/functions/installs.bash
@@ -39,7 +39,7 @@ get_concurrency() {
 install_one_local_tool() {
   local plugin_name=$1
   local search_path
-  search_path=$(pwd)
+  search_path=$PWD
 
   local plugin_versions
 
@@ -66,7 +66,7 @@ install_local_tool_versions() {
   plugins_path=$(get_plugin_path)
 
   local search_path
-  search_path=$(pwd)
+  search_path=$PWD
 
   local some_tools_installed
   local some_plugin_not_installed

--- a/lib/functions/installs.bash
+++ b/lib/functions/installs.bash
@@ -15,7 +15,7 @@ install_command() {
   local full_version=$2
   local extra_args="${*:3}"
 
-  if [ "$plugin_name" = "" ] && [ "$full_version" = "" ]; then
+  if [ -z "$plugin_name" ] && [ -z "$full_version" ]; then
     install_local_tool_versions "$extra_args"
   elif [[ $# -eq 1 ]]; then
     install_one_local_tool "$plugin_name"

--- a/lib/functions/installs.bash
+++ b/lib/functions/installs.bash
@@ -6,7 +6,7 @@ handle_failure() {
 
 handle_cancel() {
   local install_path="$1"
-  printf "\\nreceived sigint, cleaning up"
+  printf "\nreceived sigint, cleaning up"
   handle_failure "$install_path"
 }
 
@@ -32,7 +32,7 @@ get_concurrency() {
   elif [ -f /proc/cpuinfo ]; then
     grep -c processor /proc/cpuinfo
   else
-    printf "1\\n"
+    printf "1\n"
   fi
 }
 
@@ -56,7 +56,7 @@ install_one_local_tool() {
       install_tool_version "$plugin_name" "$plugin_version"
     done
   else
-    printf "No versions specified for %s in config files or environment\\n" "$plugin_name"
+    printf "No versions specified for %s in config files or environment\n" "$plugin_name"
     exit 1
   fi
 }
@@ -86,7 +86,7 @@ install_local_tool_versions() {
   fi
 
   if [ -z "$plugins_installed" ]; then
-    printf "Install plugins first to be able to install tools\\n"
+    printf "Install plugins first to be able to install tools\n"
     exit 1
   fi
 
@@ -123,9 +123,9 @@ install_local_tool_versions() {
   fi
 
   if [ -z "$some_tools_installed" ]; then
-    printf "Either specify a tool & version in the command\\n"
-    printf "OR add .tool-versions file in this directory\\n"
-    printf "or in a parent directory\\n"
+    printf "Either specify a tool & version in the command\n"
+    printf "OR add .tool-versions file in this directory\n"
+    printf "or in a parent directory\n"
     exit 1
   fi
 }
@@ -181,7 +181,7 @@ install_tool_version() {
   trap 'handle_cancel $install_path' INT
 
   if [ -d "$install_path" ]; then
-    printf "%s %s is already installed\\n" "$plugin_name" "$full_version"
+    printf "%s %s is already installed\n" "$plugin_name" "$full_version"
   else
 
     if [ -f "${plugin_path}/bin/download" ]; then

--- a/lib/functions/plugins.bash
+++ b/lib/functions/plugins.bash
@@ -28,7 +28,7 @@ plugin_list_command() {
         printf "%s" "$plugin_name"
 
         if [ -n "$show_repo" ]; then
-          printf "\\t%s" "$(git --git-dir "$plugin_path/.git" remote get-url origin 2>/dev/null)"
+          printf "\t%s" "$(git --git-dir "$plugin_path/.git" remote get-url origin 2>/dev/null)"
         fi
 
         if [ -n "$show_ref" ]; then
@@ -36,10 +36,10 @@ plugin_list_command() {
           local gitref
           branch=$(git --git-dir "$plugin_path/.git" rev-parse --abbrev-ref HEAD 2>/dev/null)
           gitref=$(git --git-dir "$plugin_path/.git" rev-parse --short HEAD 2>/dev/null)
-          printf "\\t%s\\t%s" "$branch" "$gitref"
+          printf "\t%s\t%s" "$branch" "$gitref"
         fi
 
-        printf "\\n"
+        printf "\n"
       done
     ) | awk '{ if (NF > 1) { printf("%-28s", $1) ; $1="" }; print $0}'
   else
@@ -144,7 +144,7 @@ update_plugin() {
     asdf_run_hook "pre_asdf_plugin_update" "$plugin_name"
     asdf_run_hook "pre_asdf_plugin_update_${plugin_name}"
 
-    printf "Updating %s to %s\\n" "$plugin_name" "$gitref"
+    printf "Updating %s to %s\n" "$plugin_name" "$gitref"
 
     git "${common_git_options[@]}" fetch --prune --update-head-ok origin "$gitref:$gitref"
     prev_ref=$(git "${common_git_options[@]}" rev-parse --short HEAD)

--- a/lib/functions/versions.bash
+++ b/lib/functions/versions.bash
@@ -24,7 +24,7 @@ version_command() {
   elif [ "$cmd" = "local-tree" ]; then
     file=$(find_tool_versions)
   else # cmd = local
-    file="$(pwd)/$file_name"
+    file="$PWD/$file_name"
   fi
 
   if [ -L "$file" ]; then

--- a/lib/functions/versions.bash
+++ b/lib/functions/versions.bash
@@ -4,9 +4,9 @@ version_command() {
 
   if [ "$#" -lt "3" ]; then
     if [ "$cmd" = "global" ]; then
-      printf "Usage: asdf global <name> <version>\\n"
+      printf "Usage: asdf global <name> <version>\n"
     else
-      printf "Usage: asdf local <name> <version>\\n"
+      printf "Usage: asdf local <name> <version>\n"
     fi
     exit 1
   fi
@@ -68,7 +68,7 @@ version_command() {
     [[ -n "$(tail -c1 "$file")" && -f "$file" ]] && printf '\n' >>"$file"
 
     # Add a new version line to the end of the file
-    printf "%s %s\\n" "$plugin_name" "${resolved_versions[*]}" >>"$file"
+    printf "%s %s\n" "$plugin_name" "${resolved_versions[*]}" >>"$file"
   fi
 }
 
@@ -92,16 +92,16 @@ list_all_command() {
 
   if [[ $return_code -ne 0 ]]; then
     # Printing all output to allow plugin to handle error formatting
-    printf "Plugin %s's list-all callback script failed with output:\\n" "${plugin_name}" >&2
-    printf "%s\\n" "$(cat "$std_err_file")" >&2
-    printf "%s\\n" "$(cat "$std_out_file")" >&2
+    printf "Plugin %s's list-all callback script failed with output:\n" "${plugin_name}" >&2
+    printf "%s\n" "$(cat "$std_err_file")" >&2
+    printf "%s\n" "$(cat "$std_out_file")" >&2
     rm "$std_out_file" "$std_err_file"
     exit 1
   fi
 
   if [[ $query ]]; then
     output=$(tr ' ' '\n' <"$std_out_file" |
-      grep -E "^\\s*$query" |
+      grep -E "^\s*$query" |
       tr '\n' ' ')
   else
     output=$(cat "$std_out_file")
@@ -115,7 +115,7 @@ list_all_command() {
   IFS=' ' read -r -a versions_list <<<"$output"
 
   for version in "${versions_list[@]}"; do
-    printf "%s\\n" "${version}"
+    printf "%s\n" "${version}"
   done
 
   # Remove temp files if they still exist
@@ -144,13 +144,13 @@ latest_command() {
     versions=$("${plugin_path}"/bin/latest-stable "$query")
     if [ -z "${versions}" ]; then
       # this branch requires this print to mimic the error from the list-all branch
-      printf "No compatible versions available (%s %s)\\n" "$plugin_name" "$query" >&2
+      printf "No compatible versions available (%s %s)\n" "$plugin_name" "$query" >&2
       exit 1
     fi
   else
     # pattern from xxenv-latest (https://github.com/momo-lab/xxenv-latest)
     versions=$(list_all_command "$plugin_name" "$query" |
-      grep -ivE "(^Available versions:|-src|-dev|-latest|-stm|[-\\.]rc|-milestone|-alpha|-beta|[-\\.]pre|-next|(a|b|c)[0-9]+|snapshot|master)" |
+      grep -ivE "(^Available versions:|-src|-dev|-latest|-stm|[-\.]rc|-milestone|-alpha|-beta|[-\.]pre|-next|(a|b|c)[0-9]+|snapshot|master)" |
       sed 's/^[[:space:]]\+//' |
       tail -1)
     if [ -z "${versions}" ]; then
@@ -158,7 +158,7 @@ latest_command() {
     fi
   fi
 
-  printf "%s\\n" "$versions"
+  printf "%s\n" "$versions"
 }
 
 latest_all() {
@@ -181,7 +181,7 @@ latest_all() {
       else
         # pattern from xxenv-latest (https://github.com/momo-lab/xxenv-latest)
         version=$(list_all_command "$plugin_name" |
-          grep -ivE "(^Available version:|-src|-dev|-latest|-stm|[-\\.]rc|-alpha|-beta|[-\\.]pre|-next|(a|b|c)[0-9]+|snapshot|master)" |
+          grep -ivE "(^Available version:|-src|-dev|-latest|-stm|[-\.]rc|-alpha|-beta|[-\.]pre|-next|(a|b|c)[0-9]+|snapshot|master)" |
           sed 's/^[[:space:]]\+//' |
           tail -1)
         if [ -z "${version}" ]; then
@@ -198,10 +198,10 @@ latest_all() {
       if [ -n "$installed_versions" ] && printf '%s\n' "$installed_versions" | grep -q "^$version\$"; then
         installed_status="installed"
       fi
-      printf "%s\\t%s\\t%s\\n" "$plugin_name" "$version" "$installed_status"
+      printf "%s\t%s\t%s\n" "$plugin_name" "$version" "$installed_status"
     done
   else
-    printf "%s\\n" 'No plugins installed'
+    printf "%s\n" 'No plugins installed'
   fi
   exit 0
 }

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -141,7 +141,7 @@ version_not_installed_text() {
 }
 
 get_plugin_path() {
-  if test -n "$1"; then
+  if [ -n "$1" ]; then
     printf "%s\n" "$(asdf_data_dir)/plugins/$1"
   else
     printf "%s\n" "$(asdf_data_dir)/plugins"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -347,7 +347,7 @@ parse_legacy_version_file() {
 get_preset_version_for() {
   local plugin_name=$1
   local search_path
-  search_path=$(pwd)
+  search_path=$PWD
   local version_and_path
   version_and_path=$(find_versions "$plugin_name" "$search_path")
   local version
@@ -451,7 +451,7 @@ find_tool_versions() {
 find_file_upwards() {
   local name="$1"
   local search_path
-  search_path=$(pwd)
+  search_path=$PWD
   while [ "$search_path" != "/" ]; do
     if [ -f "$search_path/$name" ]; then
       printf "%s\n" "${search_path}/$name"
@@ -706,7 +706,7 @@ select_version() {
   # These are separated by a space. e.g. python 3.7.2 2.7.15
   # For each plugin/version pair, we check if it is present in the shim
   local search_path
-  search_path=$(pwd)
+  search_path=$PWD
   local shim_versions
   IFS=$'\n' read -rd '' -a shim_versions <<<"$(get_shim_versions "$shim_name")"
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -13,9 +13,9 @@ asdf_version() {
   version="v$(cat "$(asdf_dir)/version.txt")"
   if [ -d "$(asdf_dir)/.git" ]; then
     git_rev="$(git --git-dir "$(asdf_dir)/.git" rev-parse --short HEAD)"
-    printf "%s-%s\\n" "$version" "$git_rev"
+    printf "%s-%s\n" "$version" "$git_rev"
   else
-    printf "%s\\n" "$version"
+    printf "%s\n" "$version"
   fi
 }
 
@@ -29,11 +29,11 @@ asdf_dir() {
     )
   fi
 
-  printf "%s\\n" "$ASDF_DIR"
+  printf "%s\n" "$ASDF_DIR"
 }
 
 asdf_repository_url() {
-  printf "https://github.com/asdf-vm/asdf-plugins.git\\n"
+  printf "https://github.com/asdf-vm/asdf-plugins.git\n"
 }
 
 asdf_data_dir() {
@@ -47,7 +47,7 @@ asdf_data_dir() {
     data_dir=$(asdf_dir)
   fi
 
-  printf "%s\\n" "$data_dir"
+  printf "%s\n" "$data_dir"
 }
 
 get_install_path() {
@@ -61,11 +61,11 @@ get_install_path() {
   mkdir -p "${install_dir}/${plugin}"
 
   if [ "$install_type" = "version" ]; then
-    printf "%s/%s/%s\\n" "$install_dir" "$plugin" "$version"
+    printf "%s/%s/%s\n" "$install_dir" "$plugin" "$version"
   elif [ "$install_type" = "path" ]; then
-    printf "%s\\n" "$version"
+    printf "%s\n" "$version"
   else
-    printf "%s/%s/%s-%s\\n" "$install_dir" "$plugin" "$install_type" "$version"
+    printf "%s/%s/%s-%s\n" "$install_dir" "$plugin" "$install_type" "$version"
   fi
 }
 
@@ -80,11 +80,11 @@ get_download_path() {
   mkdir -p "${download_dir}/${plugin}"
 
   if [ "$install_type" = "version" ]; then
-    printf "%s/%s/%s\\n" "$download_dir" "$plugin" "$version"
+    printf "%s/%s/%s\n" "$download_dir" "$plugin" "$version"
   elif [ "$install_type" = "path" ]; then
     return
   else
-    printf "%s/%s/%s-%s\\n" "$download_dir" "$plugin" "$install_type" "$version"
+    printf "%s/%s/%s-%s\n" "$download_dir" "$plugin" "$install_type" "$version"
   fi
 }
 
@@ -137,19 +137,19 @@ version_not_installed_text() {
   local plugin_name=$1
   local version=$2
 
-  printf "version %s is not installed for %s\\n" "$version" "$plugin_name"
+  printf "version %s is not installed for %s\n" "$version" "$plugin_name"
 }
 
 get_plugin_path() {
   if test -n "$1"; then
-    printf "%s\\n" "$(asdf_data_dir)/plugins/$1"
+    printf "%s\n" "$(asdf_data_dir)/plugins/$1"
   else
-    printf "%s\\n" "$(asdf_data_dir)/plugins"
+    printf "%s\n" "$(asdf_data_dir)/plugins"
   fi
 }
 
 display_error() {
-  printf "%s\\n" "$1" >&2
+  printf "%s\n" "$1" >&2
 }
 
 get_version_in_dir() {
@@ -163,7 +163,7 @@ get_version_in_dir() {
   asdf_version=$(parse_asdf_version_file "$search_path/$file_name" "$plugin_name")
 
   if [ -n "$asdf_version" ]; then
-    printf "%s\\n" "$asdf_version|$search_path/$file_name"
+    printf "%s\n" "$asdf_version|$search_path/$file_name"
     return 0
   fi
 
@@ -172,7 +172,7 @@ get_version_in_dir() {
     legacy_version=$(parse_legacy_version_file "$search_path/$filename" "$plugin_name")
 
     if [ -n "$legacy_version" ]; then
-      printf "%s\\n" "$legacy_version|$search_path/$filename"
+      printf "%s\n" "$legacy_version|$search_path/$filename"
       return 0
     fi
   done
@@ -190,10 +190,10 @@ find_versions() {
   version=$(get_version_from_env "$plugin_name")
   if [ -n "$version" ]; then
     local upcase_name
-    upcase_name=$(printf "%s\\n" "$plugin_name" | tr '[:lower:]-' '[:upper:]_')
+    upcase_name=$(printf "%s\n" "$plugin_name" | tr '[:lower:]-' '[:upper:]_')
     local version_env_var="ASDF_${upcase_name}_VERSION"
 
-    printf "%s\\n" "$version|$version_env_var environment variable"
+    printf "%s\n" "$version|$version_env_var environment variable"
     return 0
   fi
 
@@ -212,7 +212,7 @@ find_versions() {
   while [ "$search_path" != "/" ]; do
     version=$(get_version_in_dir "$plugin_name" "$search_path" "$legacy_filenames")
     if [ -n "$version" ]; then
-      printf "%s\\n" "$version"
+      printf "%s\n" "$version"
       return 0
     fi
     search_path=$(dirname "$search_path")
@@ -223,7 +223,7 @@ find_versions() {
   if [ -f "$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME" ]; then
     versions=$(parse_asdf_version_file "$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME" "$plugin_name")
     if [ -n "$versions" ]; then
-      printf "%s\\n" "$versions|$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME"
+      printf "%s\n" "$versions|$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME"
       return 0
     fi
   fi
@@ -231,16 +231,16 @@ find_versions() {
 
 display_no_version_set() {
   local plugin_name=$1
-  printf "No version is set for %s; please run \`asdf <global | shell | local> %s <version>\`\\n" "$plugin_name" "$plugin_name"
+  printf "No version is set for %s; please run \`asdf <global | shell | local> %s <version>\`\n" "$plugin_name" "$plugin_name"
 }
 
 get_version_from_env() {
   local plugin_name=$1
   local upcase_name
-  upcase_name=$(printf "%s\\n" "$plugin_name" | tr '[:lower:]-' '[:upper:]_')
+  upcase_name=$(printf "%s\n" "$plugin_name" | tr '[:lower:]-' '[:upper:]_')
   local version_env_var="ASDF_${upcase_name}_VERSION"
   local version=${!version_env_var:-}
-  printf "%s\\n" "$version"
+  printf "%s\n" "$version"
 }
 
 find_install_path() {
@@ -251,7 +251,7 @@ find_install_path() {
   IFS=':' read -a version_info <<<"$version"
 
   if [ "$version" = "system" ]; then
-    printf "\\n"
+    printf "\n"
   elif [ "${version_info[0]}" = "ref" ]; then
     local install_type="${version_info[0]}"
     local version="${version_info[1]}"
@@ -263,7 +263,7 @@ find_install_path() {
     # And then use the binaries there
     local install_type="path"
     local version="path"
-    printf "%s\\n" "${version_info[1]}"
+    printf "%s\n" "${version_info[1]}"
   else
     local install_type="version"
     local version="${version_info[0]}"
@@ -281,12 +281,12 @@ get_custom_executable_path() {
     cmd=$(basename "$executable_path")
     local relative_path
     # shellcheck disable=SC2001
-    relative_path=$(printf "%s\\n" "$executable_path" | sed -e "s|${install_path}/||")
+    relative_path=$(printf "%s\n" "$executable_path" | sed -e "s|${install_path}/||")
     relative_path="$("${plugin_path}/bin/exec-path" "$install_path" "$cmd" "$relative_path")"
     executable_path="$install_path/$relative_path"
   fi
 
-  printf "%s\\n" "$executable_path"
+  printf "%s\n" "$executable_path"
 }
 
 get_executable_path() {
@@ -304,11 +304,11 @@ get_executable_path() {
     if [ $? -ne 0 ]; then
       return 1
     fi
-    printf "%s\\n" "$cmd_path"
+    printf "%s\n" "$cmd_path"
   else
     local install_path
     install_path=$(find_install_path "$plugin_name" "$version")
-    printf "%s\\n" "${install_path}"/"${executable_path}"
+    printf "%s\n" "${install_path}"/"${executable_path}"
   fi
 }
 
@@ -320,7 +320,7 @@ parse_asdf_version_file() {
     local version
     version=$(strip_tool_version_comments "$file_path" | grep "^${plugin_name} " | sed -e "s/^${plugin_name} //")
     if [ -n "$version" ]; then
-      printf "%s\\n" "$version"
+      printf "%s\n" "$version"
       return 0
     fi
   fi
@@ -353,7 +353,7 @@ get_preset_version_for() {
   local version
   version=$(cut -d '|' -f 1 <<<"$version_and_path")
 
-  printf "%s\\n" "$version"
+  printf "%s\n" "$version"
 }
 
 get_asdf_config_value_from_file() {
@@ -365,9 +365,9 @@ get_asdf_config_value_from_file() {
   fi
 
   local result
-  result=$(grep -E "^\\s*$key\\s*=\\s*" "$config_path" | head | sed -e 's/^[^=]*= *//' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+  result=$(grep -E "^\s*$key\s*=\s*" "$config_path" | head | sed -e 's/^[^=]*= *//' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
   if [ -n "$result" ]; then
-    printf "%s\\n" "$result"
+    printf "%s\n" "$result"
     return 0
   fi
 
@@ -414,7 +414,7 @@ initialize_or_update_repository() {
 
   disable_plugin_short_name_repo="$(get_asdf_config_value "disable_plugin_short_name_repository")"
   if [ "yes" == "$disable_plugin_short_name_repo" ]; then
-    printf "Short-name plugin repository is disabled\\n" >&2
+    printf "Short-name plugin repository is disabled\n" >&2
     exit 1
   fi
 
@@ -454,7 +454,7 @@ find_file_upwards() {
   search_path=$(pwd)
   while [ "$search_path" != "/" ]; do
     if [ -f "$search_path/$name" ]; then
-      printf "%s\\n" "${search_path}/$name"
+      printf "%s\n" "${search_path}/$name"
       return 0
     fi
     search_path=$(dirname "$search_path")
@@ -475,12 +475,12 @@ resolve_symlink() {
   # as relative
   case $resolved_path in
   /*)
-    printf "%s\\n" "$resolved_path"
+    printf "%s\n" "$resolved_path"
     ;;
   *)
     (
       cd "$(dirname "$symlink")" || exit 1
-      printf "%s\\n" "$PWD/$resolved_path"
+      printf "%s\n" "$PWD/$resolved_path"
     )
     ;;
   esac
@@ -508,7 +508,7 @@ list_plugin_bin_paths() {
   else
     local space_separated_list_of_bin_paths="bin"
   fi
-  printf "%s\\n" "$space_separated_list_of_bin_paths"
+  printf "%s\n" "$space_separated_list_of_bin_paths"
 }
 
 list_plugin_exec_paths() {
@@ -531,7 +531,7 @@ list_plugin_exec_paths() {
   local plugin_shims_path
   plugin_shims_path=$(get_plugin_path "$plugin_name")/shims
   if [ -d "$plugin_shims_path" ]; then
-    printf "%s\\n" "$plugin_shims_path"
+    printf "%s\n" "$plugin_shims_path"
   fi
 
   space_separated_list_of_bin_paths="$(list_plugin_bin_paths "$plugin_name" "$version" "$install_type")"
@@ -541,7 +541,7 @@ list_plugin_exec_paths() {
   install_path=$(get_install_path "$plugin_name" "$install_type" "$version")
 
   for bin_path in "${all_bin_paths[@]}"; do
-    printf "%s\\n" "$install_path/$bin_path"
+    printf "%s\n" "$install_path/$bin_path"
   done
 }
 
@@ -603,7 +603,7 @@ plugin_executables() {
   for bin_path in "${all_bin_paths[@]}"; do
     for executable_file in "$bin_path"/*; do
       if is_executable "$executable_file"; then
-        printf "%s\\n" "$executable_file"
+        printf "%s\n" "$executable_file"
       fi
     done
   done
@@ -631,7 +631,7 @@ shim_plugin_versions() {
   if [ -x "$shim_path" ]; then
     grep "# asdf-plugin: " "$shim_path" 2>/dev/null | sed -e "s/# asdf-plugin: //" | uniq
   else
-    printf "asdf: unknown shim %s\\n" "$executable_name"
+    printf "asdf: unknown shim %s\n" "$executable_name"
     return 1
   fi
 }
@@ -644,7 +644,7 @@ shim_plugins() {
   if [ -x "$shim_path" ]; then
     grep "# asdf-plugin: " "$shim_path" 2>/dev/null | sed -e "s/# asdf-plugin: //" | cut -d' ' -f 1 | uniq
   else
-    printf "asdf: unknown shim %s\\n" "$executable_name"
+    printf "asdf: unknown shim %s\n" "$executable_name"
     return 1
   fi
 }
@@ -682,7 +682,7 @@ get_shim_versions() {
 
 preset_versions() {
   shim_name=$1
-  shim_plugin_versions "${shim_name}" | cut -d' ' -f 1 | uniq | xargs -IPLUGIN bash -c ". $(asdf_dir)/lib/utils.bash; printf \"%s %s\\n\" PLUGIN \$(get_preset_version_for PLUGIN)"
+  shim_plugin_versions "${shim_name}" | cut -d' ' -f 1 | uniq | xargs -IPLUGIN bash -c ". $(asdf_dir)/lib/utils.bash; printf \"%s %s\n\" PLUGIN \$(get_preset_version_for PLUGIN)"
 }
 
 select_from_preset_version() {
@@ -693,7 +693,7 @@ select_from_preset_version() {
   shim_versions=$(get_shim_versions "$shim_name")
   if [ -n "$shim_versions" ]; then
     preset_versions=$(preset_versions "$shim_name")
-    grep -F "$shim_versions" <<<"$preset_versions" | head -n 1 | xargs -IVERSION printf "%s\\n" VERSION
+    grep -F "$shim_versions" <<<"$preset_versions" | head -n 1 | xargs -IVERSION printf "%s\n" VERSION
   fi
 }
 
@@ -728,10 +728,10 @@ select_version() {
         IFS=' ' read -r plugin_shim_name plugin_shim_version <<<"$plugin_and_version"
         if [[ "$plugin_name" == "$plugin_shim_name" ]]; then
           if [[ "$plugin_version" == "$plugin_shim_version" ]]; then
-            printf "%s\\n" "$plugin_name $plugin_version"
+            printf "%s\n" "$plugin_name $plugin_version"
             return
           elif [[ "$plugin_version" == "path:"* ]]; then
-            printf "%s\\n" "$plugin_name $plugin_version"
+            printf "%s\n" "$plugin_name $plugin_version"
             return
           fi
         fi
@@ -746,7 +746,7 @@ with_shim_executable() {
   local shim_exec="${2}"
 
   if [ ! -f "$(asdf_data_dir)/shims/${shim_name}" ]; then
-    printf "%s %s %s\\n" "unknown command:" "${shim_name}." "Perhaps you have to reshim?" >&2
+    printf "%s %s %s\n" "unknown command:" "${shim_name}." "Perhaps you have to reshim?" >&2
     return 1
   fi
 
@@ -803,15 +803,15 @@ with_shim_executable() {
     done
 
     if [ -n "${preset_plugin_versions[*]}" ]; then
-      printf "%s %s\\n" "No preset version installed for command" "$shim_name"
-      printf "%s\\n\\n" "Please install a version by running one of the following:"
+      printf "%s %s\n" "No preset version installed for command" "$shim_name"
+      printf "%s\n\n" "Please install a version by running one of the following:"
       for preset_plugin_version in "${preset_plugin_versions[@]}"; do
-        printf "%s %s\\n" "asdf install" "$preset_plugin_version"
+        printf "%s %s\n" "asdf install" "$preset_plugin_version"
       done
-      printf "\\n%s %s\\n" "or add one of the following versions in your config file at" "$closest_tool_version"
+      printf "\n%s %s\n" "or add one of the following versions in your config file at" "$closest_tool_version"
     else
-      printf "%s %s\\n" "No version is set for command" "$shim_name"
-      printf "%s %s\\n" "Consider adding one of the following versions in your config file at" "$closest_tool_version"
+      printf "%s %s\n" "No version is set for command" "$shim_name"
+      printf "%s %s\n" "Consider adding one of the following versions in your config file at" "$closest_tool_version"
     fi
     shim_plugin_versions "${shim_name}"
   ) >&2

--- a/scripts/update_version_in_docs.bash
+++ b/scripts/update_version_in_docs.bash
@@ -3,4 +3,4 @@
 set -euo pipefail
 
 version=$(cat version.txt)
-sed -i "s/\\(git clone.*--branch \\).*\\(\`.*|\\)/\\1v$version\\2/" docs/guide/getting-started.md
+sed -i "s/\(git clone.*--branch \).*\(\`.*|\)/\1v$version\2/" docs/guide/getting-started.md

--- a/scripts/update_version_list_in_security_policy.bash
+++ b/scripts/update_version_list_in_security_policy.bash
@@ -8,5 +8,5 @@ version_major_minor_x="$(cut -f1-2 -d "." version.txt).x"
 if ! grep -q "$version_major_minor_x" SECURITY.md; then
   # prepend new version to the list
   sed -i "s/white_check_mark:/x:               /g" SECURITY.md
-  sed -i "s/^\\(| -* | -* |\\)$/\\1\\n| $version_major_minor_x  | :white_check_mark: |/" SECURITY.md
+  sed -i "s/^\(| -* | -* |\)$/\1\n| $version_major_minor_x  | :white_check_mark: |/" SECURITY.md
 fi

--- a/test/asdf_elvish.bats
+++ b/test/asdf_elvish.bats
@@ -59,7 +59,7 @@ cleaned_path() {
   [ "$?" -eq 0 ]
   echo "$result"
   output=$(echo "$result" | grep "asdf")
-  [ "$output" != "" ]
+  [ -n "$output" ]
 }
 
 @test "defines the _asdf namespace" {
@@ -84,7 +84,7 @@ cleaned_path() {
   ")
   [ "$?" -eq 0 ]
   output=$(echo $result | tr ':' '\n' | grep "asdf" | sort | uniq -d)
-  [ "$output" = "" ]
+  [ -z "$output" ]
 }
 
 @test "defines the asdf function" {
@@ -108,5 +108,5 @@ cleaned_path() {
   ")
   [ "$?" -eq 0 ]
   output=$(echo "$result" | grep "ASDF INSTALLED PLUGINS:")
-  [ "$output" != "" ]
+  [ -n "$output" ]
 }

--- a/test/asdf_fish.bats
+++ b/test/asdf_fish.bats
@@ -21,7 +21,7 @@ cleaned_path() {
     echo \$ASDF_DIR
   ")
   [ "$?" -eq 0 ]
-  [ "$output" != "" ]
+  [ -n "$output" ]
 }
 
 @test "adds asdf dirs to PATH" {
@@ -36,7 +36,7 @@ cleaned_path() {
  ")
   [ "$?" -eq 0 ]
   output=$(echo "$result" | grep "asdf")
-  [ "$output" != "" ]
+  [ -n "$output" ]
 }
 
 @test "does not add paths to PATH more than once" {
@@ -52,7 +52,7 @@ cleaned_path() {
   ")
   [ "$?" -eq 0 ]
   output=$(echo $result | tr ' ' '\n' | grep "asdf" | sort | uniq -d)
-  [ "$output" = "" ]
+  [ -z "$output" ]
 }
 
 @test "defines the asdf function" {
@@ -79,5 +79,5 @@ cleaned_path() {
   ")
   [ "$?" -eq 0 ]
   output=$(echo "$result" | grep "ASDF INSTALLED PLUGINS:")
-  [ "$output" != "" ]
+  [ -n "$output" ]
 }

--- a/test/asdf_sh.bats
+++ b/test/asdf_sh.bats
@@ -23,7 +23,7 @@ cleaned_path() {
 
   output=$(echo "$result" | grep "asdf")
   [ "$?" -eq 0 ]
-  [ "$output" != "" ]
+  [ -n "$output" ]
 }
 
 @test "does not error if nounset is enabled" {
@@ -39,7 +39,7 @@ cleaned_path() {
 
   output=$(echo "$result" | grep "asdf")
   [ "$?" -eq 0 ]
-  [ "$output" != "" ]
+  [ -n "$output" ]
 }
 
 @test "adds asdf dirs to PATH" {
@@ -54,7 +54,7 @@ cleaned_path() {
 
   output=$(echo "$result" | grep "asdf")
   [ "$?" -eq 0 ]
-  [ "$output" != "" ]
+  [ -n "$output" ]
 }
 
 @test "does not add paths to PATH more than once" {
@@ -70,7 +70,7 @@ cleaned_path() {
 
   output=$(echo $result | tr ':' '\n' | grep "asdf" | sort | uniq -d)
   [ "$?" -eq 0 ]
-  [ "$output" = "" ]
+  [ -z "$output" ]
 }
 
 @test "defines the asdf function" {
@@ -97,5 +97,5 @@ cleaned_path() {
   )
   [ "$?" -eq 0 ]
   output=$(echo "$result" | grep "ASDF INSTALLED PLUGINS:")
-  [ "$output" != "" ]
+  [ -n "$output" ]
 }

--- a/test/asdf_sh.bats
+++ b/test/asdf_sh.bats
@@ -18,7 +18,7 @@ cleaned_path() {
     PATH=$(cleaned_path)
 
     source_asdf_sh
-    echo $ASDF_DIR
+    echo "$ASDF_DIR"
   )
 
   output=$(echo "$result" | grep "asdf")
@@ -34,7 +34,7 @@ cleaned_path() {
     set -o nounset
 
     source_asdf_sh
-    echo $ASDF_DIR
+    echo "$ASDF_DIR"
   )
 
   output=$(echo "$result" | grep "asdf")

--- a/test/banned_commands.bats
+++ b/test/banned_commands.bats
@@ -77,7 +77,7 @@ teardown() {
     fi
 
     [ "$status" -eq 1 ]
-    [ "" == "$output" ]
+    [ -z "$output" ]
   done
 
   for cmd in "${banned_commands_regex[@]}"; do
@@ -94,6 +94,6 @@ teardown() {
     fi
 
     [ "$status" -eq 1 ]
-    [ "" == "$output" ]
+    [ -z "$output" ]
   done
 }

--- a/test/current_command.bats
+++ b/test/current_command.bats
@@ -10,7 +10,7 @@ setup() {
   install_dummy_version "nightly-2000-01-01"
 
   PROJECT_DIR=$HOME/project
-  mkdir $PROJECT_DIR
+  mkdir -p "$PROJECT_DIR"
 }
 
 teardown() {
@@ -18,8 +18,8 @@ teardown() {
 }
 
 @test "current should derive from the current .tool-versions" {
-  cd $PROJECT_DIR
-  echo 'dummy 1.1.0' >>$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  echo 'dummy 1.1.0' >>"$PROJECT_DIR/.tool-versions"
   expected="dummy           1.1.0           $PROJECT_DIR/.tool-versions"
 
   run asdf current "dummy"
@@ -28,8 +28,8 @@ teardown() {
 }
 
 @test "current should handle long version name" {
-  cd $PROJECT_DIR
-  echo "dummy nightly-2000-01-01" >>$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  echo "dummy nightly-2000-01-01" >>"$PROJECT_DIR/.tool-versions"
   expected="dummy           nightly-2000-01-01 $PROJECT_DIR/.tool-versions"
 
   run asdf current "dummy"
@@ -38,8 +38,8 @@ teardown() {
 }
 
 @test "current should handle multiple versions" {
-  cd $PROJECT_DIR
-  echo "dummy 1.2.0 1.1.0" >>$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  echo "dummy 1.2.0 1.1.0" >>"$PROJECT_DIR/.tool-versions"
   expected="dummy           1.2.0 1.1.0     $PROJECT_DIR/.tool-versions"
 
   run asdf current "dummy"
@@ -48,10 +48,10 @@ teardown() {
 }
 
 @test "current should derive from the legacy file if enabled" {
-  cd $PROJECT_DIR
-  echo 'legacy_version_file = yes' >$HOME/.asdfrc
-  echo '1.2.0' >>$PROJECT_DIR/.dummy-version
-  expected="dummy           1.2.0           $PROJECT_DIR/.dummy-version"
+  cd "$PROJECT_DIR"
+  echo 'legacy_version_file = yes' >"$HOME/.asdfrc"
+  echo '1.2.0' >>"$PROJECT_DIR/.dummy-version"
+  expected="dummy           1.2.0           "$PROJECT_DIR/.dummy-version""
 
   run asdf current "dummy"
   [ "$status" -eq 0 ]
@@ -68,7 +68,7 @@ teardown() {
 }
 
 @test "current should error when no version is set" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
   expected="dummy           ______          No version is set. Run \"asdf <global|shell|local> dummy <version>\""
 
   run asdf current "dummy"
@@ -77,8 +77,8 @@ teardown() {
 }
 
 @test "current should error when a version is set that isn't installed" {
-  cd $PROJECT_DIR
-  echo 'dummy 9.9.9' >>$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  echo 'dummy 9.9.9' >>"$PROJECT_DIR/.tool-versions"
   expected="dummy           9.9.9           Not installed. Run \"asdf install dummy 9.9.9\""
 
   run asdf current "dummy"
@@ -96,14 +96,14 @@ teardown() {
 
   install_mock_plugin "baz"
 
-  cd $PROJECT_DIR
-  echo 'dummy 1.1.0' >>$PROJECT_DIR/.tool-versions
-  echo 'foobar 1.0.0' >>$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  echo 'dummy 1.1.0' >>"$PROJECT_DIR/.tool-versions"
+  echo 'foobar 1.0.0' >>"$PROJECT_DIR/.tool-versions"
 
   run asdf current
   expected="baz             ______          No version is set. Run \"asdf <global|shell|local> baz <version>\"
-dummy           1.1.0           $PROJECT_DIR/.tool-versions
-foobar          1.0.0           $PROJECT_DIR/.tool-versions"
+dummy           1.1.0           "$PROJECT_DIR/.tool-versions"
+foobar          1.0.0           "$PROJECT_DIR/.tool-versions""
 
   [ "$expected" = "$output" ]
 }
@@ -115,9 +115,9 @@ foobar          1.0.0           $PROJECT_DIR/.tool-versions"
   install_mock_plugin "y"
   install_mock_plugin_version "y" "2.1.0"
 
-  cd $PROJECT_DIR
-  echo 'dummy 1.1.0' >>$PROJECT_DIR/.tool-versions
-  echo 'y 2.1.0' >>$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  echo 'dummy 1.1.0' >>"$PROJECT_DIR/.tool-versions"
+  echo 'y 2.1.0' >>"$PROJECT_DIR/.tool-versions"
 
   run asdf current "y"
   [ "$status" -eq 0 ]
@@ -134,8 +134,8 @@ foobar          1.0.0           $PROJECT_DIR/.tool-versions"
 }
 
 @test "current should handle comments" {
-  cd $PROJECT_DIR
-  echo "dummy 1.2.0  # this is a comment" >>$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  echo "dummy 1.2.0  # this is a comment" >>"$PROJECT_DIR/.tool-versions"
   expected="dummy           1.2.0           $PROJECT_DIR/.tool-versions"
 
   run asdf current "dummy"

--- a/test/fixtures/dummy_plugin/bin/latest-stable
+++ b/test/fixtures/dummy_plugin/bin/latest-stable
@@ -4,7 +4,7 @@ get_latest_stable() {
   query=$1
 
   version_list=(1.0.0 1.1.0 2.0.0)
-  printf "%s\n" "${version_list[@]}" | grep -E "^\\s*$query" | tail -1
+  printf "%s\n" "${version_list[@]}" | grep -E "^\s*$query" | tail -1
 }
 
 get_latest_stable "$1"

--- a/test/help_command.bats
+++ b/test/help_command.bats
@@ -57,7 +57,7 @@ EOF
 
   run asdf help "sunny"
   [ "$status" -eq 1 ]
-  [ "$output" == "No plugin named sunny" ]
+  [ "$output" = "No plugin named sunny" ]
 }
 
 @test "help should fail when plugin doesn't have documentation callback" {
@@ -65,7 +65,7 @@ EOF
 
   run asdf help "legacy-dummy"
   [ "$status" -eq 1 ]
-  [ "$output" == "No documentation for plugin legacy-dummy" ]
+  [ "$output" = "No documentation for plugin legacy-dummy" ]
 }
 
 @test "help should show asdf help when no plugin name is provided" {

--- a/test/help_command.bats
+++ b/test/help_command.bats
@@ -10,7 +10,7 @@ setup() {
   run asdf install dummy 1.1
 
   PROJECT_DIR=$HOME/project
-  mkdir $PROJECT_DIR
+  mkdir -p "$PROJECT_DIR"
 }
 
 teardown() {
@@ -18,7 +18,7 @@ teardown() {
 }
 
 @test "help should show dummy plugin help" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
 
   run asdf help "dummy"
 
@@ -34,7 +34,7 @@ EOF
 }
 
 @test "help should show dummy plugin help specific to version when version is present" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
 
   run asdf help "dummy" "1.2.3"
 
@@ -53,7 +53,7 @@ EOF
 }
 
 @test "help should fail for unknown plugins" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
 
   run asdf help "sunny"
   [ "$status" -eq 1 ]
@@ -61,7 +61,7 @@ EOF
 }
 
 @test "help should fail when plugin doesn't have documentation callback" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
 
   run asdf help "legacy-dummy"
   [ "$status" -eq 1 ]
@@ -69,7 +69,7 @@ EOF
 }
 
 @test "help should show asdf help when no plugin name is provided" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
 
   run asdf help
 

--- a/test/info_command.bats
+++ b/test/info_command.bats
@@ -10,7 +10,7 @@ setup() {
   run asdf install dummy 1.1
 
   PROJECT_DIR=$HOME/project
-  mkdir $PROJECT_DIR
+  mkdir -p "$PROJECT_DIR"
 }
 
 teardown() {
@@ -18,7 +18,7 @@ teardown() {
 }
 
 @test "info should show os, shell and asdf debug information" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
 
   run asdf info
 

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -9,7 +9,7 @@ setup() {
   install_dummy_broken_plugin
 
   PROJECT_DIR=$HOME/project
-  mkdir $PROJECT_DIR
+  mkdir -p "$PROJECT_DIR"
 }
 
 teardown() {
@@ -19,36 +19,36 @@ teardown() {
 @test "install_command installs the correct version" {
   run asdf install dummy 1.1.0
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.1.0/version) = "1.1.0" ]
+  [ $(cat "$ASDF_DIR/installs/dummy/1.1.0/version") = "1.1.0" ]
 }
 
 @test "install_command installs the correct version for plugins without download script" {
   run asdf install legacy-dummy 1.1.0
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/legacy-dummy/1.1.0/version) = "1.1.0" ]
+  [ $(cat "$ASDF_DIR/installs/legacy-dummy/1.1.0/version") = "1.1.0" ]
 }
 
 @test "install_command without arguments installs even if the user is terrible and does not use newlines" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
   echo -n 'dummy 1.2.0' >".tool-versions"
   run asdf install
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.2.0/version) = "1.2.0" ]
+  [ $(cat "$ASDF_DIR/installs/dummy/1.2.0/version") = "1.2.0" ]
 }
 
 @test "install_command with only name installs the version in .tool-versions" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
   echo -n 'dummy 1.2.0' >".tool-versions"
   run asdf install dummy
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.2.0/version) = "1.2.0" ]
+  [ $(cat "$ASDF_DIR/installs/dummy/1.2.0/version") = "1.2.0" ]
 }
 
 @test "install_command set ASDF_CONCURRENCY" {
   run asdf install dummy 1.0.0
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/installs/dummy/1.0.0/env ]
-  run grep ASDF_CONCURRENCY $ASDF_DIR/installs/dummy/1.0.0/env
+  [ -f "$ASDF_DIR/installs/dummy/1.0.0/env" ]
+  run grep ASDF_CONCURRENCY "$ASDF_DIR/installs/dummy/1.0.0/env"
   [ "$status" -eq 0 ]
 }
 
@@ -61,22 +61,22 @@ teardown() {
   run asdf install
 
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.2.0/version) = "1.2.0" ]
+  [ $(cat "$ASDF_DIR/installs/dummy/1.2.0/version") = "1.2.0" ]
 }
 
 @test "install_command should create a shim with asdf-plugin metadata" {
   run asdf install dummy 1.0.0
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/installs/dummy/1.0.0/env ]
-  run grep "asdf-plugin: dummy 1.0.0" $ASDF_DIR/shims/dummy
+  [ -f "$ASDF_DIR/installs/dummy/1.0.0/env" ]
+  run grep "asdf-plugin: dummy 1.0.0" "$ASDF_DIR/shims/dummy"
   [ "$status" -eq 0 ]
 }
 
 @test "install_command should create a shim with asdf-plugin metadata for plugins without download script" {
   run asdf install legacy-dummy 1.0.0
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/installs/legacy-dummy/1.0.0/env ]
-  run grep "asdf-plugin: legacy-dummy 1.0.0" $ASDF_DIR/shims/dummy
+  [ -f "$ASDF_DIR/installs/legacy-dummy/1.0.0/env" ]
+  run grep "asdf-plugin: legacy-dummy 1.0.0" "$ASDF_DIR/shims/dummy"
   [ "$status" -eq 0 ]
 }
 
@@ -84,27 +84,27 @@ teardown() {
   run asdf install dummy 1.1.0
   [ "$status" -eq 0 ]
 
-  run grep "asdf-plugin: dummy 1.1.0" $ASDF_DIR/shims/dummy
+  run grep "asdf-plugin: dummy 1.1.0" "$ASDF_DIR/shims/dummy"
   [ "$status" -eq 0 ]
 
-  run grep "asdf-plugin: dummy 1.0.0" $ASDF_DIR/shims/dummy
+  run grep "asdf-plugin: dummy 1.0.0" "$ASDF_DIR/shims/dummy"
   [ "$status" -eq 1 ]
 
   run asdf install dummy 1.0.0
   [ "$status" -eq 0 ]
-  run grep "asdf-plugin: dummy 1.0.0" $ASDF_DIR/shims/dummy
+  run grep "asdf-plugin: dummy 1.0.0" "$ASDF_DIR/shims/dummy"
   [ "$status" -eq 0 ]
 
-  run grep "# asdf-plugin: dummy 1.0.0"$'\n'"# asdf-plugin: dummy 1.1.0" $ASDF_DIR/shims/dummy
+  run grep "# asdf-plugin: dummy 1.0.0"$'\n'"# asdf-plugin: dummy 1.1.0" "$ASDF_DIR/shims/dummy"
   [ "$status" -eq 0 ]
 
-  lines_count=$(grep "asdf-plugin: dummy 1.1.0" $ASDF_DIR/shims/dummy | wc -l)
+  lines_count=$(grep "asdf-plugin: dummy 1.1.0" "$ASDF_DIR/shims/dummy" | wc -l)
   [ "$lines_count" -eq "1" ]
 }
 
 @test "install_command without arguments should not generate shim for subdir" {
-  cd $PROJECT_DIR
-  echo 'dummy 1.0.0' >$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  echo 'dummy 1.0.0' >"$PROJECT_DIR/.tool-versions"
 
   run asdf install
   [ "$status" -eq 0 ]
@@ -114,14 +114,14 @@ teardown() {
 
 @test "install_command without arguments should generate shim that passes all arguments to executable" {
   # asdf lib needed to run generated shims
-  cp -rf $BATS_TEST_DIRNAME/../{bin,lib} $ASDF_DIR/
+  cp -rf $BATS_TEST_DIRNAME/../{bin,lib} "$ASDF_DIR/"
 
-  cd $PROJECT_DIR
-  echo 'dummy 1.0.0' >$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  echo 'dummy 1.0.0' >"$PROJECT_DIR/.tool-versions"
   run asdf install
 
   # execute the generated shim
-  run $ASDF_DIR/shims/dummy world hello
+  run "$ASDF_DIR/shims/dummy" world hello
   [ "$status" -eq 0 ]
   [ "$output" == "This is Dummy 1.0.0! hello world" ]
 }
@@ -130,12 +130,12 @@ teardown() {
   run asdf install dummy
   [ "$status" -eq 1 ]
   [ "$output" = "No versions specified for dummy in config files or environment" ]
-  [ ! -f $ASDF_DIR/installs/dummy/1.1.0/version ]
+  [ ! -f "$ASDF_DIR/installs/dummy/1.1.0/version" ]
 }
 
 @test "install_command fails if the plugin is not installed" {
-  cd $PROJECT_DIR
-  echo 'other_dummy 1.0.0' >$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  echo 'other_dummy 1.0.0' >"$PROJECT_DIR/.tool-versions"
 
   run asdf install
   [ "$status" -eq 1 ]
@@ -143,8 +143,8 @@ teardown() {
 }
 
 @test "install_command fails if the plugin is not installed without collisions" {
-  cd $PROJECT_DIR
-  printf "dummy 1.0.0\ndum 1.0.0" >$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  printf "dummy 1.0.0\ndum 1.0.0" >"$PROJECT_DIR/.tool-versions"
 
   run asdf install
   [ "$status" -eq 1 ]
@@ -152,58 +152,58 @@ teardown() {
 }
 
 @test "install_command fails when tool is specified but no version of the tool is configured in config file" {
-  echo 'dummy 1.0.0' >$PROJECT_DIR/.tool-versions
+  echo 'dummy 1.0.0' >"$PROJECT_DIR/.tool-versions"
   run asdf install other-dummy
   [ "$status" -eq 1 ]
   [ "$output" = "No versions specified for other-dummy in config files or environment" ]
-  [ ! -f $ASDF_DIR/installs/dummy/1.0.0/version ]
+  [ ! -f "$ASDF_DIR/installs/dummy/1.0.0/version" ]
 }
 
 @test "install_command fails when two tools are specified with no versions" {
-  printf 'dummy 1.0.0\nother-dummy 2.0.0' >$PROJECT_DIR/.tool-versions
+  printf 'dummy 1.0.0\nother-dummy 2.0.0' >"$PROJECT_DIR/.tool-versions"
   run asdf install dummy other-dummy
   [ "$status" -eq 1 ]
   [ "$output" = "Dummy couldn't install version: other-dummy (on purpose)" ]
-  [ ! -f $ASDF_DIR/installs/dummy/1.0.0/version ]
-  [ ! -f $ASDF_DIR/installs/other-dummy/2.0.0/version ]
+  [ ! -f "$ASDF_DIR/installs/dummy/1.0.0/version" ]
+  [ ! -f "$ASDF_DIR/installs/other-dummy/2.0.0/version" ]
 }
 
 @test "install_command without arguments uses a parent directory .tool-versions file if present" {
   # asdf lib needed to run generated shims
-  cp -rf $BATS_TEST_DIRNAME/../{bin,lib} $ASDF_DIR/
+  cp -rf $BATS_TEST_DIRNAME/../{bin,lib} "$ASDF_DIR/"
 
-  echo 'dummy 1.0.0' >$PROJECT_DIR/.tool-versions
-  mkdir -p $PROJECT_DIR/child
+  echo 'dummy 1.0.0' >"$PROJECT_DIR/.tool-versions"
+  mkdir -p "$PROJECT_DIR/child"
 
-  cd $PROJECT_DIR/child
+  cd "$PROJECT_DIR/child"
 
   run asdf install
 
   # execute the generated shim
-  [ "$($ASDF_DIR/shims/dummy world hello)" == "This is Dummy 1.0.0! hello world" ]
+  [ "$("$ASDF_DIR/shims/dummy" world hello)" == "This is Dummy 1.0.0! hello world" ]
   [ "$status" -eq 0 ]
 }
 
 @test "install_command installs multiple tool versions when they are specified in a .tool-versions file" {
-  echo 'dummy 1.0.0 1.2.0' >$PROJECT_DIR/.tool-versions
-  cd $PROJECT_DIR
+  echo 'dummy 1.0.0 1.2.0' >"$PROJECT_DIR/.tool-versions"
+  cd "$PROJECT_DIR"
 
   run asdf install
   echo $output
   [ "$status" -eq 0 ]
 
-  [ $(cat $ASDF_DIR/installs/dummy/1.0.0/version) = "1.0.0" ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.2.0/version) = "1.2.0" ]
+  [ $(cat "$ASDF_DIR/installs/dummy/1.0.0/version") = "1.0.0" ]
+  [ $(cat "$ASDF_DIR/installs/dummy/1.2.0/version") = "1.2.0" ]
 }
 
 @test "install_command doesn't install system version" {
   run asdf install dummy system
   [ "$status" -eq 0 ]
-  [ ! -f $ASDF_DIR/installs/dummy/system/version ]
+  [ ! -f "$ASDF_DIR/installs/dummy/system/version" ]
 }
 
 @test "install command executes configured pre plugin install hook" {
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 pre_asdf_install_dummy = echo will install dummy $1
 EOM
 
@@ -212,7 +212,7 @@ EOM
 }
 
 @test "install command executes configured post plugin install hook" {
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 post_asdf_install_dummy = echo HEY $version FROM $plugin_name
 EOM
 
@@ -221,68 +221,68 @@ EOM
 }
 
 @test "install command without arguments installs versions from legacy files" {
-  echo 'legacy_version_file = yes' >$HOME/.asdfrc
-  echo '1.2.0' >>$PROJECT_DIR/.dummy-version
-  cd $PROJECT_DIR
+  echo 'legacy_version_file = yes' >"$HOME/.asdfrc"
+  echo '1.2.0' >>"$PROJECT_DIR/.dummy-version"
+  cd "$PROJECT_DIR"
   run asdf install
   [ "$status" -eq 0 ]
   [ -z "$output" ]
-  [ -f $ASDF_DIR/installs/dummy/1.2.0/version ]
+  [ -f "$ASDF_DIR/installs/dummy/1.2.0/version" ]
 }
 
 @test "install command without arguments installs versions from legacy files in parent directories" {
-  echo 'legacy_version_file = yes' >$HOME/.asdfrc
-  echo '1.2.0' >>$PROJECT_DIR/.dummy-version
+  echo 'legacy_version_file = yes' >"$HOME/.asdfrc"
+  echo '1.2.0' >>"$PROJECT_DIR/.dummy-version"
 
-  mkdir -p $PROJECT_DIR/child
-  cd $PROJECT_DIR/child
+  mkdir -p "$PROJECT_DIR/child"
+  cd ""$PROJECT_DIR/child""
 
   run asdf install
   [ "$status" -eq 0 ]
   [ -z "$output" ]
-  [ -f $ASDF_DIR/installs/dummy/1.2.0/version ]
+  [ -f "$ASDF_DIR/installs/dummy/1.2.0/version" ]
 }
 
 @test "install_command latest installs latest stable version" {
   run asdf install dummy latest
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/2.0.0/version) = "2.0.0" ]
+  [ $(cat "$ASDF_DIR/installs/dummy/2.0.0/version") = "2.0.0" ]
 }
 
 @test "install_command latest:version installs latest stable version that matches the given string" {
   run asdf install dummy latest:1
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.1.0/version) = "1.1.0" ]
+  [ $(cat "$ASDF_DIR/installs/dummy/1.1.0/version") = "1.1.0" ]
 }
 
 @test "install_command deletes the download directory" {
   run asdf install dummy 1.1.0
   [ "$status" -eq 0 ]
-  [ ! -d $ASDF_DIR/downloads/dummy/1.1.0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.1.0/version) = "1.1.0" ]
+  [ ! -d "$ASDF_DIR/downloads/dummy/1.1.0" ]
+  [ $(cat "$ASDF_DIR/installs/dummy/1.1.0/version") = "1.1.0" ]
 }
 
 @test "install_command keeps the download directory when --keep-download flag is provided" {
   run asdf install dummy 1.1.0 --keep-download
   [ "$status" -eq 0 ]
-  [ -d $ASDF_DIR/downloads/dummy/1.1.0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.1.0/version) = "1.1.0" ]
+  [ -d "$ASDF_DIR/downloads/dummy/1.1.0" ]
+  [ $(cat "$ASDF_DIR/installs/dummy/1.1.0/version") = "1.1.0" ]
 }
 
 @test "install_command keeps the download directory when always_keep_download setting is true" {
-  echo 'always_keep_download = yes' >$HOME/.asdfrc
+  echo 'always_keep_download = yes' >"$HOME/.asdfrc"
   run asdf install dummy 1.1.0
   echo $output
   [ "$status" -eq 0 ]
-  [ -d $ASDF_DIR/downloads/dummy/1.1.0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.1.0/version) = "1.1.0" ]
+  [ -d "$ASDF_DIR/downloads/dummy/1.1.0" ]
+  [ $(cat "$ASDF_DIR/installs/dummy/1.1.0/version") = "1.1.0" ]
 }
 
 @test "install_command fails when download script exits with non-zero code" {
   run asdf install dummy-broken 1.0.0
   echo $output
   [ "$status" -eq 1 ]
-  [ ! -d $ASDF_DIR/downloads/dummy-broken/1.1.0 ]
-  [ ! -d $ASDF_DIR/installs/dummy-broken/1.1.0 ]
+  [ ! -d "$ASDF_DIR/downloads/dummy-broken/1.1.0" ]
+  [ ! -d "$ASDF_DIR/installs/dummy-broken/1.1.0" ]
   [ "$output" == "Download failed!" ]
 }

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -226,7 +226,7 @@ EOM
   cd $PROJECT_DIR
   run asdf install
   [ "$status" -eq 0 ]
-  [ "$output" == "" ]
+  [ -z "$output" ]
   [ -f $ASDF_DIR/installs/dummy/1.2.0/version ]
 }
 
@@ -239,7 +239,7 @@ EOM
 
   run asdf install
   [ "$status" -eq 0 ]
-  [ "$output" == "" ]
+  [ -z "$output" ]
   [ -f $ASDF_DIR/installs/dummy/1.2.0/version ]
 }
 

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -123,7 +123,7 @@ teardown() {
   # execute the generated shim
   run "$ASDF_DIR/shims/dummy" world hello
   [ "$status" -eq 0 ]
-  [ "$output" == "This is Dummy 1.0.0! hello world" ]
+  [ "$output" = "This is Dummy 1.0.0! hello world" ]
 }
 
 @test "install_command fails when tool is specified but no version of the tool is configured" {
@@ -180,7 +180,7 @@ teardown() {
   run asdf install
 
   # execute the generated shim
-  [ "$("$ASDF_DIR/shims/dummy" world hello)" == "This is Dummy 1.0.0! hello world" ]
+  [ "$("$ASDF_DIR/shims/dummy" world hello)" = "This is Dummy 1.0.0! hello world" ]
   [ "$status" -eq 0 ]
 }
 
@@ -208,7 +208,7 @@ pre_asdf_install_dummy = echo will install dummy $1
 EOM
 
   run asdf install dummy 1.0.0
-  [ "$output" == "will install dummy 1.0.0" ]
+  [ "$output" = "will install dummy 1.0.0" ]
 }
 
 @test "install command executes configured post plugin install hook" {
@@ -217,7 +217,7 @@ post_asdf_install_dummy = echo HEY $version FROM $plugin_name
 EOM
 
   run asdf install dummy 1.0.0
-  [ "$output" == "HEY 1.0.0 FROM dummy" ]
+  [ "$output" = "HEY 1.0.0 FROM dummy" ]
 }
 
 @test "install command without arguments installs versions from legacy files" {
@@ -284,5 +284,5 @@ EOM
   [ "$status" -eq 1 ]
   [ ! -d "$ASDF_DIR/downloads/dummy-broken/1.1.0" ]
   [ ! -d "$ASDF_DIR/installs/dummy-broken/1.1.0" ]
-  [ "$output" == "Download failed!" ]
+  [ "$output" = "Download failed!" ]
 }

--- a/test/latest_command.bats
+++ b/test/latest_command.bats
@@ -17,19 +17,19 @@ teardown() {
 ####################################################
 @test "[latest_command - dummy_plugin] shows latest stable version" {
   run asdf latest dummy
-  [ "$(echo "2.0.0")" == "$output" ]
+  [ "$(echo "2.0.0")" = "$output" ]
   [ "$status" -eq 0 ]
 }
 
 @test "[latest_command - dummy_plugin] shows latest stable version that matches the given string" {
   run asdf latest dummy 1
-  [ "$(echo "1.1.0")" == "$output" ]
+  [ "$(echo "1.1.0")" = "$output" ]
   [ "$status" -eq 0 ]
 }
 
 @test "[latest_command - dummy_plugin] an invalid version should return an error" {
   run asdf latest dummy 3
-  [ "$(echo "No compatible versions available (dummy 3)")" == "$output" ]
+  [ "$(echo "No compatible versions available (dummy 3)")" = "$output" ]
   [ "$status" -eq 1 ]
 }
 
@@ -40,7 +40,7 @@ teardown() {
   run asdf latest legacy-dummy
   echo "status: $status"
   echo "output: $output"
-  [ "$(echo "5.1.0")" == "$output" ]
+  [ "$(echo "5.1.0")" = "$output" ]
   [ "$status" -eq 0 ]
 }
 
@@ -48,7 +48,7 @@ teardown() {
   run asdf latest legacy-dummy 1
   echo "status: $status"
   echo "output: $output"
-  [ "$(echo "1.1.0")" == "$output" ]
+  [ "$(echo "1.1.0")" = "$output" ]
   [ "$status" -eq 0 ]
 }
 
@@ -64,7 +64,7 @@ teardown() {
   run asdf latest legacy-dummy 4
   echo "status: $status"
   echo "output: $output"
-  [ "$(echo "4.0.0")" == "$output" ]
+  [ "$(echo "4.0.0")" = "$output" ]
   [ "$status" -eq 0 ]
 }
 
@@ -72,7 +72,7 @@ teardown() {
   run asdf latest legacy-dummy 5
   echo "status: $status"
   echo "output: $output"
-  [ "$(echo "5.1.0")" == "$output" ]
+  [ "$(echo "5.1.0")" = "$output" ]
   [ "$status" -eq 0 ]
 }
 
@@ -80,7 +80,7 @@ teardown() {
   run asdf latest legacy-dummy 6
   echo "status: $status"
   echo "output: $output"
-  [ "$(echo "No compatible versions available (legacy-dummy 6)")" == "$output" ]
+  [ "$(echo "No compatible versions available (legacy-dummy 6)")" = "$output" ]
   [ "$status" -eq 1 ]
 }
 
@@ -92,12 +92,12 @@ teardown() {
   run asdf install legacy-dummy 4.0.0
   run asdf latest --all
   echo "output $output"
-  [ "$(echo -e "dummy\t2.0.0\tinstalled\nlegacy-dummy\t5.1.0\tmissing\n")" == "$output" ]
+  [ "$(echo -e "dummy\t2.0.0\tinstalled\nlegacy-dummy\t5.1.0\tmissing\n")" = "$output" ]
   [ "$status" -eq 0 ]
 }
 
 @test "[latest_command - all plugins] not installed plugin should return missing" {
   run asdf latest --all
-  [ "$(echo -e "dummy\t2.0.0\tmissing\nlegacy-dummy\t5.1.0\tmissing\n")" == "$output" ]
+  [ "$(echo -e "dummy\t2.0.0\tmissing\nlegacy-dummy\t5.1.0\tmissing\n")" = "$output" ]
   [ "$status" -eq 0 ]
 }

--- a/test/list_command.bats
+++ b/test/list_command.bats
@@ -8,7 +8,7 @@ setup() {
   install_dummy_broken_plugin
 
   PROJECT_DIR=$HOME/project
-  mkdir $PROJECT_DIR
+  mkdir -p "$PROJECT_DIR"
 }
 
 teardown() {
@@ -25,8 +25,8 @@ teardown() {
 }
 
 @test "list_command should list plugins with installed versions and any selected versions marked with asterisk" {
-  cd $PROJECT_DIR
-  echo 'dummy 1.1.0' >>$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  echo 'dummy 1.1.0' >>"$PROJECT_DIR/.tool-versions"
   run asdf install dummy 1.0.0
   run asdf install dummy 1.1.0
 

--- a/test/list_command.bats
+++ b/test/list_command.bats
@@ -19,8 +19,8 @@ teardown() {
   run asdf install dummy 1.0.0
   run asdf install dummy 1.1.0
   run asdf list
-  [[ "$output" == *"$(echo -e "dummy\n  1.0.0\n  1.1.0")"* ]]
-  [[ "$output" == *"$(echo -e "dummy-broken\n  No versions installed")"* ]]
+  [[ "$output" = *"$(echo -e "dummy\n  1.0.0\n  1.1.0")"* ]]
+  [[ "$output" = *"$(echo -e "dummy-broken\n  No versions installed")"* ]]
   [ "$status" -eq 0 ]
 }
 
@@ -31,8 +31,8 @@ teardown() {
   run asdf install dummy 1.1.0
 
   run asdf list
-  [[ "$output" == *"$(echo -e "dummy\n  1.0.0\n *1.1.0")"* ]]
-  [[ "$output" == *"$(echo -e "dummy-broken\n  No versions installed")"* ]]
+  [[ "$output" = *"$(echo -e "dummy\n  1.0.0\n *1.1.0")"* ]]
+  [[ "$output" = *"$(echo -e "dummy-broken\n  No versions installed")"* ]]
   [ "$status" -eq 0 ]
 }
 
@@ -43,10 +43,10 @@ teardown() {
   run asdf install dummy 1.0.0
   run asdf install tummy 2.0.0
   run asdf list
-  [[ "$output" == *"$(echo -e "dummy\n  1.0.0")"* ]]
-  [[ "$output" == *"$(echo -e "dummy-broken\n  No versions installed")"* ]]
-  [[ "$output" == *"$(echo -e "mummy\n  No versions installed")"* ]]
-  [[ "$output" == *"$(echo -e "tummy\n  2.0.0")"* ]]
+  [[ "$output" = *"$(echo -e "dummy\n  1.0.0")"* ]]
+  [[ "$output" = *"$(echo -e "dummy-broken\n  No versions installed")"* ]]
+  [[ "$output" = *"$(echo -e "mummy\n  No versions installed")"* ]]
+  [[ "$output" = *"$(echo -e "tummy\n  2.0.0")"* ]]
   [ "$status" -eq 0 ]
 }
 
@@ -54,7 +54,7 @@ teardown() {
   run asdf install dummy 1.0.0
   run asdf install dummy 1.1.0
   run asdf list dummy
-  [ "$(echo -e "  1.0.0\n  1.1.0")" == "$output" ]
+  [ "$(echo -e "  1.0.0\n  1.1.0")" = "$output" ]
   [ "$status" -eq 0 ]
 }
 
@@ -63,7 +63,7 @@ teardown() {
   run asdf install dummy 1.1
   run asdf install dummy 2.0
   run asdf list dummy 1
-  [ "$(echo -e "  1.0\n  1.1")" == "$output" ]
+  [ "$(echo -e "  1.0\n  1.1")" = "$output" ]
   [ "$status" -eq 0 ]
 }
 
@@ -71,25 +71,25 @@ teardown() {
   run asdf install dummy 1.0
   run asdf install dummy 1.1
   run asdf list dummy 2
-  [ "$(echo "No compatible versions installed (dummy 2)")" == "$output" ]
+  [ "$(echo "No compatible versions installed (dummy 2)")" = "$output" ]
   [ "$status" -eq 1 ]
 }
 
 @test "list_all_command lists available versions" {
   run asdf list-all dummy
-  [ "$(echo -e "1.0.0\n1.1.0\n2.0.0")" == "$output" ]
+  [ "$(echo -e "1.0.0\n1.1.0\n2.0.0")" = "$output" ]
   [ "$status" -eq 0 ]
 }
 
 @test "list_all_command with version filters available versions" {
   run asdf list-all dummy 1
-  [ "$(echo -e "1.0.0\n1.1.0")" == "$output" ]
+  [ "$(echo -e "1.0.0\n1.1.0")" = "$output" ]
   [ "$status" -eq 0 ]
 }
 
 @test "list_all_command with an invalid version should return an error" {
   run asdf list-all dummy 3
-  [ "$(echo "No compatible versions available (dummy 3)")" == "$output" ]
+  [ "$(echo "No compatible versions available (dummy 3)")" = "$output" ]
   [ "$status" -eq 1 ]
 }
 
@@ -97,14 +97,14 @@ teardown() {
   run asdf list-all dummy-broken
   echo $output
   [ "$status" -eq 1 ]
-  [[ "$output" == "Plugin dummy-broken's list-all callback script failed with output:"* ]]
+  [[ "$output" = "Plugin dummy-broken's list-all callback script failed with output:"* ]]
 }
 
 @test "list_all_command displays stderr then stdout when failing" {
   run asdf list-all dummy-broken
   echo $output
-  [[ "$output" == *"List-all failed!"* ]]
-  [[ "$output" == *"Attempting to list versions" ]]
+  [[ "$output" = *"List-all failed!"* ]]
+  [[ "$output" = *"Attempting to list versions" ]]
 }
 
 @test "list_all_command ignores stderr when completing successfully" {

--- a/test/plugin_add_command.bats
+++ b/test/plugin_add_command.bats
@@ -57,7 +57,7 @@ teardown() {
 }
 
 @test "plugin_add command with no URL specified adds a plugin when short name repository is enabled" {
-  export ASDF_CONFIG_DEFAULT_FILE=$HOME/.asdfrc
+  export ASDF_CONFIG_DEFAULT_FILE="$HOME/.asdfrc"
   echo "disable_plugin_short_name_repository=no" >$ASDF_CONFIG_DEFAULT_FILE
 
   run asdf plugin add "elixir"
@@ -69,7 +69,7 @@ teardown() {
 }
 
 @test "plugin_add command with no URL specified fails to add a plugin when disabled" {
-  export ASDF_CONFIG_DEFAULT_FILE=$HOME/.asdfrc
+  export ASDF_CONFIG_DEFAULT_FILE="$HOME/.asdfrc"
   echo "disable_plugin_short_name_repository=yes" >$ASDF_CONFIG_DEFAULT_FILE
   local expected="Short-name plugin repository is disabled"
 
@@ -114,7 +114,7 @@ teardown() {
 @test "plugin_add command executes configured pre hook (generic)" {
   install_mock_plugin_repo "dummy"
 
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 pre_asdf_plugin_add = echo ADD ${@}
 EOM
 
@@ -128,7 +128,7 @@ plugin add path=${ASDF_DIR}/plugins/dummy source_url=${BASE_DIR}/repo-dummy"
 @test "plugin_add command executes configured pre hook (specific)" {
   install_mock_plugin_repo "dummy"
 
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 pre_asdf_plugin_add_dummy = echo ADD
 EOM
 
@@ -142,7 +142,7 @@ plugin add path=${ASDF_DIR}/plugins/dummy source_url=${BASE_DIR}/repo-dummy"
 @test "plugin_add command executes configured post hook (generic)" {
   install_mock_plugin_repo "dummy"
 
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 post_asdf_plugin_add = echo ADD ${@}
 EOM
 
@@ -156,7 +156,7 @@ ADD dummy"
 @test "plugin_add command executes configured post hook (specific)" {
   install_mock_plugin_repo "dummy"
 
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 post_asdf_plugin_add_dummy = echo ADD
 EOM
 

--- a/test/plugin_extension_command.bats
+++ b/test/plugin_extension_command.bats
@@ -42,12 +42,12 @@ teardown() {
 
   run asdf help
   [ "$status" -eq 0 ]
-  [[ "$output" == *"PLUGIN $plugin_name"* ]]
+  [[ "$output" = *"PLUGIN $plugin_name"* ]]
   # shellcheck disable=SC2154
   listed_cmds=$(grep -c "asdf $plugin_name" <<<"${output}")
   [[ $listed_cmds -eq 3 ]]
-  [[ "$output" == *"asdf $plugin_name foo"* ]]
-  [[ "$output" == *"asdf $plugin_name foo bar"* ]]
+  [[ "$output" = *"asdf $plugin_name foo"* ]]
+  [[ "$output" = *"asdf $plugin_name foo bar"* ]]
 }
 
 @test "asdf can execute plugin bin commands" {

--- a/test/plugin_extension_command.bats
+++ b/test/plugin_extension_command.bats
@@ -29,7 +29,7 @@ teardown() {
 }
 
 @test "asdf help shows extension commands for plugin with hyphens in the name" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
 
   plugin_name=dummy-hyphenated
   install_mock_plugin $plugin_name

--- a/test/plugin_list_all_command.bats
+++ b/test/plugin_list_all_command.bats
@@ -13,7 +13,7 @@ teardown() {
 }
 
 @test "plugin_list_all should exit before syncing the plugin repo if disabled" {
-  export ASDF_CONFIG_DEFAULT_FILE=$HOME/.asdfrc
+  export ASDF_CONFIG_DEFAULT_FILE="$HOME/.asdfrc"
   echo 'disable_plugin_short_name_repository=yes' >$ASDF_CONFIG_DEFAULT_FILE
   local expected="Short-name plugin repository is disabled"
 
@@ -23,7 +23,7 @@ teardown() {
 }
 
 @test "plugin_list_all should sync repo when check_duration set to 0" {
-  export ASDF_CONFIG_DEFAULT_FILE=$HOME/.asdfrc
+  export ASDF_CONFIG_DEFAULT_FILE="$HOME/.asdfrc"
   echo 'plugin_repository_last_check_duration = 0' >$ASDF_CONFIG_DEFAULT_FILE
   local expected_plugin_repo_sync="updating plugin repository..."
   local expected_plugins_list="\
@@ -38,7 +38,7 @@ foo                           http://example.com/foo"
 }
 
 @test "plugin_list_all no immediate repo sync expected because check_duration is greater than 0" {
-  export ASDF_CONFIG_DEFAULT_FILE=$HOME/.asdfrc
+  export ASDF_CONFIG_DEFAULT_FILE="$HOME/.asdfrc"
   echo 'plugin_repository_last_check_duration = 10' >$ASDF_CONFIG_DEFAULT_FILE
   local expected="\
 bar                           http://example.com/bar
@@ -51,7 +51,7 @@ foo                           http://example.com/foo"
 }
 
 @test "plugin_list_all skips repo sync because check_duration is set to never" {
-  export ASDF_CONFIG_DEFAULT_FILE=$HOME/.asdfrc
+  export ASDF_CONFIG_DEFAULT_FILE="$HOME/.asdfrc"
   echo 'plugin_repository_last_check_duration = never' >$ASDF_CONFIG_DEFAULT_FILE
   local expected="\
 bar                           http://example.com/bar

--- a/test/plugin_update_command.bats
+++ b/test/plugin_update_command.bats
@@ -83,34 +83,34 @@ teardown() {
 @test "asdf plugin-update should not remove plugin versions" {
   run asdf install dummy 1.1
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.1/version) = "1.1" ]
+  [ $(cat "$ASDF_DIR/installs/dummy/1.1/version") = "1.1" ]
   run asdf plugin-update dummy
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/installs/dummy/1.1/version ]
+  [ -f "$ASDF_DIR/installs/dummy/1.1/version" ]
   run asdf plugin-update --all
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/installs/dummy/1.1/version ]
+  [ -f "$ASDF_DIR/installs/dummy/1.1/version" ]
 }
 
 @test "asdf plugin-update should not remove plugins" {
   # dummy plugin is already installed
   run asdf plugin-update dummy
   [ "$status" -eq 0 ]
-  [ -d $ASDF_DIR/plugins/dummy ]
+  [ -d "$ASDF_DIR/plugins/dummy" ]
   run asdf plugin-update --all
   [ "$status" -eq 0 ]
-  [ -d $ASDF_DIR/plugins/dummy ]
+  [ -d "$ASDF_DIR/plugins/dummy" ]
 }
 
 @test "asdf plugin-update should not remove shims" {
   run asdf install dummy 1.1
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
   run asdf plugin-update dummy
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
   run asdf plugin-update --all
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
 }
 
 @test "asdf plugin-update done for all plugins" {
@@ -157,7 +157,7 @@ teardown() {
 }
 
 @test "asdf plugin-update executes configured pre hook (generic)" {
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 pre_asdf_plugin_update = echo UPDATE ${@}
 EOM
 
@@ -173,7 +173,7 @@ EOM
 }
 
 @test "asdf plugin-update executes configured pre hook (specific)" {
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 pre_asdf_plugin_update_dummy = echo UPDATE
 EOM
 
@@ -189,7 +189,7 @@ EOM
 }
 
 @test "asdf plugin-update executes configured post hook (generic)" {
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 post_asdf_plugin_update = echo UPDATE ${@}
 EOM
 
@@ -206,7 +206,7 @@ UPDATE dummy"
 }
 
 @test "asdf plugin-update executes configured post hook (specific)" {
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 post_asdf_plugin_update_dummy = echo UPDATE
 EOM
 

--- a/test/remove_command.bats
+++ b/test/remove_command.bats
@@ -34,22 +34,22 @@ teardown() {
   install_dummy_plugin
   run asdf install dummy 1.0
   [ "$status" -eq 0 ]
-  [ -d $ASDF_DIR/installs/dummy ]
+  [ -d "$ASDF_DIR/installs/dummy" ]
 
   run asdf plugin-remove dummy
   [ "$status" -eq 0 ]
-  [ ! -d $ASDF_DIR/installs/dummy ]
+  [ ! -d "$ASDF_DIR/installs/dummy" ]
 }
 
 @test "plugin_remove_command should also remove shims for that plugin" {
   install_dummy_plugin
   run asdf install dummy 1.0
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
 
   run asdf plugin-remove dummy
   [ "$status" -eq 0 ]
-  [ ! -f $ASDF_DIR/shims/dummy ]
+  [ ! -f "$ASDF_DIR/shims/dummy" ]
 }
 
 @test "plugin_remove_command should not remove unrelated shims" {
@@ -57,13 +57,13 @@ teardown() {
   run asdf install dummy 1.0
 
   # make an unrelated shim
-  echo "# asdf-plugin: gummy" >$ASDF_DIR/shims/gummy
+  echo "# asdf-plugin: gummy" >"$ASDF_DIR/shims/gummy"
 
   run asdf plugin-remove dummy
   [ "$status" -eq 0 ]
 
   # unrelated shim should exist
-  [ -f $ASDF_DIR/shims/gummy ]
+  [ -f "$ASDF_DIR/shims/gummy" ]
 }
 
 @test "plugin_remove_command executes pre-plugin-remove script" {
@@ -77,7 +77,7 @@ teardown() {
 @test "plugin_remove_command executes configured pre hook (generic)" {
   install_dummy_plugin
 
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 pre_asdf_plugin_remove = echo REMOVE ${@}
 EOM
 
@@ -91,7 +91,7 @@ plugin-remove ${ASDF_DIR}/plugins/dummy"
 @test "plugin_remove_command executes configured pre hook (specific)" {
   install_dummy_plugin
 
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 pre_asdf_plugin_remove_dummy = echo REMOVE
 EOM
 
@@ -105,7 +105,7 @@ plugin-remove ${ASDF_DIR}/plugins/dummy"
 @test "plugin_remove_command executes configured post hook (generic)" {
   install_dummy_plugin
 
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 post_asdf_plugin_remove = echo REMOVE ${@}
 EOM
 
@@ -119,7 +119,7 @@ REMOVE dummy"
 @test "plugin_remove_command executes configured post hook (specific)" {
   install_dummy_plugin
 
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 post_asdf_plugin_remove_dummy = echo REMOVE
 EOM
 

--- a/test/reshim_command.bats
+++ b/test/reshim_command.bats
@@ -127,7 +127,7 @@ pre_asdf_reshim_dummy = echo RESHIM
 EOM
 
   run asdf reshim dummy 1.0
-  [ "$output" == "RESHIM" ]
+  [ "$output" = "RESHIM" ]
 }
 
 @test "reshim command executes configured post hook" {
@@ -138,5 +138,5 @@ post_asdf_reshim_dummy = echo RESHIM
 EOM
 
   run asdf reshim dummy 1.0
-  [ "$output" == "RESHIM" ]
+  [ "$output" = "RESHIM" ]
 }

--- a/test/shim_env_command.bats
+++ b/test/shim_env_command.bats
@@ -30,7 +30,7 @@ teardown() {
 
   run asdf env dummy which dummy
   [ "$status" -eq 0 ]
-  [ "$output" == "$ASDF_DIR/installs/dummy/1.0/bin/dummy" ]
+  [ "$output" = "$ASDF_DIR/installs/dummy/1.0/bin/dummy" ]
 }
 
 @test "asdf env should execute under plugin custom environment used for a shim" {
@@ -58,11 +58,11 @@ teardown() {
   [ "$status" -eq 0 ]
 
   run grep 'FOO=bar' <(echo $output)
-  [ "$output" == "" ]
+  [ "$output" = "" ]
   [ "$status" -eq 1 ]
 
   run asdf env dummy which dummy
-  [ "$output" == "$ASDF_DIR/shims/dummy" ]
+  [ "$output" = "$ASDF_DIR/shims/dummy" ]
   [ "$status" -eq 0 ]
 }
 
@@ -79,5 +79,5 @@ teardown() {
 
   # Should not contain duplicate colon
   run grep '::' <(echo "$path_line")
-  [ "$duplicate_colon" == "" ]
+  [ "$duplicate_colon" = "" ]
 }

--- a/test/shim_env_command.bats
+++ b/test/shim_env_command.bats
@@ -58,7 +58,7 @@ teardown() {
   [ "$status" -eq 0 ]
 
   run grep 'FOO=bar' <(echo $output)
-  [ "$output" == "" ]
+  [ -z "$output" ]
   [ "$status" -eq 1 ]
 
   run asdf env dummy which dummy
@@ -75,9 +75,9 @@ teardown() {
 
   # Should set path
   path_line=$(echo "$output" | grep '^PATH=')
-  [ "$path_line" != "" ]
+  [ -n "$path_line" ]
 
   # Should not contain duplicate colon
   run grep '::' <(echo "$path_line")
-  [ "$duplicate_colon" == "" ]
+  [ -z "$duplicate_colon" ]
 }

--- a/test/shim_env_command.bats
+++ b/test/shim_env_command.bats
@@ -11,7 +11,7 @@ setup() {
   cd $PROJECT_DIR
 
   # asdf lib needed to run generated shims
-  cp -rf $BATS_TEST_DIRNAME/../{bin,lib} $ASDF_DIR/
+  cp -rf $BATS_TEST_DIRNAME/../{bin,lib} "$ASDF_DIR/"
 }
 
 teardown() {
@@ -37,8 +37,8 @@ teardown() {
   echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
   run asdf install
 
-  echo "export FOO=bar" >$ASDF_DIR/plugins/dummy/bin/exec-env
-  chmod +x $ASDF_DIR/plugins/dummy/bin/exec-env
+  echo "export FOO=bar" >"$ASDF_DIR/plugins/dummy/bin/exec-env"
+  chmod +x "$ASDF_DIR/plugins/dummy/bin/exec-env"
 
   run asdf env dummy
   [ "$status" -eq 0 ]
@@ -49,8 +49,8 @@ teardown() {
   echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
   run asdf install
 
-  echo "export FOO=bar" >$ASDF_DIR/plugins/dummy/bin/exec-env
-  chmod +x $ASDF_DIR/plugins/dummy/bin/exec-env
+  echo "export FOO=bar" >"$ASDF_DIR/plugins/dummy/bin/exec-env"
+  chmod +x "$ASDF_DIR/plugins/dummy/bin/exec-env"
 
   echo "dummy system" >$PROJECT_DIR/.tool-versions
 
@@ -58,7 +58,7 @@ teardown() {
   [ "$status" -eq 0 ]
 
   run grep 'FOO=bar' <(echo $output)
-  [ -z "$output" ]
+  [ "$output" == "" ]
   [ "$status" -eq 1 ]
 
   run asdf env dummy which dummy
@@ -75,9 +75,9 @@ teardown() {
 
   # Should set path
   path_line=$(echo "$output" | grep '^PATH=')
-  [ -n "$path_line" ]
+  [ "$path_line" != "" ]
 
   # Should not contain duplicate colon
   run grep '::' <(echo "$path_line")
-  [ -z "$duplicate_colon" ]
+  [ "$duplicate_colon" == "" ]
 }

--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -7,11 +7,11 @@ setup() {
   install_dummy_plugin
 
   PROJECT_DIR=$HOME/project
-  mkdir -p $PROJECT_DIR
-  cd $PROJECT_DIR
+  mkdir -p "$PROJECT_DIR"
+  cd "$PROJECT_DIR"
 
   # asdf lib needed to run generated shims
-  cp -rf $BATS_TEST_DIRNAME/../{bin,lib} $ASDF_DIR/
+  cp -rf $BATS_TEST_DIRNAME/../{bin,lib} "$ASDF_DIR/"
 }
 
 teardown() {
@@ -25,7 +25,7 @@ teardown() {
 }
 
 @test "asdf exec should pass all arguments to executable" {
-  echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
+  echo "dummy 1.0" >"$PROJECT_DIR/.tool-versions"
   run asdf install
 
   run asdf exec dummy world hello
@@ -34,7 +34,7 @@ teardown() {
 }
 
 @test "asdf exec should pass all arguments to executable even if shim is not in PATH" {
-  echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
+  echo "dummy 1.0" >"$PROJECT_DIR/.tool-versions"
   run asdf install
 
   path=$(echo "$PATH" | sed -e "s|$(asdf_data_dir)/shims||g; s|::|:|g")
@@ -48,24 +48,24 @@ teardown() {
 }
 
 @test "shim exec should pass all arguments to executable" {
-  echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
+  echo "dummy 1.0" >"$PROJECT_DIR/.tool-versions"
   run asdf install
 
-  run $ASDF_DIR/shims/dummy world hello
+  run "$ASDF_DIR/shims/dummy" world hello
   [ "$output" == "This is Dummy 1.0! hello world" ]
   [ "$status" -eq 0 ]
 }
 
 @test "shim exec should pass stdin to executable" {
-  echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
+  echo "dummy 1.0" >"$PROJECT_DIR/.tool-versions"
   run asdf install
 
-  echo "tr [:lower:] [:upper:]" >$ASDF_DIR/installs/dummy/1.0/bin/upper
-  chmod +x $ASDF_DIR/installs/dummy/1.0/bin/upper
+  echo "tr [:lower:] [:upper:]" >"$ASDF_DIR/installs/dummy/1.0/bin/upper"
+  chmod +x "$ASDF_DIR/installs/dummy/1.0/bin/upper"
 
   run asdf reshim dummy 1.0
 
-  run echo $(echo hello | $ASDF_DIR/shims/upper)
+  run echo $(echo hello | "$ASDF_DIR/shims/upper")
   [ "$output" == "HELLO" ]
   [ "$status" -eq 0 ]
 }
@@ -73,9 +73,9 @@ teardown() {
 @test "shim exec should fail if no version is selected" {
   run asdf install dummy 1.0
 
-  touch $PROJECT_DIR/.tool-versions
+  touch "$PROJECT_DIR/.tool-versions"
 
-  run $ASDF_DIR/shims/dummy world hello
+  run "$ASDF_DIR/shims/dummy" world hello
   [ "$status" -eq 126 ]
   echo "$output" | grep -q "No version is set for command dummy" 2>/dev/null
 }
@@ -84,9 +84,9 @@ teardown() {
   run asdf install dummy 1.0
   run asdf install dummy 2.0.0
 
-  touch $PROJECT_DIR/.tool-versions
+  touch "$PROJECT_DIR/.tool-versions"
 
-  run $ASDF_DIR/shims/dummy world hello
+  run "$ASDF_DIR/shims/dummy" world hello
   [ "$status" -eq 126 ]
 
   echo "$output" | grep -q "No version is set for command dummy" 2>/dev/null
@@ -97,14 +97,14 @@ teardown() {
 
 @test "shim exec should suggest different plugins providing same tool when no version is selected" {
   # Another fake plugin with 'dummy' executable
-  cp -rf $ASDF_DIR/plugins/dummy $ASDF_DIR/plugins/mummy
+  cp -rf "$ASDF_DIR/plugins/dummy" "$ASDF_DIR/plugins/mummy"
 
   run asdf install dummy 1.0
   run asdf install mummy 3.0
 
-  touch $PROJECT_DIR/.tool-versions
+  touch "$PROJECT_DIR/.tool-versions"
 
-  run $ASDF_DIR/shims/dummy world hello
+  run "$ASDF_DIR/shims/dummy" world hello
   [ "$status" -eq 126 ]
 
   echo "$output" | grep -q "No version is set for command dummy" 2>/dev/null
@@ -116,9 +116,9 @@ teardown() {
 @test "shim exec should suggest to install missing version" {
   run asdf install dummy 1.0
 
-  echo "dummy 2.0.0 1.3" >$PROJECT_DIR/.tool-versions
+  echo "dummy 2.0.0 1.3" >"$PROJECT_DIR/.tool-versions"
 
-  run $ASDF_DIR/shims/dummy world hello
+  run "$ASDF_DIR/shims/dummy" world hello
   [ "$status" -eq 126 ]
   echo "$output" | grep -q "No preset version installed for command dummy" 2>/dev/null
   echo "$output" | grep -q "Please install a version by running one of the following:" 2>/dev/null
@@ -132,9 +132,9 @@ teardown() {
   run asdf install dummy 2.0.0
   run asdf install dummy 3.0
 
-  echo "dummy 1.0 3.0 2.0.0" >$PROJECT_DIR/.tool-versions
+  echo "dummy 1.0 3.0 2.0.0" >"$PROJECT_DIR/.tool-versions"
 
-  run $ASDF_DIR/shims/dummy world hello
+  run "$ASDF_DIR/shims/dummy" world hello
   [ "$status" -eq 0 ]
 
   echo "$output" | grep -q "This is Dummy 3.0! hello world" 2>/dev/null
@@ -143,10 +143,10 @@ teardown() {
 @test "shim exec should only use the first version found for a plugin" {
   run asdf install dummy 3.0
 
-  echo "dummy 3.0" >$PROJECT_DIR/.tool-versions
-  echo "dummy 1.0" >>$PROJECT_DIR/.tool-versions
+  echo "dummy 3.0" >"$PROJECT_DIR/.tool-versions"
+  echo "dummy 1.0" >>"$PROJECT_DIR/.tool-versions"
 
-  run $ASDF_DIR/shims/dummy world hello
+  run "$ASDF_DIR/shims/dummy" world hello
   [ "$status" -eq 0 ]
 
   echo "$output" | grep -q "This is Dummy 3.0! hello world" 2>/dev/null
@@ -154,8 +154,8 @@ teardown() {
 
 @test "shim exec should determine correct executable on two projects using different plugins that provide the same tool" {
   # Another fake plugin with 'dummy' executable
-  cp -rf $ASDF_DIR/plugins/dummy $ASDF_DIR/plugins/mummy
-  sed -i -e 's/Dummy/Mummy/' $ASDF_DIR/plugins/mummy/bin/install
+  cp -rf "$ASDF_DIR/plugins/dummy" "$ASDF_DIR/plugins/mummy"
+  sed -i -e 's/Dummy/Mummy/' "$ASDF_DIR/plugins/mummy/bin/install"
 
   run asdf install mummy 3.0
   run asdf install dummy 1.0
@@ -164,30 +164,30 @@ teardown() {
   echo "dummy 1.0" >$PROJECT_DIR/A/.tool-versions
   echo "mummy 3.0" >$PROJECT_DIR/B/.tool-versions
 
-  cd $PROJECT_DIR/A
-  run $ASDF_DIR/shims/dummy world hello
+  cd "$PROJECT_DIR"/A
+  run "$ASDF_DIR/shims/dummy" world hello
   [ "$output" == "This is Dummy 1.0! hello world" ]
   [ "$status" -eq 0 ]
 
-  cd $PROJECT_DIR/B
-  run $ASDF_DIR/shims/dummy world hello
+  cd "$PROJECT_DIR"/B
+  run "$ASDF_DIR/shims/dummy" world hello
   [ "$output" == "This is Mummy 3.0! hello world" ]
   [ "$status" -eq 0 ]
 }
 
 @test "shim exec should determine correct executable on a project with two plugins set that provide the same tool" {
   # Another fake plugin with 'dummy' executable
-  cp -rf $ASDF_DIR/plugins/dummy $ASDF_DIR/plugins/mummy
-  sed -i -e 's/Dummy/Mummy/' $ASDF_DIR/plugins/mummy/bin/install
+  cp -rf "$ASDF_DIR/plugins/dummy" "$ASDF_DIR/plugins/mummy"
+  sed -i -e 's/Dummy/Mummy/' "$ASDF_DIR/plugins/mummy/bin/install"
 
   run asdf install dummy 1.0
   run asdf install mummy 3.0
 
-  echo "dummy 2.0.0" >$PROJECT_DIR/.tool-versions
-  echo "mummy 3.0" >>$PROJECT_DIR/.tool-versions
-  echo "dummy 1.0" >>$PROJECT_DIR/.tool-versions
+  echo "dummy 2.0.0" >"$PROJECT_DIR/.tool-versions"
+  echo "mummy 3.0" >>"$PROJECT_DIR/.tool-versions"
+  echo "dummy 1.0" >>"$PROJECT_DIR/.tool-versions"
 
-  run $ASDF_DIR/shims/dummy world hello
+  run "$ASDF_DIR/shims/dummy" world hello
   [ "$output" == "This is Mummy 3.0! hello world" ]
   [ "$status" -eq 0 ]
 }
@@ -195,13 +195,13 @@ teardown() {
 @test "shim exec should fallback to system executable when specified version is system" {
   run asdf install dummy 1.0
 
-  echo "dummy system" >$PROJECT_DIR/.tool-versions
+  echo "dummy system" >"$PROJECT_DIR/.tool-versions"
 
-  mkdir $PROJECT_DIR/foo/
-  echo "echo System" >$PROJECT_DIR/foo/dummy
-  chmod +x $PROJECT_DIR/foo/dummy
+  mkdir "$PROJECT_DIR/foo/"
+  echo "echo System" >"$PROJECT_DIR/foo/dummy"
+  chmod +x "$PROJECT_DIR/foo/dummy"
 
-  run env PATH=$PATH:$PROJECT_DIR/foo $ASDF_DIR/shims/dummy hello
+  run env PATH=$PATH:$PROJECT_DIR/foo "$ASDF_DIR/shims/dummy" hello
   [ "$output" == "System" ]
 }
 
@@ -210,126 +210,126 @@ teardown() {
 
   CUSTOM_DUMMY_PATH=$PROJECT_DIR/foo
   CUSTOM_DUMMY_BIN_PATH=$CUSTOM_DUMMY_PATH/bin
-  mkdir -p $CUSTOM_DUMMY_BIN_PATH
-  echo "echo System" >$CUSTOM_DUMMY_BIN_PATH/dummy
-  chmod +x $CUSTOM_DUMMY_BIN_PATH/dummy
+  mkdir -p "$CUSTOM_DUMMY_BIN_PATH"
+  echo "echo System" >"$CUSTOM_DUMMY_BIN_PATH/dummy"
+  chmod +x "$CUSTOM_DUMMY_BIN_PATH/dummy"
 
-  echo "dummy path:$CUSTOM_DUMMY_PATH" >$PROJECT_DIR/.tool-versions
+  echo "dummy path:$CUSTOM_DUMMY_PATH" >"$PROJECT_DIR/.tool-versions"
 
-  run $ASDF_DIR/shims/dummy hello
+  run "$ASDF_DIR/shims/dummy" hello
   [ "$output" == "System" ]
 }
 
 @test "shim exec should execute system if set first" {
   run asdf install dummy 2.0.0
 
-  echo "dummy system" >$PROJECT_DIR/.tool-versions
-  echo "dummy 2.0.0" >>$PROJECT_DIR/.tool-versions
+  echo "dummy system" >"$PROJECT_DIR/.tool-versions"
+  echo "dummy 2.0.0" >>"$PROJECT_DIR/.tool-versions"
 
   mkdir $PROJECT_DIR/foo/
-  echo "echo System" >$PROJECT_DIR/foo/dummy
-  chmod +x $PROJECT_DIR/foo/dummy
+  echo "echo System" >"$PROJECT_DIR/foo/dummy"
+  chmod +x "$PROJECT_DIR/foo/dummy"
 
-  run env PATH=$PATH:$PROJECT_DIR/foo $ASDF_DIR/shims/dummy hello
+  run env PATH=$PATH:$PROJECT_DIR/foo "$ASDF_DIR/shims/dummy" hello
   [ "$output" == "System" ]
 }
 
 @test "shim exec should use custom exec-env for tool" {
   run asdf install dummy 2.0.0
-  echo "export FOO=sourced" >$ASDF_DIR/plugins/dummy/bin/exec-env
-  mkdir $ASDF_DIR/plugins/dummy/shims
-  echo 'echo $FOO custom' >$ASDF_DIR/plugins/dummy/shims/foo
-  chmod +x $ASDF_DIR/plugins/dummy/shims/foo
+  echo "export FOO=sourced" >"$ASDF_DIR/plugins/dummy/bin/exec-env"
+  mkdir "$ASDF_DIR/plugins/dummy/shims"
+  echo 'echo $FOO custom' >"$ASDF_DIR/plugins/dummy/shims/foo"
+  chmod +x "$ASDF_DIR/plugins/dummy/shims/foo"
   run asdf reshim dummy 2.0.0
 
-  echo "dummy 2.0.0" >$PROJECT_DIR/.tool-versions
-  run $ASDF_DIR/shims/foo
+  echo "dummy 2.0.0" >"$PROJECT_DIR/.tool-versions"
+  run "$ASDF_DIR/shims/foo"
   [ "$output" == "sourced custom" ]
 }
 
 @test "shim exec with custom exec-env using ASDF_INSTALL_PATH" {
   run asdf install dummy 2.0.0
-  echo 'export FOO=$ASDF_INSTALL_PATH/foo' >$ASDF_DIR/plugins/dummy/bin/exec-env
-  mkdir $ASDF_DIR/plugins/dummy/shims
-  echo 'echo $FOO custom' >$ASDF_DIR/plugins/dummy/shims/foo
-  chmod +x $ASDF_DIR/plugins/dummy/shims/foo
+  echo 'export FOO=$ASDF_INSTALL_PATH/foo' >"$ASDF_DIR/plugins/dummy/bin/exec-env"
+  mkdir "$ASDF_DIR/plugins/dummy/shims"
+  echo 'echo $FOO custom' >"$ASDF_DIR/plugins/dummy/shims/foo"
+  chmod +x "$ASDF_DIR/plugins/dummy/shims/foo"
   run asdf reshim dummy 2.0.0
 
-  echo "dummy 2.0.0" >$PROJECT_DIR/.tool-versions
-  run $ASDF_DIR/shims/foo
+  echo "dummy 2.0.0" >"$PROJECT_DIR/.tool-versions"
+  run "$ASDF_DIR/shims/foo"
   [ "$output" == "$ASDF_DIR/installs/dummy/2.0.0/foo custom" ]
 }
 
 @test "shim exec doest not use custom exec-env for system version" {
   run asdf install dummy 2.0.0
-  echo "export FOO=sourced" >$ASDF_DIR/plugins/dummy/bin/exec-env
-  mkdir $ASDF_DIR/plugins/dummy/shims
-  echo 'echo $FOO custom' >$ASDF_DIR/plugins/dummy/shims/foo
-  chmod +x $ASDF_DIR/plugins/dummy/shims/foo
+  echo "export FOO=sourced" >"$ASDF_DIR/plugins/dummy/bin/exec-env"
+  mkdir "$ASDF_DIR/plugins/dummy/shims"
+  echo 'echo $FOO custom' >"$ASDF_DIR/plugins/dummy/shims/foo"
+  chmod +x "$ASDF_DIR/plugins/dummy/shims/foo"
   run asdf reshim dummy 2.0.0
 
-  echo "dummy system" >$PROJECT_DIR/.tool-versions
+  echo "dummy system" >"$PROJECT_DIR/.tool-versions"
 
-  mkdir $PROJECT_DIR/sys/
-  echo 'echo x$FOO System' >$PROJECT_DIR/sys/foo
-  chmod +x $PROJECT_DIR/sys/foo
+  mkdir "$PROJECT_DIR/sys/"
+  echo 'echo x$FOO System' >"$PROJECT_DIR/sys/foo"
+  chmod +x "$PROJECT_DIR/sys/foo"
 
-  run env PATH=$PATH:$PROJECT_DIR/sys $ASDF_DIR/shims/foo
+  run env "PATH=$PATH:$PROJECT_DIR/sys" "$ASDF_DIR/shims/foo"
   [ "$output" == "x System" ]
 }
 
 @test "shim exec should prepend the plugin paths on execution" {
   run asdf install dummy 2.0.0
 
-  mkdir $ASDF_DIR/plugins/dummy/shims
-  echo 'which dummy' >$ASDF_DIR/plugins/dummy/shims/foo
-  chmod +x $ASDF_DIR/plugins/dummy/shims/foo
+  mkdir "$ASDF_DIR/plugins/dummy/shims"
+  echo 'which dummy' >"$ASDF_DIR/plugins/dummy/shims/foo"
+  chmod +x "$ASDF_DIR/plugins/dummy/shims/foo"
   run asdf reshim dummy 2.0.0
 
-  echo "dummy 2.0.0" >$PROJECT_DIR/.tool-versions
+  echo "dummy 2.0.0" >"$PROJECT_DIR/.tool-versions"
 
-  run $ASDF_DIR/shims/foo
+  run "$ASDF_DIR/shims/foo"
   [ "$output" == "$ASDF_DIR/installs/dummy/2.0.0/bin/dummy" ]
 }
 
 @test "shim exec should be able to find other shims in path" {
-  cp -rf $ASDF_DIR/plugins/dummy $ASDF_DIR/plugins/gummy
+  cp -rf "$ASDF_DIR/plugins/dummy" "$ASDF_DIR/plugins/gummy"
 
-  echo "dummy 2.0.0" >$PROJECT_DIR/.tool-versions
-  echo "gummy 2.0.0" >>$PROJECT_DIR/.tool-versions
+  echo "dummy 2.0.0" >"$PROJECT_DIR/.tool-versions"
+  echo "gummy 2.0.0" >>"$PROJECT_DIR/.tool-versions"
 
   run asdf install
 
-  mkdir $ASDF_DIR/plugins/{dummy,gummy}/shims
+  mkdir "$ASDF_DIR/plugins/"{dummy,gummy}/shims
 
-  echo 'which dummy' >$ASDF_DIR/plugins/dummy/shims/foo
-  chmod +x $ASDF_DIR/plugins/dummy/shims/foo
+  echo 'which dummy' >"$ASDF_DIR/plugins/dummy/shims/foo"
+  chmod +x "$ASDF_DIR/plugins/dummy/shims/foo"
 
-  echo 'which gummy' >$ASDF_DIR/plugins/dummy/shims/bar
-  chmod +x $ASDF_DIR/plugins/dummy/shims/bar
+  echo 'which gummy' >"$ASDF_DIR/plugins/dummy/shims/bar"
+  chmod +x "$ASDF_DIR/plugins/dummy/shims/bar"
 
-  touch $ASDF_DIR/plugins/gummy/shims/gummy
-  chmod +x $ASDF_DIR/plugins/gummy/shims/gummy
+  touch "$ASDF_DIR/plugins/gummy/shims/gummy"
+  chmod +x "$ASDF_DIR/plugins/gummy/shims/gummy"
 
   run asdf reshim
 
-  run $ASDF_DIR/shims/foo
+  run "$ASDF_DIR/shims/foo"
   [ "$output" == "$ASDF_DIR/installs/dummy/2.0.0/bin/dummy" ]
 
-  run $ASDF_DIR/shims/bar
+  run "$ASDF_DIR/shims/bar"
   [ "$output" == "$ASDF_DIR/shims/gummy" ]
 }
 
 @test "shim exec should remove shim_path from path on system version execution" {
   run asdf install dummy 2.0.0
 
-  echo "dummy system" >$PROJECT_DIR/.tool-versions
+  echo "dummy system" >"$PROJECT_DIR/.tool-versions"
 
-  mkdir $PROJECT_DIR/sys/
-  echo 'which dummy' >$PROJECT_DIR/sys/dummy
-  chmod +x $PROJECT_DIR/sys/dummy
+  mkdir "$PROJECT_DIR/sys/"
+  echo 'which dummy' >"$PROJECT_DIR/sys/dummy"
+  chmod +x "$PROJECT_DIR/sys/dummy"
 
-  run env PATH=$PATH:$PROJECT_DIR/sys $ASDF_DIR/shims/dummy
+  run env "PATH=$PATH:$PROJECT_DIR/sys" "$ASDF_DIR/shims/dummy"
   echo $status $output
   [ "$output" == "$ASDF_DIR/shims/dummy" ]
 }
@@ -337,16 +337,16 @@ teardown() {
 @test "shim exec can take version from legacy file if configured" {
   run asdf install dummy 2.0.0
 
-  echo "legacy_version_file = yes" >$HOME/.asdfrc
-  echo "2.0.0" >$PROJECT_DIR/.dummy-version
+  echo "legacy_version_file = yes" >"$HOME/.asdfrc"
+  echo "2.0.0" >"$PROJECT_DIR/.dummy-version"
 
-  run $ASDF_DIR/shims/dummy world hello
+  run "$ASDF_DIR/shims/dummy" world hello
   [ "$output" == "This is Dummy 2.0.0! hello world" ]
 }
 
 @test "shim exec can take version from environment variable" {
   run asdf install dummy 2.0.0
-  run env ASDF_DUMMY_VERSION=2.0.0 $ASDF_DIR/shims/dummy world hello
+  run env ASDF_DUMMY_VERSION=2.0.0 "$ASDF_DIR/shims/dummy" world hello
   [ "$output" == "This is Dummy 2.0.0! hello world" ]
 }
 
@@ -358,7 +358,7 @@ teardown() {
   chmod +x $exec_path
 
   run asdf install dummy 1.0
-  echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
+  echo "dummy 1.0" >"$PROJECT_DIR/.tool-versions"
 
   mkdir $custom_path
   echo "echo CUSTOM" >$custom_path/foo
@@ -366,7 +366,7 @@ teardown() {
 
   run asdf reshim dummy 1.0
 
-  run $ASDF_DIR/shims/foo
+  run "$ASDF_DIR/shims/foo"
   [ "$output" == "CUSTOM" ]
 }
 
@@ -383,9 +383,9 @@ teardown() {
   echo "echo CUSTOM" >$custom_dummy
   chmod +x $custom_dummy
 
-  echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
+  echo "dummy 1.0" >"$PROJECT_DIR/.tool-versions"
 
-  run $ASDF_DIR/shims/dummy
+  run "$ASDF_DIR/shims/dummy"
   [ "$output" == "CUSTOM" ]
 }
 
@@ -397,21 +397,21 @@ teardown() {
   echo 'echo $3 # always same path' >$exec_path
   chmod +x $exec_path
 
-  echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
+  echo "dummy 1.0" >"$PROJECT_DIR/.tool-versions"
 
-  run $ASDF_DIR/shims/dummy
+  run "$ASDF_DIR/shims/dummy"
   [ "$output" == "This is Dummy 1.0!" ]
 }
 
 @test "shim exec executes configured pre-hook" {
   run asdf install dummy 1.0
-  echo dummy 1.0 >$PROJECT_DIR/.tool-versions
+  echo dummy 1.0 >"$PROJECT_DIR/.tool-versions"
 
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 pre_dummy_dummy = echo PRE $version $1 $2
 EOM
 
-  run $ASDF_DIR/shims/dummy hello world
+  run "$ASDF_DIR/shims/dummy" hello world
   [ "$status" -eq 0 ]
   echo "$output" | grep "PRE 1.0 hello world"
   echo "$output" | grep "This is Dummy 1.0! world hello"
@@ -419,18 +419,18 @@ EOM
 
 @test "shim exec doesnt execute command if pre-hook failed" {
   run asdf install dummy 1.0
-  echo dummy 1.0 >$PROJECT_DIR/.tool-versions
+  echo dummy 1.0 >"$PROJECT_DIR/.tool-versions"
 
   mkdir $HOME/hook
   pre_cmd="$HOME/hook/pre"
   echo 'echo $* && false' >"$pre_cmd"
   chmod +x "$pre_cmd"
 
-  cat >$HOME/.asdfrc <<'EOM'
+  cat >"$HOME/.asdfrc" <<'EOM'
 pre_dummy_dummy = pre $1 no $plugin_name $2
 EOM
 
-  run env PATH=$PATH:$HOME/hook $ASDF_DIR/shims/dummy hello world
+  run env PATH=$PATH:$HOME/hook "$ASDF_DIR/shims/dummy" hello world
   [ "$output" == "hello no dummy world" ]
   [ "$status" -eq 1 ]
 }
@@ -439,7 +439,7 @@ EOM
 @test "asdf exec should not crash when POSIXLY_CORRECT=1" {
   export POSIXLY_CORRECT=1
 
-  echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
+  echo "dummy 1.0" >"$PROJECT_DIR/.tool-versions"
   run asdf install
 
   run asdf exec dummy world hello

--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -29,7 +29,7 @@ teardown() {
   run asdf install
 
   run asdf exec dummy world hello
-  [ "$output" == "This is Dummy 1.0! hello world" ]
+  [ "$output" = "This is Dummy 1.0! hello world" ]
   [ "$status" -eq 0 ]
 }
 
@@ -43,7 +43,7 @@ teardown() {
   [ "$status" -eq 1 ]
 
   run env PATH=$path asdf exec dummy world hello
-  [ "$output" == "This is Dummy 1.0! hello world" ]
+  [ "$output" = "This is Dummy 1.0! hello world" ]
   [ "$status" -eq 0 ]
 }
 
@@ -52,7 +52,7 @@ teardown() {
   run asdf install
 
   run "$ASDF_DIR/shims/dummy" world hello
-  [ "$output" == "This is Dummy 1.0! hello world" ]
+  [ "$output" = "This is Dummy 1.0! hello world" ]
   [ "$status" -eq 0 ]
 }
 
@@ -66,7 +66,7 @@ teardown() {
   run asdf reshim dummy 1.0
 
   run echo $(echo hello | "$ASDF_DIR/shims/upper")
-  [ "$output" == "HELLO" ]
+  [ "$output" = "HELLO" ]
   [ "$status" -eq 0 ]
 }
 
@@ -166,12 +166,12 @@ teardown() {
 
   cd "$PROJECT_DIR"/A
   run "$ASDF_DIR/shims/dummy" world hello
-  [ "$output" == "This is Dummy 1.0! hello world" ]
+  [ "$output" = "This is Dummy 1.0! hello world" ]
   [ "$status" -eq 0 ]
 
   cd "$PROJECT_DIR"/B
   run "$ASDF_DIR/shims/dummy" world hello
-  [ "$output" == "This is Mummy 3.0! hello world" ]
+  [ "$output" = "This is Mummy 3.0! hello world" ]
   [ "$status" -eq 0 ]
 }
 
@@ -188,7 +188,7 @@ teardown() {
   echo "dummy 1.0" >>"$PROJECT_DIR/.tool-versions"
 
   run "$ASDF_DIR/shims/dummy" world hello
-  [ "$output" == "This is Mummy 3.0! hello world" ]
+  [ "$output" = "This is Mummy 3.0! hello world" ]
   [ "$status" -eq 0 ]
 }
 
@@ -202,7 +202,7 @@ teardown() {
   chmod +x "$PROJECT_DIR/foo/dummy"
 
   run env PATH=$PATH:$PROJECT_DIR/foo "$ASDF_DIR/shims/dummy" hello
-  [ "$output" == "System" ]
+  [ "$output" = "System" ]
 }
 
 @test "shim exec should use path executable when specified version path:<path>" {
@@ -217,7 +217,7 @@ teardown() {
   echo "dummy path:$CUSTOM_DUMMY_PATH" >"$PROJECT_DIR/.tool-versions"
 
   run "$ASDF_DIR/shims/dummy" hello
-  [ "$output" == "System" ]
+  [ "$output" = "System" ]
 }
 
 @test "shim exec should execute system if set first" {
@@ -231,7 +231,7 @@ teardown() {
   chmod +x "$PROJECT_DIR/foo/dummy"
 
   run env PATH=$PATH:$PROJECT_DIR/foo "$ASDF_DIR/shims/dummy" hello
-  [ "$output" == "System" ]
+  [ "$output" = "System" ]
 }
 
 @test "shim exec should use custom exec-env for tool" {
@@ -244,7 +244,7 @@ teardown() {
 
   echo "dummy 2.0.0" >"$PROJECT_DIR/.tool-versions"
   run "$ASDF_DIR/shims/foo"
-  [ "$output" == "sourced custom" ]
+  [ "$output" = "sourced custom" ]
 }
 
 @test "shim exec with custom exec-env using ASDF_INSTALL_PATH" {
@@ -257,7 +257,7 @@ teardown() {
 
   echo "dummy 2.0.0" >"$PROJECT_DIR/.tool-versions"
   run "$ASDF_DIR/shims/foo"
-  [ "$output" == "$ASDF_DIR/installs/dummy/2.0.0/foo custom" ]
+  [ "$output" = "$ASDF_DIR/installs/dummy/2.0.0/foo custom" ]
 }
 
 @test "shim exec doest not use custom exec-env for system version" {
@@ -275,7 +275,7 @@ teardown() {
   chmod +x "$PROJECT_DIR/sys/foo"
 
   run env "PATH=$PATH:$PROJECT_DIR/sys" "$ASDF_DIR/shims/foo"
-  [ "$output" == "x System" ]
+  [ "$output" = "x System" ]
 }
 
 @test "shim exec should prepend the plugin paths on execution" {
@@ -289,7 +289,7 @@ teardown() {
   echo "dummy 2.0.0" >"$PROJECT_DIR/.tool-versions"
 
   run "$ASDF_DIR/shims/foo"
-  [ "$output" == "$ASDF_DIR/installs/dummy/2.0.0/bin/dummy" ]
+  [ "$output" = "$ASDF_DIR/installs/dummy/2.0.0/bin/dummy" ]
 }
 
 @test "shim exec should be able to find other shims in path" {
@@ -314,10 +314,10 @@ teardown() {
   run asdf reshim
 
   run "$ASDF_DIR/shims/foo"
-  [ "$output" == "$ASDF_DIR/installs/dummy/2.0.0/bin/dummy" ]
+  [ "$output" = "$ASDF_DIR/installs/dummy/2.0.0/bin/dummy" ]
 
   run "$ASDF_DIR/shims/bar"
-  [ "$output" == "$ASDF_DIR/shims/gummy" ]
+  [ "$output" = "$ASDF_DIR/shims/gummy" ]
 }
 
 @test "shim exec should remove shim_path from path on system version execution" {
@@ -331,7 +331,7 @@ teardown() {
 
   run env "PATH=$PATH:$PROJECT_DIR/sys" "$ASDF_DIR/shims/dummy"
   echo $status $output
-  [ "$output" == "$ASDF_DIR/shims/dummy" ]
+  [ "$output" = "$ASDF_DIR/shims/dummy" ]
 }
 
 @test "shim exec can take version from legacy file if configured" {
@@ -341,13 +341,13 @@ teardown() {
   echo "2.0.0" >"$PROJECT_DIR/.dummy-version"
 
   run "$ASDF_DIR/shims/dummy" world hello
-  [ "$output" == "This is Dummy 2.0.0! hello world" ]
+  [ "$output" = "This is Dummy 2.0.0! hello world" ]
 }
 
 @test "shim exec can take version from environment variable" {
   run asdf install dummy 2.0.0
   run env ASDF_DUMMY_VERSION=2.0.0 "$ASDF_DIR/shims/dummy" world hello
-  [ "$output" == "This is Dummy 2.0.0! hello world" ]
+  [ "$output" = "This is Dummy 2.0.0! hello world" ]
 }
 
 @test "shim exec uses plugin list-bin-paths" {
@@ -367,7 +367,7 @@ teardown() {
   run asdf reshim dummy 1.0
 
   run "$ASDF_DIR/shims/foo"
-  [ "$output" == "CUSTOM" ]
+  [ "$output" = "CUSTOM" ]
 }
 
 @test "shim exec uses plugin custom exec-path hook" {
@@ -386,7 +386,7 @@ teardown() {
   echo "dummy 1.0" >"$PROJECT_DIR/.tool-versions"
 
   run "$ASDF_DIR/shims/dummy"
-  [ "$output" == "CUSTOM" ]
+  [ "$output" = "CUSTOM" ]
 }
 
 @test "shim exec uses plugin custom exec-path hook that defaults" {
@@ -400,7 +400,7 @@ teardown() {
   echo "dummy 1.0" >"$PROJECT_DIR/.tool-versions"
 
   run "$ASDF_DIR/shims/dummy"
-  [ "$output" == "This is Dummy 1.0!" ]
+  [ "$output" = "This is Dummy 1.0!" ]
 }
 
 @test "shim exec executes configured pre-hook" {
@@ -431,7 +431,7 @@ pre_dummy_dummy = pre $1 no $plugin_name $2
 EOM
 
   run env PATH=$PATH:$HOME/hook "$ASDF_DIR/shims/dummy" hello world
-  [ "$output" == "hello no dummy world" ]
+  [ "$output" = "hello no dummy world" ]
   [ "$status" -eq 1 ]
 }
 
@@ -444,6 +444,6 @@ EOM
 
   run asdf exec dummy world hello
   echo $output
-  [ "$output" == "This is Dummy 1.0! hello world" ]
+  [ "$output" = "This is Dummy 1.0! hello world" ]
   [ "$status" -eq 0 ]
 }

--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -39,7 +39,7 @@ teardown() {
 
   path=$(echo "$PATH" | sed -e "s|$(asdf_data_dir)/shims||g; s|::|:|g")
   run env PATH=$path which dummy
-  [ "$output" == "" ]
+  [ -z "$output" ]
   [ "$status" -eq 1 ]
 
   run env PATH=$path asdf exec dummy world hello

--- a/test/shim_versions_command.bats
+++ b/test/shim_versions_command.bats
@@ -7,8 +7,8 @@ setup() {
   install_dummy_plugin
 
   PROJECT_DIR=$HOME/project
-  mkdir -p $PROJECT_DIR
-  cd $PROJECT_DIR
+  mkdir -p "$PROJECT_DIR"
+  cd "$PROJECT_DIR"
 }
 
 teardown() {
@@ -16,7 +16,7 @@ teardown() {
 }
 
 @test "shim_versions_command should list plugins and versions where command is available" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
   run asdf install dummy 3.0
   run asdf install dummy 1.0
   run asdf reshim dummy

--- a/test/test_helpers.bash
+++ b/test/test_helpers.bash
@@ -22,7 +22,7 @@ setup_asdf_dir() {
   ASDF_BIN="$(dirname "$BATS_TEST_DIRNAME")/bin"
 
   # shellcheck disable=SC2031
-  PATH="$ASDF_BIN:$ASDF_DIR/shims:$PATH"
+  PATH="$ASDF_BIN:"$ASDF_DIR/shims":$PATH"
 }
 
 install_mock_plugin() {

--- a/test/uninstall_command.bats
+++ b/test/uninstall_command.bats
@@ -16,7 +16,7 @@ teardown() {
 
 @test "uninstall_command should fail when no such version is installed" {
   run asdf uninstall dummy 3.14
-  [ "$output" == "No such version" ]
+  [ "$output" = "No such version" ]
   [ "$status" -eq 1 ]
 }
 
@@ -35,7 +35,7 @@ teardown() {
   echo "echo custom uninstall" >"$ASDF_DIR/plugins/dummy/bin/uninstall"
   chmod 755 "$ASDF_DIR/plugins/dummy/bin/uninstall"
   run asdf uninstall dummy 1.1.0
-  [ "$output" == "custom uninstall" ]
+  [ "$output" = "custom uninstall" ]
   [ "$status" -eq 0 ]
 }
 
@@ -90,7 +90,7 @@ EOM
 
   run asdf install dummy 1.0.0
   run asdf uninstall dummy 1.0.0
-  [ "$output" == "will uninstall dummy 1.0.0" ]
+  [ "$output" = "will uninstall dummy 1.0.0" ]
 }
 
 @test "uninstall command executes configured post hook" {
@@ -101,5 +101,5 @@ EOM
   run asdf install dummy 1.0.0
   run asdf uninstall dummy 1.0.0
   echo $output
-  [ "$output" == "removed dummy 1.0.0" ]
+  [ "$output" = "removed dummy 1.0.0" ]
 }

--- a/test/uninstall_command.bats
+++ b/test/uninstall_command.bats
@@ -7,7 +7,7 @@ setup() {
   install_dummy_plugin
 
   PROJECT_DIR=$HOME/project
-  mkdir $PROJECT_DIR
+  mkdir -p "$PROJECT_DIR"
 }
 
 teardown() {
@@ -23,17 +23,17 @@ teardown() {
 @test "uninstall_command should remove the plugin with that version from asdf" {
   run asdf install dummy 1.1.0
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.1.0/version) = "1.1.0" ]
+  [ $(cat "$ASDF_DIR/installs/dummy/1.1.0/version") = "1.1.0" ]
   run asdf uninstall dummy 1.1.0
-  [ ! -f $ASDF_DIR/installs/dummy/1.1.0/version ]
+  [ ! -f "$ASDF_DIR/installs/dummy/1.1.0/version" ]
 }
 
 @test "uninstall_command should invoke the plugin bin/uninstall if available" {
   run asdf install dummy 1.1.0
   [ "$status" -eq 0 ]
-  mkdir -p $ASDF_DIR/plugins/dummy/bin
-  echo "echo custom uninstall" >$ASDF_DIR/plugins/dummy/bin/uninstall
-  chmod 755 $ASDF_DIR/plugins/dummy/bin/uninstall
+  mkdir -p "$ASDF_DIR/plugins/dummy/bin"
+  echo "echo custom uninstall" >"$ASDF_DIR/plugins/dummy/bin/uninstall"
+  chmod 755 "$ASDF_DIR/plugins/dummy/bin/uninstall"
   run asdf uninstall dummy 1.1.0
   [ "$output" == "custom uninstall" ]
   [ "$status" -eq 0 ]
@@ -41,50 +41,50 @@ teardown() {
 
 @test "uninstall_command should remove the plugin shims if no other version is installed" {
   run asdf install dummy 1.1.0
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
   run asdf uninstall dummy 1.1.0
-  [ ! -f $ASDF_DIR/shims/dummy ]
+  [ ! -f "$ASDF_DIR/shims/dummy" ]
 }
 
 @test "uninstall_command should leave the plugin shims if other version is installed" {
   run asdf install dummy 1.0.0
-  [ -f $ASDF_DIR/installs/dummy/1.0.0/bin/dummy ]
+  [ -f "$ASDF_DIR/installs/dummy/1.0.0/bin/dummy" ]
 
   run asdf install dummy 1.1.0
-  [ -f $ASDF_DIR/installs/dummy/1.1.0/bin/dummy ]
+  [ -f "$ASDF_DIR/installs/dummy/1.1.0/bin/dummy" ]
 
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
   run asdf uninstall dummy 1.0.0
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
 }
 
 @test "uninstall_command should remove relevant asdf-plugin metadata" {
   run asdf install dummy 1.0.0
-  [ -f $ASDF_DIR/installs/dummy/1.0.0/bin/dummy ]
+  [ -f "$ASDF_DIR/installs/dummy/1.0.0/bin/dummy" ]
 
   run asdf install dummy 1.1.0
-  [ -f $ASDF_DIR/installs/dummy/1.1.0/bin/dummy ]
+  [ -f "$ASDF_DIR/installs/dummy/1.1.0/bin/dummy" ]
 
   run asdf uninstall dummy 1.0.0
-  run grep "asdf-plugin: dummy 1.1.0" $ASDF_DIR/shims/dummy
+  run grep "asdf-plugin: dummy 1.1.0" "$ASDF_DIR/shims/dummy"
   [ "$status" -eq 0 ]
-  run grep "asdf-plugin: dummy 1.0.0" $ASDF_DIR/shims/dummy
+  run grep "asdf-plugin: dummy 1.0.0" "$ASDF_DIR/shims/dummy"
   [ "$status" -eq 1 ]
 }
 
 @test "uninstall_command should not remove other unrelated shims" {
   run asdf install dummy 1.0.0
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
 
-  touch $ASDF_DIR/shims/gummy
-  [ -f $ASDF_DIR/shims/gummy ]
+  touch "$ASDF_DIR/shims/gummy"
+  [ -f "$ASDF_DIR/shims/gummy" ]
 
   run asdf uninstall dummy 1.0.0
-  [ -f $ASDF_DIR/shims/gummy ]
+  [ -f "$ASDF_DIR/shims/gummy" ]
 }
 
 @test "uninstall command executes configured pre hook" {
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 pre_asdf_uninstall_dummy = echo will uninstall dummy $1
 EOM
 
@@ -94,7 +94,7 @@ EOM
 }
 
 @test "uninstall command executes configured post hook" {
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 post_asdf_uninstall_dummy = echo removed dummy $1
 EOM
 

--- a/test/update_command.bats
+++ b/test/update_command.bats
@@ -15,11 +15,11 @@ setup() {
   ASDF_BIN="$ASDF_DIR/bin"
 
   # shellcheck disable=SC2031
-  PATH=$ASDF_BIN:$ASDF_DIR/shims:$PATH
+  PATH=$ASDF_BIN:"$ASDF_DIR/shims":$PATH
   install_dummy_plugin
 
   PROJECT_DIR=$HOME/project
-  mkdir $PROJECT_DIR
+  mkdir -p "$PROJECT_DIR"
 }
 
 teardown() {
@@ -29,7 +29,7 @@ teardown() {
 @test "asdf update --head should checkout the master branch" {
   run asdf update --head
   [ "$status" -eq 0 ]
-  cd $ASDF_DIR
+  cd "$ASDF_DIR"
   [ $(git rev-parse --abbrev-ref HEAD) = "master" ]
 }
 
@@ -38,8 +38,8 @@ teardown() {
   if [ -n "$tag" ]; then
     run asdf update
     [ "$status" -eq 0 ]
-    cd $ASDF_DIR
-    git tag | grep $tag
+    cd "$ASDF_DIR"
+    git tag | grep "$tag"
     [ "$?" -eq 0 ]
   fi
 }
@@ -51,21 +51,21 @@ teardown() {
     echo "use_release_candidates = yes" >$ASDF_CONFIG_DEFAULT_FILE
     run asdf update
     [ "$status" -eq 0 ]
-    cd $ASDF_DIR
-    git tag | grep $tag
+    cd "$ASDF_DIR"
+    git tag | grep "$tag"
     [ "$?" -eq 0 ]
   fi
 }
 
 @test "asdf update is a noop for when updates are disabled" {
-  touch $ASDF_DIR/asdf_updates_disabled
+  touch "$ASDF_DIR/asdf_updates_disabled"
   run asdf update
   [ "$status" -eq 42 ]
   [ "$(echo -e "Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf.")" == "$output" ]
 }
 
 @test "asdf update is a noop for non-git repos" {
-  rm -rf $ASDF_DIR/.git/
+  rm -rf "$ASDF_DIR/.git/"
   run asdf update
   [ "$status" -eq 42 ]
   [ "$(echo -e "Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf.")" == "$output" ]
@@ -80,32 +80,32 @@ teardown() {
 @test "asdf update should not remove plugin versions" {
   run asdf install dummy 1.1.0
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.1.0/version) = "1.1.0" ]
+  [ $(cat "$ASDF_DIR/installs/dummy/1.1.0/version") = "1.1.0" ]
   run asdf update
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/installs/dummy/1.1.0/version ]
+  [ -f "$ASDF_DIR/installs/dummy/1.1.0/version" ]
   run asdf update --head
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/installs/dummy/1.1.0/version ]
+  [ -f "$ASDF_DIR/installs/dummy/1.1.0/version" ]
 }
 
 @test "asdf update should not remove plugins" {
   # dummy plugin is already installed
   run asdf update
   [ "$status" -eq 0 ]
-  [ -d $ASDF_DIR/plugins/dummy ]
+  [ -d "$ASDF_DIR/plugins/dummy" ]
   run asdf update --head
   [ "$status" -eq 0 ]
-  [ -d $ASDF_DIR/plugins/dummy ]
+  [ -d "$ASDF_DIR/plugins/dummy" ]
 }
 
 @test "asdf update should not remove shims" {
   run asdf install dummy 1.1.0
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
   run asdf update
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
   run asdf update --head
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
 }

--- a/test/update_command.bats
+++ b/test/update_command.bats
@@ -61,14 +61,14 @@ teardown() {
   touch "$ASDF_DIR/asdf_updates_disabled"
   run asdf update
   [ "$status" -eq 42 ]
-  [ "$(echo -e "Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf.")" == "$output" ]
+  [ "$(echo -e "Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf.")" = "$output" ]
 }
 
 @test "asdf update is a noop for non-git repos" {
   rm -rf "$ASDF_DIR/.git/"
   run asdf update
   [ "$status" -eq 42 ]
-  [ "$(echo -e "Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf.")" == "$output" ]
+  [ "$(echo -e "Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf.")" = "$output" ]
 }
 
 @test "asdf update fails with exit code 1" {

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -9,7 +9,7 @@ setup() {
   install_dummy_version "0.2.0"
 
   PROJECT_DIR=$HOME/project
-  mkdir -p $PROJECT_DIR
+  mkdir -p "$PROJECT_DIR"
 
   cd $HOME
 }
@@ -83,15 +83,15 @@ teardown() {
 }
 
 @test "check_if_version_exists should be noop if version is system" {
-  mkdir -p $ASDF_DIR/plugins/foo
+  mkdir -p "$ASDF_DIR/plugins/foo"
   run check_if_version_exists "foo" "system"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
 
 @test "check_if_version_exists should be ok for ref:version install" {
-  mkdir -p $ASDF_DIR/plugins/foo
-  mkdir -p $ASDF_DIR/installs/foo/ref-master
+  mkdir -p "$ASDF_DIR/plugins/foo"
+  mkdir -p "$ASDF_DIR/installs/foo/ref-master"
   run check_if_version_exists "foo" "ref:master"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
@@ -110,8 +110,8 @@ teardown() {
 }
 
 @test "parse_asdf_version_file should output version" {
-  echo "dummy 0.1.0" >$PROJECT_DIR/.tool-versions
-  run parse_asdf_version_file $PROJECT_DIR/.tool-versions dummy
+  echo "dummy 0.1.0" >"$PROJECT_DIR/.tool-versions"
+  run parse_asdf_version_file "$PROJECT_DIR/.tool-versions" dummy
   [ "$status" -eq 0 ]
   [ "$output" == "0.1.0" ]
 }
@@ -127,15 +127,15 @@ teardown() {
 }
 
 @test "parse_asdf_version_file should output path version with spaces" {
-  echo "dummy path:/some/dummy path" >$PROJECT_DIR/.tool-versions
-  run parse_asdf_version_file $PROJECT_DIR/.tool-versions dummy
+  echo "dummy path:/some/dummy path" >"$PROJECT_DIR/.tool-versions"
+  run parse_asdf_version_file "$PROJECT_DIR/.tool-versions" dummy
   [ "$status" -eq 0 ]
   [ "$output" == "path:/some/dummy path" ]
 }
 
 @test "find_versions should return .tool-versions if legacy is disabled" {
-  echo "dummy 0.1.0" >$PROJECT_DIR/.tool-versions
-  echo "0.2.0" >$PROJECT_DIR/.dummy-version
+  echo "dummy 0.1.0" >"$PROJECT_DIR/.tool-versions"
+  echo "0.2.0" >"$PROJECT_DIR/.dummy-version"
 
   run find_versions "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
@@ -143,9 +143,9 @@ teardown() {
 }
 
 @test "find_versions should return the legacy file if supported" {
-  echo "legacy_version_file = yes" >$HOME/.asdfrc
-  echo "dummy 0.1.0" >$HOME/.tool-versions
-  echo "0.2.0" >$PROJECT_DIR/.dummy-version
+  echo "legacy_version_file = yes" >"$HOME/.asdfrc"
+  echo "dummy 0.1.0" >"$HOME/.tool-versions"
+  echo "0.2.0" >"$PROJECT_DIR/.dummy-version"
 
   run find_versions "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
@@ -153,8 +153,8 @@ teardown() {
 }
 
 @test "find_versions skips .tool-version file that don't list the plugin" {
-  echo "dummy 0.1.0" >$HOME/.tool-versions
-  echo "another_plugin 0.3.0" >$PROJECT_DIR/.tool-versions
+  echo "dummy 0.1.0" >"$HOME/.tool-versions"
+  echo "another_plugin 0.3.0" >"$PROJECT_DIR/.tool-versions"
 
   run find_versions "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
@@ -162,10 +162,10 @@ teardown() {
 }
 
 @test "find_versions should return .tool-versions if unsupported" {
-  echo "dummy 0.1.0" >$HOME/.tool-versions
-  echo "0.2.0" >$PROJECT_DIR/.dummy-version
-  echo "legacy_version_file = yes" >$HOME/.asdfrc
-  rm $ASDF_DIR/plugins/dummy/bin/list-legacy-filenames
+  echo "dummy 0.1.0" >"$HOME/.tool-versions"
+  echo "0.2.0" >"$PROJECT_DIR/.dummy-version"
+  echo "legacy_version_file = yes" >"$HOME/.asdfrc"
+  rm "$ASDF_DIR/plugins/dummy/bin/list-legacy-filenames"
 
   run find_versions "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
@@ -213,7 +213,7 @@ teardown() {
 
 @test "find_versions should return \$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME if set" {
   ASDF_DEFAULT_TOOL_VERSIONS_FILENAME="$PROJECT_DIR/global-tool-versions"
-  echo "dummy 0.1.0" >$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
+  echo "dummy 0.1.0" >"$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME"
 
   run find_versions "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
@@ -222,9 +222,9 @@ teardown() {
 
 @test "find_versions should check \$HOME legacy files before \$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME" {
   ASDF_DEFAULT_TOOL_VERSIONS_FILENAME="$PROJECT_DIR/global-tool-versions"
-  echo "dummy 0.2.0" >$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
+  echo "dummy 0.2.0" >"$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME"
   echo "dummy 0.1.0" >$HOME/.dummy-version
-  echo "legacy_version_file = yes" >$HOME/.asdfrc
+  echo "legacy_version_file = yes" >"$HOME/.asdfrc"
 
   run find_versions "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
@@ -232,7 +232,7 @@ teardown() {
 }
 
 @test "get_preset_version_for returns the current version" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
   echo "dummy 0.2.0" >.tool-versions
   run get_preset_version_for "dummy"
   [ "$status" -eq 0 ]
@@ -240,16 +240,16 @@ teardown() {
 }
 
 @test "get_preset_version_for returns the global version from home when project is outside of home" {
-  echo "dummy 0.1.0" >$HOME/.tool-versions
+  echo "dummy 0.1.0" >"$HOME/.tool-versions"
   PROJECT_DIR=$BASE_DIR/project
-  mkdir -p $PROJECT_DIR
+  mkdir -p "$PROJECT_DIR"
   run get_preset_version_for "dummy"
   [ "$status" -eq 0 ]
   [ "$output" = "0.1.0" ]
 }
 
 @test "get_preset_version_for returns the tool version from env if ASDF_{TOOL}_VERSION is defined" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
   echo "dummy 0.2.0" >.tool-versions
   ASDF_DUMMY_VERSION=3.0.0 run get_preset_version_for "dummy"
   [ "$status" -eq 0 ]
@@ -257,32 +257,32 @@ teardown() {
 }
 
 @test "get_preset_version_for should return branch reference version" {
-  cd $PROJECT_DIR
-  echo "dummy ref:master" >$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  echo "dummy ref:master" >"$PROJECT_DIR/.tool-versions"
   run get_preset_version_for "dummy"
   [ "$status" -eq 0 ]
   [ "$output" = "ref:master" ]
 }
 
 @test "get_preset_version_for should return path version" {
-  cd $PROJECT_DIR
-  echo "dummy path:/some/place with spaces" >$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  echo "dummy path:/some/place with spaces" >"$PROJECT_DIR/.tool-versions"
   run get_preset_version_for "dummy"
   [ "$status" -eq 0 ]
   [ "$output" = "path:/some/place with spaces" ]
 }
 
 @test "get_executable_path for system version should return system path" {
-  mkdir -p $ASDF_DIR/plugins/foo
+  mkdir -p "$ASDF_DIR/plugins/foo"
   run get_executable_path "foo" "system" "ls"
   [ "$status" -eq 0 ]
   [ "$output" = $(which ls) ]
 }
 
 @test "get_executable_path for system version should not use asdf shims" {
-  mkdir -p $ASDF_DIR/plugins/foo
-  touch $ASDF_DIR/shims/dummy_executable
-  chmod +x $ASDF_DIR/shims/dummy_executable
+  mkdir -p "$ASDF_DIR/plugins/foo"
+  touch "$ASDF_DIR/shims/dummy_executable"
+  chmod +x "$ASDF_DIR/shims/dummy_executable"
 
   run which dummy_executable
   [ "$status" -eq 0 ]
@@ -292,9 +292,9 @@ teardown() {
 }
 
 @test "get_executable_path for non system version should return relative path from plugin" {
-  mkdir -p $ASDF_DIR/plugins/foo
-  mkdir -p $ASDF_DIR/installs/foo/1.0.0/bin
-  executable_path=$ASDF_DIR/installs/foo/1.0.0/bin/dummy
+  mkdir -p "$ASDF_DIR/plugins/foo"
+  mkdir -p "$ASDF_DIR/installs/foo/1.0.0/bin"
+  executable_path="$ASDF_DIR/installs/foo/1.0.0/bin/dummy"
   touch $executable_path
   chmod +x $executable_path
 
@@ -304,9 +304,9 @@ teardown() {
 }
 
 @test "get_executable_path for ref:version installed version should resolve to ref-version" {
-  mkdir -p $ASDF_DIR/plugins/foo
-  mkdir -p $ASDF_DIR/installs/foo/ref-master/bin
-  executable_path=$ASDF_DIR/installs/foo/ref-master/bin/dummy
+  mkdir -p "$ASDF_DIR/plugins/foo"
+  mkdir -p "$ASDF_DIR/installs/foo/ref-master/bin"
+  executable_path="$ASDF_DIR/installs/foo/ref-master/bin/dummy"
   touch $executable_path
   chmod +x $executable_path
 
@@ -316,8 +316,8 @@ teardown() {
 }
 
 @test "find_tool_versions will find a .tool-versions path if it exists in current directory" {
-  echo "dummy 0.1.0" >$PROJECT_DIR/.tool-versions
-  cd $PROJECT_DIR
+  echo "dummy 0.1.0" >"$PROJECT_DIR/.tool-versions"
+  cd "$PROJECT_DIR"
 
   run find_tool_versions
   [ "$status" -eq 0 ]
@@ -325,9 +325,9 @@ teardown() {
 }
 
 @test "find_tool_versions will find a .tool-versions path if it exists in parent directory" {
-  echo "dummy 0.1.0" >$PROJECT_DIR/.tool-versions
-  mkdir -p $PROJECT_DIR/child
-  cd $PROJECT_DIR/child
+  echo "dummy 0.1.0" >"$PROJECT_DIR/.tool-versions"
+  mkdir -p "$PROJECT_DIR/child"
+  cd "$PROJECT_DIR"/child
 
   run find_tool_versions
   [ "$status" -eq 0 ]
@@ -351,7 +351,7 @@ teardown() {
 
 @test "resolve_symlink converts the symlink path to the real file path" {
   touch foo
-  ln -s $PWD/foo bar
+  ln -s "$PWD/foo" bar
 
   run resolve_symlink bar
   [ "$status" -eq 0 ]
@@ -429,11 +429,11 @@ EOF
 }
 
 @test "with_shim_executable doesn't crash when executable names contain dashes" {
-  cd $PROJECT_DIR
-  echo "dummy 0.1.0" >$PROJECT_DIR/.tool-versions
-  mkdir -p $ASDF_DIR/installs/dummy/0.1.0/bin
-  touch $ASDF_DIR/installs/dummy/0.1.0/bin/test-dash
-  chmod +x $ASDF_DIR/installs/dummy/0.1.0/bin/test-dash
+  cd "$PROJECT_DIR"
+  echo "dummy 0.1.0" >"$PROJECT_DIR/.tool-versions"
+  mkdir -p "$ASDF_DIR/installs/dummy/0.1.0/bin"
+  touch "$ASDF_DIR/installs/dummy/0.1.0/bin/test-dash"
+  chmod +x "$ASDF_DIR/installs/dummy/0.1.0/bin/test-dash"
   run asdf reshim dummy 0.1.0
 
   message="callback invoked"

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -56,7 +56,7 @@ teardown() {
 @test "get_download_path should output nothing when path version is provided" {
   run get_download_path foo path "/some/path"
   [ "$status" -eq 0 ]
-  [ "$output" = "" ]
+  [ -z "$output" ]
 }
 
 @test "check_if_version_exists should exit with 1 if plugin does not exist" {
@@ -79,14 +79,14 @@ teardown() {
 @test "check_if_version_exists should be noop if version exists" {
   run check_if_version_exists "dummy" "0.1.0"
   [ "$status" -eq 0 ]
-  [ "$output" = "" ]
+  [ -z "$output" ]
 }
 
 @test "check_if_version_exists should be noop if version is system" {
   mkdir -p $ASDF_DIR/plugins/foo
   run check_if_version_exists "foo" "system"
   [ "$status" -eq 0 ]
-  [ "$output" = "" ]
+  [ -z "$output" ]
 }
 
 @test "check_if_version_exists should be ok for ref:version install" {
@@ -94,7 +94,7 @@ teardown() {
   mkdir -p $ASDF_DIR/installs/foo/ref-master
   run check_if_version_exists "foo" "ref:master"
   [ "$status" -eq 0 ]
-  [ "$output" = "" ]
+  [ -z "$output" ]
 }
 
 @test "check_if_plugin_exists should exit with 1 when plugin is empty string" {
@@ -106,7 +106,7 @@ teardown() {
 @test "check_if_plugin_exists should be noop if plugin exists" {
   run check_if_plugin_exists "dummy"
   [ "$status" -eq 0 ]
-  [ "$output" = "" ]
+  [ -z "$output" ]
 }
 
 @test "parse_asdf_version_file should output version" {
@@ -208,7 +208,7 @@ teardown() {
 
   run check_if_plugin_exists "dummy2"
   [ "$status" -eq 0 ]
-  [ "$output" = "" ]
+  [ -z "$output" ]
 }
 
 @test "find_versions should return \$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME if set" {
@@ -346,7 +346,7 @@ teardown() {
   run get_version_from_env 'dummy'
 
   [ "$status" -eq 0 ]
-  [ "$output" = '' ]
+  [ -z "$output" ]
 }
 
 @test "resolve_symlink converts the symlink path to the real file path" {
@@ -392,7 +392,7 @@ EOF
   echo -n "# comment line" >test_file
   run strip_tool_version_comments test_file
   [ "$status" -eq 0 ]
-  [ "$output" = "" ]
+  [ -z "$output" ]
 }
 
 @test "strip_tool_version_comments removes trailing comments on lines containing version information" {

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -351,11 +351,11 @@ teardown() {
 
 @test "resolve_symlink converts the symlink path to the real file path" {
   touch foo
-  ln -s $(pwd)/foo bar
+  ln -s $PWD/foo bar
 
   run resolve_symlink bar
   [ "$status" -eq 0 ]
-  [ "$output" = $(pwd)/foo ]
+  [ "$output" = $PWD/foo ]
   rm -f foo bar
 }
 
@@ -365,7 +365,7 @@ teardown() {
 
   run resolve_symlink baz/bar
   [ "$status" -eq 0 ]
-  [ "$output" = $(pwd)/baz/../foo ]
+  [ "$output" = $PWD/baz/../foo ]
   rm -f foo bar
 }
 
@@ -375,7 +375,7 @@ teardown() {
 
   run resolve_symlink bar
   [ "$status" -eq 0 ]
-  [ "$output" = $(pwd)/foo ]
+  [ "$output" = $PWD/foo ]
   rm -f foo bar
 }
 

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -113,7 +113,7 @@ teardown() {
   echo "dummy 0.1.0" >"$PROJECT_DIR/.tool-versions"
   run parse_asdf_version_file "$PROJECT_DIR/.tool-versions" dummy
   [ "$status" -eq 0 ]
-  [ "$output" == "0.1.0" ]
+  [ "$output" = "0.1.0" ]
 }
 
 @test "parse_asdf_version_file should output path on project with spaces" {
@@ -123,14 +123,14 @@ teardown() {
   echo "dummy 0.1.0" >"$PROJECT_DIR/.tool-versions"
   run parse_asdf_version_file "$PROJECT_DIR/.tool-versions" dummy
   [ "$status" -eq 0 ]
-  [ "$output" == "0.1.0" ]
+  [ "$output" = "0.1.0" ]
 }
 
 @test "parse_asdf_version_file should output path version with spaces" {
   echo "dummy path:/some/dummy path" >"$PROJECT_DIR/.tool-versions"
   run parse_asdf_version_file "$PROJECT_DIR/.tool-versions" dummy
   [ "$status" -eq 0 ]
-  [ "$output" == "path:/some/dummy path" ]
+  [ "$output" = "path:/some/dummy path" ]
 }
 
 @test "find_versions should return .tool-versions if legacy is disabled" {

--- a/test/version_commands.bats
+++ b/test/version_commands.bats
@@ -286,7 +286,7 @@ teardown() {
   run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
   [ "$(cat $ASDF_DEFAULT_TOOL_VERSIONS_FILENAME)" = "dummy 1.1.0" ]
-  [ "$(cat .tool-versions)" = "" ]
+  [ -z "$(cat .tool-versions)" ]
   unset ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
 }
 
@@ -296,7 +296,7 @@ teardown() {
   run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
   [ "$(cat $ASDF_DEFAULT_TOOL_VERSIONS_FILENAME)" = "dummy 1.1.0" ]
-  [ "$(cat .tool-versions)" = "" ]
+  [ -z "$(cat .tool-versions)" ]
   unset ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
 }
 
@@ -305,7 +305,7 @@ teardown() {
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
   [ "$(cat $HOME/$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME)" = "dummy 1.1.0" ]
-  [ "$(cat $HOME/.tool-versions)" = "" ]
+  [ -z "$(cat $HOME/.tool-versions)" ]
   unset ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
 }
 
@@ -315,7 +315,7 @@ teardown() {
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
   [ "$(cat $HOME/$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME)" = "dummy 1.1.0" ]
-  [ "$(cat $HOME/.tool-versions)" = "" ]
+  [ -z "$(cat $HOME/.tool-versions)" ]
   unset ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
 }
 

--- a/test/version_commands.bats
+++ b/test/version_commands.bats
@@ -16,15 +16,15 @@ setup() {
   install_dummy_legacy_version "5.1.0"
 
   PROJECT_DIR=$HOME/project
-  mkdir -p $PROJECT_DIR
+  mkdir -p "$PROJECT_DIR"
 
   CHILD_DIR=$PROJECT_DIR/child-dir
   mkdir -p $CHILD_DIR
 
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
 
   # asdf lib needed to run asdf.sh
-  cp -rf $BATS_TEST_DIRNAME/../{bin,lib} $ASDF_DIR/
+  cp -rf $BATS_TEST_DIRNAME/../{bin,lib} "$ASDF_DIR/"
 }
 
 teardown() {
@@ -53,19 +53,19 @@ teardown() {
 @test "local should create a local .tool-versions file if it doesn't exist" {
   run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.1.0" ]
 }
 
 @test "[local - dummy_plugin] with latest should use the latest installed version" {
   run asdf local "dummy" "latest"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 2.0.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 2.0.0" ]
 }
 
 @test "[local - dummy_plugin] with latest:version should use the latest valid installed version" {
   run asdf local "dummy" "latest:1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.0.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.0.0" ]
 }
 
 @test "[local - dummy_plugin] with latest:version should return an error for invalid versions" {
@@ -77,13 +77,13 @@ teardown() {
 @test "[local - dummy_legacy_plugin] with latest should use the latest installed version" {
   run asdf local "legacy-dummy" "latest"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "legacy-dummy 5.1.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "legacy-dummy 5.1.0" ]
 }
 
 @test "[local - dummy_legacy_plugin] with latest:version should use the latest valid installed version" {
   run asdf local "legacy-dummy" "latest:1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "legacy-dummy 1.0.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "legacy-dummy 1.0.0" ]
 }
 
 @test "[local - dummy_legacy_plugin] with latest:version should return an error for invalid versions" {
@@ -95,7 +95,7 @@ teardown() {
 @test "local should allow multiple versions" {
   run asdf local "dummy" "1.1.0" "1.0.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0 1.0.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.1.0 1.0.0" ]
 }
 
 @test "local should create a local .tool-versions file if it doesn't exist when the directory name contains whitespace" {
@@ -111,35 +111,35 @@ teardown() {
 }
 
 @test "local should not create a duplicate .tool-versions file if such file exists" {
-  echo 'dummy 1.0.0' >>$PROJECT_DIR/.tool-versions
+  echo 'dummy 1.0.0' >>"$PROJECT_DIR/.tool-versions"
 
   run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(ls $PROJECT_DIR/.tool-versions* | wc -l)" -eq 1 ]
+  [ "$(ls "$PROJECT_DIR/.tool-versions"* | wc -l)" -eq 1 ]
 }
 
 @test "local should overwrite the existing version if it's set" {
-  echo 'dummy 1.0.0' >>$PROJECT_DIR/.tool-versions
+  echo 'dummy 1.0.0' >>"$PROJECT_DIR/.tool-versions"
 
   run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.1.0" ]
 }
 
 @test "local should append trailing newline before appending new version when missing" {
-  echo -n 'foobar 1.0.0' >>$PROJECT_DIR/.tool-versions
+  echo -n 'foobar 1.0.0' >>"$PROJECT_DIR/.tool-versions"
 
   run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = $'foobar 1.0.0\ndummy 1.1.0' ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = $'foobar 1.0.0\ndummy 1.1.0' ]
 }
 
 @test "local should not append trailing newline before appending new version when one present" {
-  echo 'foobar 1.0.0' >>$PROJECT_DIR/.tool-versions
+  echo 'foobar 1.0.0' >>"$PROJECT_DIR/.tool-versions"
 
   run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = $'foobar 1.0.0\ndummy 1.1.0' ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = $'foobar 1.0.0\ndummy 1.1.0' ]
 }
 
 @test "local should fail to set a path:dir if dir does not exists " {
@@ -149,10 +149,10 @@ teardown() {
 }
 
 @test "local should set a path:dir if dir exists " {
-  mkdir -p $PROJECT_DIR/local
+  mkdir -p "$PROJECT_DIR/local"
   run asdf local "dummy" "path:$PROJECT_DIR/local"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy path:$PROJECT_DIR/local" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy path:$PROJECT_DIR/local" ]
 }
 
 @test "local -p/--parent should set should emit an error when called with incorrect arity" {
@@ -174,45 +174,45 @@ teardown() {
 }
 
 @test "local -p/--parent should allow multiple versions" {
-  cd $CHILD_DIR
-  touch $PROJECT_DIR/.tool-versions
+  cd "$CHILD_DIR"
+  touch "$PROJECT_DIR/.tool-versions"
   run asdf local -p "dummy" "1.1.0" "1.0.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0 1.0.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.1.0 1.0.0" ]
 }
 
 @test "local -p/--parent should overwrite the existing version if it's set" {
-  cd $CHILD_DIR
-  echo 'dummy 1.0.0' >>$PROJECT_DIR/.tool-versions
+  cd "$CHILD_DIR"
+  echo 'dummy 1.0.0' >>"$PROJECT_DIR/.tool-versions"
   run asdf local -p "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.1.0" ]
 }
 
 @test "local -p/--parent should set the version if it's unset" {
-  cd $CHILD_DIR
-  touch $PROJECT_DIR/.tool-versions
+  cd "$CHILD_DIR"
+  touch "$PROJECT_DIR/.tool-versions"
   run asdf local -p "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.1.0" ]
 }
 
 @test "global should create a global .tool-versions file if it doesn't exist" {
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "dummy 1.1.0" ]
+  [ "$(cat "$HOME/.tool-versions")" = "dummy 1.1.0" ]
 }
 
 @test "[global - dummy_plugin] with latest should use the latest installed version" {
   run asdf global "dummy" "latest"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "dummy 2.0.0" ]
+  [ "$(cat "$HOME/.tool-versions")" = "dummy 2.0.0" ]
 }
 
 @test "[global - dummy_plugin] with latest:version should use the latest valid installed version" {
   run asdf global "dummy" "latest:1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "dummy 1.0.0" ]
+  [ "$(cat "$HOME/.tool-versions")" = "dummy 1.0.0" ]
 }
 
 @test "[global - dummy_plugin] with latest:version should return an error for invalid versions" {
@@ -224,13 +224,13 @@ teardown() {
 @test "[global - dummy_legacy_plugin] with latest should use the latest installed version" {
   run asdf global "legacy-dummy" "latest"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "legacy-dummy 5.1.0" ]
+  [ "$(cat "$HOME/.tool-versions")" = "legacy-dummy 5.1.0" ]
 }
 
 @test "[global - dummy_legacy_plugin] with latest:version should use the latest valid installed version" {
   run asdf global "legacy-dummy" "latest:1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "legacy-dummy 1.0.0" ]
+  [ "$(cat "$HOME/.tool-versions")" = "legacy-dummy 1.0.0" ]
 }
 
 @test "[global - dummy_legacy_plugin] with latest:version should return an error for invalid versions" {
@@ -242,30 +242,30 @@ teardown() {
 @test "global should accept multiple versions" {
   run asdf global "dummy" "1.1.0" "1.0.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "dummy 1.1.0 1.0.0" ]
+  [ "$(cat "$HOME/.tool-versions")" = "dummy 1.1.0 1.0.0" ]
 }
 
 @test "global should overwrite the existing version if it's set" {
-  echo 'dummy 1.0.0' >>$HOME/.tool-versions
+  echo 'dummy 1.0.0' >>"$HOME/.tool-versions"
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "dummy 1.1.0" ]
+  [ "$(cat "$HOME/.tool-versions")" = "dummy 1.1.0" ]
 }
 
 @test "global should append trailing newline before appending new version when missing" {
-  echo -n 'foobar 1.0.0' >>$HOME/.tool-versions
+  echo -n 'foobar 1.0.0' >>"$HOME/.tool-versions"
 
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = $'foobar 1.0.0\ndummy 1.1.0' ]
+  [ "$(cat "$HOME/.tool-versions")" = $'foobar 1.0.0\ndummy 1.1.0' ]
 }
 
 @test "global should not append trailing newline before appending new version when one present" {
-  echo 'foobar 1.0.0' >>$HOME/.tool-versions
+  echo 'foobar 1.0.0' >>"$HOME/.tool-versions"
 
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = $'foobar 1.0.0\ndummy 1.1.0' ]
+  [ "$(cat "$HOME/.tool-versions")" = $'foobar 1.0.0\ndummy 1.1.0' ]
 }
 
 @test "global should fail to set a path:dir if dir does not exists " {
@@ -275,17 +275,17 @@ teardown() {
 }
 
 @test "global should set a path:dir if dir exists " {
-  mkdir -p $PROJECT_DIR/local
+  mkdir -p "$PROJECT_DIR/local"
   run asdf global "dummy" "path:$PROJECT_DIR/local"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "dummy path:$PROJECT_DIR/local" ]
+  [ "$(cat "$HOME/.tool-versions")" = "dummy path:$PROJECT_DIR/local" ]
 }
 
 @test "local should write to ASDF_DEFAULT_TOOL_VERSIONS_FILENAME" {
   export ASDF_DEFAULT_TOOL_VERSIONS_FILENAME="local-tool-versions"
   run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $ASDF_DEFAULT_TOOL_VERSIONS_FILENAME)" = "dummy 1.1.0" ]
+  [ "$(cat "$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME")" = "dummy 1.1.0" ]
   [ -z "$(cat .tool-versions)" ]
   unset ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
 }
@@ -295,7 +295,7 @@ teardown() {
   echo 'dummy 1.0.0' >>"$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME"
   run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $ASDF_DEFAULT_TOOL_VERSIONS_FILENAME)" = "dummy 1.1.0" ]
+  [ "$(cat "$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME")" = "dummy 1.1.0" ]
   [ -z "$(cat .tool-versions)" ]
   unset ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
 }
@@ -304,8 +304,8 @@ teardown() {
   export ASDF_DEFAULT_TOOL_VERSIONS_FILENAME="global-tool-versions"
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME)" = "dummy 1.1.0" ]
-  [ -z "$(cat $HOME/.tool-versions)" ]
+  [ "$(cat "$HOME/$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME")" = "dummy 1.1.0" ]
+  [ -z "$(cat "$HOME/.tool-versions")" ]
   unset ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
 }
 
@@ -314,8 +314,8 @@ teardown() {
   echo 'dummy 1.0.0' >>"$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME"
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME)" = "dummy 1.1.0" ]
-  [ -z "$(cat $HOME/.tool-versions)" ]
+  [ "$(cat "$HOME/$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME")" = "dummy 1.1.0" ]
+  [ -z "$(cat "$HOME/.tool-versions")" ]
   unset ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
 }
 
@@ -343,39 +343,39 @@ teardown() {
 @test "global should preserve symlinks when setting versions" {
   mkdir $HOME/other-dir
   touch $HOME/other-dir/.tool-versions
-  ln -s other-dir/.tool-versions $HOME/.tool-versions
+  ln -s other-dir/.tool-versions "$HOME/.tool-versions"
 
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ -L $HOME/.tool-versions ]
+  [ -L "$HOME/.tool-versions" ]
   [ "$(cat $HOME/other-dir/.tool-versions)" = "dummy 1.1.0" ]
 }
 
 @test "global should preserve symlinks when updating versions" {
   mkdir $HOME/other-dir
   touch $HOME/other-dir/.tool-versions
-  ln -s other-dir/.tool-versions $HOME/.tool-versions
+  ln -s other-dir/.tool-versions "$HOME/.tool-versions"
 
   run asdf global "dummy" "1.1.0"
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ -L $HOME/.tool-versions ]
+  [ -L "$HOME/.tool-versions" ]
   [ "$(cat $HOME/other-dir/.tool-versions)" = "dummy 1.1.0" ]
 }
 
 @test "shell wrapper function should export ENV var" {
   . $(dirname "$BATS_TEST_DIRNAME")/asdf.sh
   asdf shell "dummy" "1.1.0"
-  [ $(echo $ASDF_DUMMY_VERSION) = "1.1.0" ]
+  [ $(echo "$ASDF_DUMMY_VERSION") = "1.1.0" ]
   unset ASDF_DUMMY_VERSION
 }
 
 @test "shell wrapper function with --unset should unset ENV var" {
   . $(dirname "$BATS_TEST_DIRNAME")/asdf.sh
   asdf shell "dummy" "1.1.0"
-  [ $(echo $ASDF_DUMMY_VERSION) = "1.1.0" ]
+  [ $(echo "$ASDF_DUMMY_VERSION") = "1.1.0" ]
   asdf shell "dummy" --unset
-  [ -z "$(echo $ASDF_DUMMY_VERSION)" ]
+  [ -z "$(echo "$ASDF_DUMMY_VERSION")" ]
   unset ASDF_DUMMY_VERSION
 }
 
@@ -453,7 +453,7 @@ false"
 @test "[shell - dummy_plugin] wrapper function should support latest" {
   . $(dirname "$BATS_TEST_DIRNAME")/asdf.sh
   asdf shell "dummy" "latest"
-  [ $(echo $ASDF_DUMMY_VERSION) = "2.0.0" ]
+  [ $(echo "$ASDF_DUMMY_VERSION") = "2.0.0" ]
   unset ASDF_DUMMY_VERSION
 }
 
@@ -465,29 +465,29 @@ false"
 }
 
 @test "[global - dummy_plugin] should support latest" {
-  echo 'dummy 1.0.0' >>$HOME/.tool-versions
+  echo 'dummy 1.0.0' >>"$HOME/.tool-versions"
   run asdf global "dummy" "1.0.0" "latest"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "dummy 1.0.0 2.0.0" ]
+  [ "$(cat "$HOME/.tool-versions")" = "dummy 1.0.0 2.0.0" ]
 }
 
 @test "[global - dummy_legacy_plugin] should support latest" {
-  echo 'legacy-dummy 1.0.0' >>$HOME/.tool-versions
+  echo 'legacy-dummy 1.0.0' >>"$HOME/.tool-versions"
   run asdf global "legacy-dummy" "1.0.0" "latest"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "legacy-dummy 1.0.0 5.1.0" ]
+  [ "$(cat "$HOME/.tool-versions")" = "legacy-dummy 1.0.0 5.1.0" ]
 }
 
 @test "[local - dummy_plugin] should support latest" {
-  echo 'dummy 1.0.0' >>$PROJECT_DIR/.tool-versions
+  echo 'dummy 1.0.0' >>"$PROJECT_DIR/.tool-versions"
   run asdf local "dummy" "1.0.0" "latest"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.0.0 2.0.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.0.0 2.0.0" ]
 }
 
 @test "[local - dummy_legacy_plugin] should support latest" {
-  echo 'legacy-dummy 1.0.0' >>$PROJECT_DIR/.tool-versions
+  echo 'legacy-dummy 1.0.0' >>"$PROJECT_DIR/.tool-versions"
   run asdf local "legacy-dummy" "1.0.0" "latest"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "legacy-dummy 1.0.0 5.1.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "legacy-dummy 1.0.0 5.1.0" ]
 }

--- a/test/where_command.bats
+++ b/test/where_command.bats
@@ -27,7 +27,7 @@ function teardown() {
 }
 
 @test "where shows install location of current version if no version specified" {
-  echo 'dummy 2.1' >>$HOME/.tool-versions
+  echo 'dummy 2.1' >>"$HOME/.tool-versions"
 
   run asdf where 'dummy'
 
@@ -36,7 +36,7 @@ function teardown() {
 }
 
 @test "where shows install location of first current version if not version specified and multiple current versions" {
-  echo 'dummy 2.1 1.0' >>$HOME/.tool-versions
+  echo 'dummy 2.1 1.0' >>"$HOME/.tool-versions"
   run asdf where 'dummy'
   [ "$status" -eq 0 ]
   [ "$output" = "$ASDF_DIR/installs/dummy/2.1" ]

--- a/test/which_command.bats
+++ b/test/which_command.bats
@@ -9,8 +9,8 @@ setup() {
   run asdf install dummy 1.1
 
   PROJECT_DIR=$HOME/project
-  mkdir $PROJECT_DIR
-  echo 'dummy 1.0' >>$PROJECT_DIR/.tool-versions
+  mkdir -p "$PROJECT_DIR"
+  echo 'dummy 1.0' >>"$PROJECT_DIR/.tool-versions"
 }
 
 teardown() {
@@ -18,7 +18,7 @@ teardown() {
 }
 
 @test "which should show dummy 1.0 main binary" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
 
   run asdf which "dummy"
   [ "$status" -eq 0 ]
@@ -26,7 +26,7 @@ teardown() {
 }
 
 @test "which should fail for unknown binary" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
 
   run asdf which "sunny"
   [ "$status" -eq 1 ]
@@ -34,7 +34,7 @@ teardown() {
 }
 
 @test "which should show dummy 1.0 other binary" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
 
   echo "echo bin bin/subdir" >"$ASDF_DIR/plugins/dummy/bin/list-bin-paths"
   chmod +x "$ASDF_DIR/plugins/dummy/bin/list-bin-paths"
@@ -46,21 +46,21 @@ teardown() {
 }
 
 @test "which should show path of system version" {
-  echo 'dummy system' >$PROJECT_DIR/.tool-versions
-  cd $PROJECT_DIR
+  echo 'dummy system' >"$PROJECT_DIR/.tool-versions"
+  cd "$PROJECT_DIR"
 
-  mkdir $PROJECT_DIR/sys
-  touch $PROJECT_DIR/sys/dummy
-  chmod +x $PROJECT_DIR/sys/dummy
+  mkdir "$PROJECT_DIR/sys"
+  touch "$PROJECT_DIR/sys/dummy"
+  chmod +x "$PROJECT_DIR/sys/dummy"
 
-  run env PATH=$PATH:$PROJECT_DIR/sys asdf which "dummy"
+  run env "PATH=$PATH:$PROJECT_DIR/sys" asdf which "dummy"
   [ "$status" -eq 0 ]
   [ "$output" == "$PROJECT_DIR/sys/dummy" ]
 }
 
 @test "which report when missing executable on system version" {
-  echo 'dummy system' >$PROJECT_DIR/.tool-versions
-  cd $PROJECT_DIR
+  echo 'dummy system' >"$PROJECT_DIR/.tool-versions"
+  cd "$PROJECT_DIR"
 
   run asdf which "dummy"
   [ "$status" -eq 1 ]
@@ -68,7 +68,7 @@ teardown() {
 }
 
 @test "which should inform when no binary is found" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
 
   run asdf which "bazbat"
   [ "$status" -eq 1 ]
@@ -76,7 +76,7 @@ teardown() {
 }
 
 @test "which should use path returned by exec-path when present" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
   install_dummy_exec_path_script "dummy"
 
   run asdf which "dummy"
@@ -85,12 +85,12 @@ teardown() {
 }
 
 @test "which should return the path set by the legacy file" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
 
-  echo 'dummy 1.0' >>$HOME/.tool-versions
-  echo '1.1' >>$PROJECT_DIR/.dummy-version
-  rm $PROJECT_DIR/.tool-versions
-  echo 'legacy_version_file = yes' >$HOME/.asdfrc
+  echo 'dummy 1.0' >>"$HOME/.tool-versions"
+  echo '1.1' >>"$PROJECT_DIR/.dummy-version"
+  rm "$PROJECT_DIR/.tool-versions"
+  echo 'legacy_version_file = yes' >"$HOME/.asdfrc"
 
   run asdf which "dummy"
   [ "$status" -eq 0 ]
@@ -98,11 +98,11 @@ teardown() {
 }
 
 @test "which should not return shim path" {
-  cd $PROJECT_DIR
-  echo 'dummy 1.0' >$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  echo 'dummy 1.0' >"$PROJECT_DIR/.tool-versions"
   rm "$ASDF_DIR/installs/dummy/1.0/bin/dummy"
 
-  run env PATH=$PATH:$ASDF_DIR/shims asdf which dummy
+  run env PATH=$PATH:"$ASDF_DIR/shims" asdf which dummy
   [ "$status" -eq 1 ]
   [ "$output" == "No dummy executable found for dummy 1.0" ]
 }

--- a/test/which_command.bats
+++ b/test/which_command.bats
@@ -30,7 +30,7 @@ teardown() {
 
   run asdf which "sunny"
   [ "$status" -eq 1 ]
-  [ "$output" == "unknown command: sunny. Perhaps you have to reshim?" ]
+  [ "$output" = "unknown command: sunny. Perhaps you have to reshim?" ]
 }
 
 @test "which should show dummy 1.0 other binary" {
@@ -55,7 +55,7 @@ teardown() {
 
   run env "PATH=$PATH:$PROJECT_DIR/sys" asdf which "dummy"
   [ "$status" -eq 0 ]
-  [ "$output" == "$PROJECT_DIR/sys/dummy" ]
+  [ "$output" = "$PROJECT_DIR/sys/dummy" ]
 }
 
 @test "which report when missing executable on system version" {
@@ -64,7 +64,7 @@ teardown() {
 
   run asdf which "dummy"
   [ "$status" -eq 1 ]
-  [ "$output" == "No dummy executable found for dummy system" ]
+  [ "$output" = "No dummy executable found for dummy system" ]
 }
 
 @test "which should inform when no binary is found" {
@@ -72,7 +72,7 @@ teardown() {
 
   run asdf which "bazbat"
   [ "$status" -eq 1 ]
-  [ "$output" == "unknown command: bazbat. Perhaps you have to reshim?" ]
+  [ "$output" = "unknown command: bazbat. Perhaps you have to reshim?" ]
 }
 
 @test "which should use path returned by exec-path when present" {
@@ -104,5 +104,5 @@ teardown() {
 
   run env PATH=$PATH:"$ASDF_DIR/shims" asdf which dummy
   [ "$status" -eq 1 ]
-  [ "$output" == "No dummy executable found for dummy 1.0" ]
+  [ "$output" = "No dummy executable found for dummy 1.0" ]
 }


### PR DESCRIPTION
This fixes various subtle Bash issues / inconsistencies. Generally, these improve semantics and make things a bit clearer - extra details in the commit messages where applicable.

As a side note, how does replacing `basename` and `dirname` sound (in a separate PR)? Doing that will improve performance greatly (along with the $(pwd) i already did!) - asking because it's a bit more involved since the builtin facilities (like `${var%/*}`) don't automatically handle extra trailing slashes and whatnot, so I wanted to ask to be sure

Also, does the project specify a minimum Bash version - couldn't find any info on the website or source code? I saw some opportunities to cut out of some `cat` invocations, etc., but I held back for that reason. For my personal Bash projects, the minimum is `v4.3`, but I assume this projects supports the latest of the `v3` series due to compatibility with macOS?

Edit by @jthegedus:

Fixes #1313 