### PR TITLE
feat: Full compliance with XDG Base Directory Specification

### DIFF
--- a/bin/asdf
+++ b/bin/asdf
@@ -80,6 +80,17 @@ asdf_cmd() {
   ASDF_DIR=$(asdf_dir)
   export ASDF_DIR
 
+  if [ "$1" = '--internal-get-asdf-config-file' ]; then
+    printf '%s\n' "$ASDF_CONFIG_FILE"
+    exit 0
+  elif [ "$1" = '--internal-get-asdf-data-dir' ]; then
+    printf '%s\n' "$ASDF_DATA_DIR"
+    exit 0
+  elif [ "$1" = '--internal-get-asdf-dir' ]; then
+    printf '%s\n' "$ASDF_DIR"
+    exit 0
+  fi
+
   local result=
   result="$(find_asdf_cmd "$@")"
   ASDF_CMD_FILE=${result% *}

--- a/completions/_asdf
+++ b/completions/_asdf
@@ -2,7 +2,8 @@
 #description tool to manage versions of multiple runtimes
 
 local curcontext="$curcontext" state state_descr line subcmd
-local asdf_dir="${ASDF_DATA_DIR:-$HOME/.asdf}"
+local asdf_dir=
+asdf_dir=$(asdf --internal-get-asdf-dir)
 
 local -a asdf_commands
 asdf_commands=( # 'asdf help' lists commands with help text

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -21,21 +21,31 @@ asdf_tool_versions_filename() {
 }
 
 asdf_config_file() {
-  printf '%s\n' "${ASDF_CONFIG_FILE:-$HOME/.asdfrc}"
+  if [ -n "$ASDF_CONFIG_FILE" ]; then
+    printf '%s\n' "$ASDF_CONFIG_FILE"
+  elif [ -f "$HOME/.asdfrc" ]; then
+    printf '%s\n' "$HOME/.asdfrc"
+  elif [ "${XDG_CONFIG_HOME::1}" = '/' ]; then
+    printf '%s\n' "$XDG_CONFIG_HOME/asdf/asdfrc"
+  else
+    printf '%s\n' "$HOME/.config/asdf/asdfrc"
+  fi
 }
 
 asdf_data_dir() {
-  local data_dir
-
   if [ -n "${ASDF_DATA_DIR}" ]; then
-    data_dir="${ASDF_DATA_DIR}"
+    printf '%s\n' "${ASDF_DATA_DIR}"
   elif [ -n "$HOME" ]; then
-    data_dir="$HOME/.asdf"
+    if [ -d "$HOME/.asdf" ]; then
+      printf '%s\n' "$HOME/.asdf"
+    elif [ "${XDG_DATA_HOME::1}" = '/' ]; then
+      printf '%s\n' "$XDG_DATA_HOME/asdf"
+    else
+      printf '%s\n' "$HOME/.local/state/asdf"
+    fi
   else
     data_dir=$(asdf_dir)
   fi
-
-  printf "%s\n" "$data_dir"
 }
 
 asdf_dir() {


### PR DESCRIPTION
# Summary

### This changes things so that:

- [ ] `ASDF_CONFIG_FILE`
	- [x] If env var is empty, and old default location does not exist, new default is `$XDG_CONFIG_HOME/asdf/asdfrc`
	- [ ] Docs
	- [ ] Source/completion scripts
	- [ ] Tests
- ~~`ASDF_DEFAULT_TOOL_VERSIONS_FILENAME`~~ (N/A, no change needed)
- [ ] `ASDF_DEFAULT_GLOBAL_TOOL_VERSIONS_FILEPATH`
  - [ ] Impl
  - [ ] Docs
  - [ ] Tests
- [x] `ASDF_DIR`
	- [x] No change needed (is calculated dynamically)
- [ ] `ASDF_DATA_DIR`
  - [x] If env var is empty, and old location does not exist, new default is `"$XDG_STATE_HOME/asdf"`
  - [ ] Docs
  - [ ] Source/completion scripts
  - [ ] Tests
 
Each environment variable is exported so that they new values are automatically used by plugins. If plugins use the environment variables, everything should Just Work

### What still needs to be done:

- `~/.config/asdf/.tool-versions`
- Documentation changes
- Installation instructions / script to update to use `XDG_DATA_HOME` (for the git repository) (for `ASDF_DIR`)
- Completion scripts to use the new location
  - [completions/_asdf](https://github.com/hyperupcall/asdf/blob/c85f5c22785cf072485765921b152fea1f870ecc/completions/_asdf#L6) shows an example of how it should be done for Fish, Bash, etc. completions
- `asdf.sh` use the new location

Fixes #687
Fixes https://github.com/asdf-vm/asdf-ruby/issues/203
Fixes #1553 (TODO)
Fixes #1556 (TODO)
Fixes #1617
Fixes #846
Fixes #1309
TODO: Look at #1122
