### PR TITLE
fix: Ban use of 'test'

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -141,7 +141,7 @@ version_not_installed_text() {
 }
 
 get_plugin_path() {
-  if test -n "$1"; then
+  if [ -n "$1" ]; then
     printf "%s\\n" "$(asdf_data_dir)/plugins/$1"
   else
     printf "%s\\n" "$(asdf_data_dir)/plugins"

--- a/test/banned_commands.bats
+++ b/test/banned_commands.bats
@@ -21,6 +21,8 @@ banned_commands=(
   # source isn't POSIX compliant. . behaves the same and is POSIX compliant
   # Except in fish, where . is deprecated, and will be removed in the future.
   source
+  # For consistency, [ should be used instead. There is a leading space so 'fail_test', etc. is not matched
+  ' test'
 )
 
 banned_commands_regex=(


### PR DESCRIPTION
# Summary

This bans the use of `test`. `test` is functionally an alias of `[`; this improves codebase consistency and parseability.

Partially addresses #1313, and is related to #1349 

