### PR TITLE
docs: improve promotion of git install method

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -35,11 +35,17 @@
 
 ## 2. Download asdf
 
-We recommend using Git, though there are other platform specific methods:
+We recommend using Git:
+```sh
+git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.11.0
+```
+See latest release version here: https://github.com/asdf-vm/asdf/releases
+
+
+Platform specific alternatives:
 
 | Method   | Command                                                                                                                                                             |
 | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Git      | `git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.10.2`                                                                                             |
 | Homebrew | `brew install asdf`                                                                                                                                                 |
 | Pacman   | `git clone https://aur.archlinux.org/asdf-vm.git && cd asdf-vm && makepkg -si` or use your preferred [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers) |
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -11,7 +11,16 @@
 
 ## 1. Install Dependencies
 
-**Linux**:
+asdf primarily requires `git` & `curl`. Here is a _non-exhaustive_ list of commands to run for _your_ package manager (some might automatically install these tools in later steps).
+
+| OS    | Package Manager | Command                            |
+| ----- | --------------- | ---------------------------------- |
+| linux | Aptitude        | `apt install curl git`             |
+| linux | DNF             | `dnf install curl git`             |
+| linux | Pacman          | `pacman -S curl git`               |
+| linux | Zypper          | `zypper install curl git`          |
+| macOS | Homebrew        | `brew install coreutils curl git`  |
+| macOS | Spack           | `spack install coreutils curl git` |
 
 ::: tip Note
 
@@ -19,35 +28,23 @@
 
 :::
 
-| Package Manager | Command                   |
-| --------------- | ------------------------- |
-| Aptitude        | `apt install curl git`    |
-| DNF             | `dnf install curl git`    |
-| Pacman          | `pacman -S curl git`      |
-| Zypper          | `zypper install curl git` |
-
-**macOS**:
-
-| Package Manager | Command                                                   |
-| --------------- | --------------------------------------------------------- |
-| Homebrew        | Dependencies will be automatically installed by Homebrew. |
-| Spack           | `spack install coreutils curl git`                        |
-
 ## 2. Download asdf
 
-We recommend using Git:
-```sh
-git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.11.0
+### Official Download
+
+```shell:no-line-numbers
+git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.10.2
 ```
-See latest release version here: https://github.com/asdf-vm/asdf/releases
 
+### Community Supported Download Methods
 
-Platform specific alternatives:
+We highly recommend using the official `git` method.
 
 | Method   | Command                                                                                                                                                             |
 | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Homebrew | `brew install asdf`                                                                                                                                                 |
 | Pacman   | `git clone https://aur.archlinux.org/asdf-vm.git && cd asdf-vm && makepkg -si` or use your preferred [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers) |
+
 
 ## 3. Install asdf
 


### PR DESCRIPTION
This can generally avoid complications due to installing under a package manager (homebrew, etc).

Related: https://github.com/asdf-vm/asdf/issues/1387