### PR TITLE
docs: Add documentation for Linux Homebrew Bash installs

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -84,6 +84,22 @@ Completions must be configured manually with the following entry in your `.bash_
 
 :::
 
+::: details Bash & Homebrew
+
+Add `asdf.sh` to your `~/.bashrc` with:
+
+```shell:no-line-numbers
+echo -e "\n. $(brew --prefix asdf)/libexec/asdf.sh" >> ~/.bashrc
+```
+
+Completions will need to be [configured as per Homebrew's instructions](https://docs.brew.sh/Shell-Completion#configuring-completions-in-bash) or with the following:
+
+```shell:no-line-numbers
+echo -e "\n. $(brew --prefix asdf)/etc/bash_completion.d/asdf.bash" >> ~/.bashrc
+```
+
+:::
+
 ::: details Bash & Homebrew (macOS)
 
 If using **macOS Catalina or newer**, the default shell has changed to **ZSH**. Unless changing back to Bash, follow the ZSH instructions.

--- a/docs/manage/core.md
+++ b/docs/manage/core.md
@@ -124,6 +124,31 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 
 :::
 
+::: details Bash & Homebrew
+
+1. In your `~/.bashrc` remove the lines that source `asdf.sh` and the completions:
+
+```shell
+. $(brew --prefix asdf)/libexec/asdf.sh
+. $(brew --prefix asdf)/etc/bash_completion.d/asdf.bash
+```
+
+Completions may have been [configured as per Homebrew's instructions](https://docs.brew.sh/Shell-Completion#configuring-completions-in-bash) so follow their guide to find out what to remove.
+
+2. Uninstall with your package manager:
+
+```shell:no-line-numbers
+brew uninstall asdf --force
+```
+
+3. Run this command to remove all `asdf` config files:
+
+```shell:no-line-numbers
+rm -rf $HOME/.tool-versions $HOME/.asdfrc
+```
+
+:::
+
 ::: details Bash & Homebrew (macOS)
 
 If using **macOS Catalina or newer**, the default shell has changed to **ZSH**. If you can't find any config in your `~/.bash_profile` it may be in a `~/.zshrc` in which case please follow the ZSH instructions.

--- a/docs/pt-br/guide/getting-started.md
+++ b/docs/pt-br/guide/getting-started.md
@@ -79,6 +79,22 @@ O auto completar deve ser configurado manualmente a partir da adição da seguin
 
 :::
 
+::: details Bash & Homebrew
+
+Adicione `asdf.sh` ao `~/.bashrc` através do comando:
+
+```shell:no-line-numbers
+echo -e "\n. $(brew --prefix asdf)/asdf.sh" >> ~/.bashrc
+```
+
+O auto completar deve ser configurado seguindo as [instruções da Homebrew](https://docs.brew.sh/Shell-Completion#configuring-completions-in-bash), ou as seguintes:
+
+```shell:no-line-numbers
+echo -e "\n. $(brew --prefix asdf)/etc/bash_completion.d/asdf.bash" >> ~/.bashrc
+```
+
+:::
+
 ::: details Bash & Homebrew (macOS)
 
 Se você estiver usando o **macOS Catalina ou mais recente**, o shell padrão mudou para o **ZSH**. A não ser que você tenha voltado para o bash, siga as instruções de instalação para o ZSH.

--- a/docs/pt-br/manage/core.md
+++ b/docs/pt-br/manage/core.md
@@ -126,6 +126,31 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 
 :::
 
+::: details Bash & Homebrew
+
+1. Em seu `~/.bashrc` remova as linhas do `asdf.sh` e remova seus complementos:
+
+```shell
+. $(brew --prefix asdf)/libexec/asdf.sh
+. $(brew --prefix asdf)/etc/bash_completion.d/asdf.bash
+```
+
+?> Os complementos precisam [instruções de configuração do Homebrew](https://docs.brew.sh/Shell-Completion#configuring-completions-in-bash) e siga o guia de remoção.
+
+2. Desinstale usando seu gerenciador de pacotes:
+
+```shell
+brew uninstall asdf --force
+```
+
+3. Execute o comando para remover todos os arquivos de configurações do `asdf`:
+
+```shell
+rm -rf $HOME/.tool-versions $HOME/.asdfrc
+```
+
+:::
+
 ::: details Bash & Homebrew (macOS)
 
 Caso esteja usando **macOs Catalina ou mais recente**, por padrão o _shell_ é **ZSH**. Se não achar alguma configuração em seu `~/.bash_profile` talvez esteja em `~/.zshrc` em cada caso siga as intruções do ZSH.

--- a/docs/zh-hans/guide/getting-started.md
+++ b/docs/zh-hans/guide/getting-started.md
@@ -79,6 +79,22 @@
 
 :::
 
+::: details Bash & Homebrew
+
+使用以下命令将 `asdf.sh` 加入到 `~/.bashrc` 文件中：
+
+```shell:no-line-numbers
+echo -e "\n. $(brew --prefix asdf)/libexec/asdf.sh" >> ~/.bashrc
+```
+
+补全功能将需要 [按照 Homebrew 的说明完成配置](https://docs.brew.sh/Shell-Completion#configuring-completions-in-bash) 或者执行以下命令：
+
+```shell:no-line-numbers
+echo -e "\n. $(brew --prefix asdf)/etc/bash_completion.d/asdf.bash" >> ~/.bashrc
+```
+
+:::
+
 ::: details Bash & Homebrew (macOS)
 
 如果你正在使用 **macOS Catalina 或者更新的版本**, 默认的 shell 已经被修改为 **ZSH**。除非修改回 Bash, 否则请遵循 ZSH 的说明。

--- a/docs/zh-hans/manage/core.md
+++ b/docs/zh-hans/manage/core.md
@@ -124,6 +124,31 @@ rm -rf $HOME/.tool-versions $HOME/.asdfrc
 
 :::
 
+::: details Bash & Homebrew
+
+1. 在 `~/.bashrc` 配置文件中移除生效 `asdf.sh` 和补全功能的行：
+
+```shell
+. $(brew --prefix asdf)/libexec/asdf.sh
+. $(brew --prefix asdf)/etc/bash_completion.d/asdf.bash
+```
+
+补全功能可能已经如 [Homebrew 的指南](https://docs.brew.sh/Shell-Completion#configuring-completions-in-bash) 那样配置了，因此请按照他们的指南找出要删除的内容。
+
+2. 用包管理器卸载：
+
+```shell:no-line-numbers
+brew uninstall asdf --force
+```
+
+3. 执行以下命令移除 `asdf` 所有配置文件：
+
+```shell:no-line-numbers
+rm -rf $HOME/.tool-versions $HOME/.asdfrc
+```
+
+:::
+
 ::: details Bash & Homebrew (macOS)
 
 如果你正在使用 **macOS Catalina 以及更新版本**，默认的 shell 已经变成了 **ZSH**。如果你在 `~/.bash_profile` 文件中找不到任何配置，则可能位于 `~/.zshrc` 中。在这种情况下，请按照 ZSH 指南进行操作。


### PR DESCRIPTION
# Summary

When using Homebrew on Linux with Bash, as the linked issue states, instructions should specify to put `asdf` initialization in `.bashrc` instead of `.bash_profile. This implements that recommendation.
 
Fixes: #1347
