### PR TITLE
revert: .asdf/.tool-versions overrides ~/.tool-versions, so remove python.

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,3 @@
 bats 1.7.0
 shellcheck 0.8.0
 shfmt 3.5.1
-python 3.10.9


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

Commit 3492043241e466337c5965a6fe2e089147bc4152 adds `python` to _~/.asdf/.tool-versions_ which is a breaking
change in some contexts.  To reproduce the error, install `asdf` versions of `node` and `python` then use `npm` to install   `markov-pwgen`, whose installer runs a python script.  Here is the output:


```shell
npm i -g markov-pwgen
```
> npm ERR! code 126
> npm ERR! path /home/alm/.asdf/installs/nodejs/18.12.1/lib/node_modules/markov-pwgen
> npm ERR! command failed
> npm ERR! command sh -c test -f dictionary.js || ./scripts/filter-wordlist.py
> npm ERR! No preset version installed for command python3
> npm ERR! Please install a version by running one of the following:
> npm ERR! 
> npm ERR! asdf install python 3.10.9
> npm ERR! 
> npm ERR! or add one of the following versions in your config file at /home/alm/.asdf/.tool-versions
> npm ERR! python 3.11.1
> 
> npm ERR! A complete log of this run can be found in:
> npm ERR!     /home/alm/.npm/_logs/2022-12-28T16_47_59_838Z-debug-0.log



## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->

This pull request simply reverts part of commit 3492043241e466337c5965a6fe2e089147bc4152 - removing `python` from _~/.asdf/.tool-versions_  - until the underlying issue can be addressed (e.g., perhaps _~/.tool-versions_ should override _~/.asdf/.tool-versions_).