### PR TITLE
fix: Do not use type not exported on older Python versions

### DIFF
--- a/scripts/checkstyle.py
+++ b/scripts/checkstyle.py
@@ -32,7 +32,7 @@ class c:
 
 # Before: printf '%s\\n' '^w^'
 # After: printf '%s\n' '^w^'
-def noDoubleBackslashFixer(line: str, rule: Dict[str, str], m: re.Match[str]) -> str:
+def noDoubleBackslashFixer(line: str, rule: Dict[str, str], m) -> str:
     prestr = line[0:m.start('match')]
     midstr = line[m.start('match'):m.end('match')]
     poststr = line[m.end('match'):]


### PR DESCRIPTION
# Summary

This fixes an issue I mentioned in #1406, [here](https://github.com/asdf-vm/asdf/pull/1406#issuecomment-1367642291). Now, the `checkstyle.py` script runs with Python `3.6.15`