### PR TITLE
fix: correct order of checks in conditional for adding a missing newline

### DIFF
--- a/lib/functions/versions.bash
+++ b/lib/functions/versions.bash
@@ -64,8 +64,8 @@ version_command() {
     sed -i.bak -e "s|^$plugin_name .*$|$plugin_name ${resolved_versions[*]}|" "$file"
     rm -f "$file".bak
   else
-    # Add a trailing newline at the end of the file if missing
-    [[ -n "$(tail -c1 "$file")" && -f "$file" ]] && printf '\n' >>"$file"
+    # Add a trailing newline at the end of the file if missing and file present
+    [[ -f "$file" && -n "$(tail -c1 "$file")" ]] && printf '\n' >>"$file"
 
     # Add a new version line to the end of the file
     printf "%s %s\n" "$plugin_name" "${resolved_versions[*]}" >>"$file"


### PR DESCRIPTION
We need to add trailing newlines to .tool-versions file before appending a new version to the file. The order of the checks was wrong here as the first check assumed the file existed, and the second checked if it did. Switching them fixes the issue.

This fix was provided by @h3y6e

Fixes #1417
