### PR TITLE
test: Improve Elvish tests

### DIFF
--- a/test/asdf_elvish.bats
+++ b/test/asdf_elvish.bats
@@ -3,9 +3,7 @@
 load test_helpers
 
 setup() {
-  cd $(dirname "$BATS_TEST_DIRNAME")
-  mkdir -p $HOME/.config/elvish/lib
-  cp ./asdf.elv $HOME/.config/elvish/lib/asdftest.elv
+  export XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_DATA_DIRS=
 
   local version=
   version=$(elvish -version)
@@ -18,10 +16,6 @@ setup() {
   fi
 }
 
-teardown() {
-  rm $HOME/.config/elvish/lib/asdftest.elv
-}
-
 cleaned_path() {
   echo $PATH | tr ':' '\n' | grep -v "asdf" | tr '\n' ' '
 }
@@ -30,7 +24,7 @@ cleaned_path() {
   output=$(elvish -norc -c "
     unset-env ASDF_DIR
     set paths = [$(cleaned_path)]
-    use asdftest _asdf; var asdf~ = \$_asdf:asdf~
+    use ./asdf _asdf; var asdf~ = \$_asdf:asdf~
     echo \$E:ASDF_DIR
   ")
   [ "$?" -eq 0 ]
@@ -41,7 +35,7 @@ cleaned_path() {
   output=$(elvish -norc -c "
     set-env ASDF_DIR "/path/to/asdf"
     set paths = [$(cleaned_path)]
-    use asdftest _asdf; var asdf~ = \$_asdf:asdf~
+    use ./asdf _asdf; var asdf~ = \$_asdf:asdf~
     echo \$E:ASDF_DIR
   ")
   [ "$?" -eq 0 ]
@@ -52,7 +46,7 @@ cleaned_path() {
   output=$(elvish -norc -c "
     set-env ASDF_DATA_DIR "/path/to/asdf-data"
     set paths = [$(cleaned_path)]
-    use asdftest _asdf; var asdf~ = \$_asdf:asdf~
+    use ./asdf _asdf; var asdf~ = \$_asdf:asdf~
     echo \$E:ASDF_DATA_DIR
   ")
   [ "$?" -eq 0 ]
@@ -63,7 +57,7 @@ cleaned_path() {
   result=$(elvish -norc -c "
     unset-env ASDF_DIR
     set paths = [$(cleaned_path)]
-    use asdftest _asdf; var asdf~ = \$_asdf:asdf~
+    use ./asdf _asdf; var asdf~ = \$_asdf:asdf~
     echo \$E:PATH
   ")
   [ "$?" -eq 0 ]
@@ -76,7 +70,7 @@ cleaned_path() {
   output=$(elvish -norc -c "
     unset-env ASDF_DIR
     set paths = [$(cleaned_path)]
-    use asdftest _asdf; var asdf~ = \$_asdf:asdf~
+    use ./asdf _asdf; var asdf~ = \$_asdf:asdf~
     pprint \$_asdf:
   ")
   [ "$?" -eq 0 ]
@@ -88,8 +82,8 @@ cleaned_path() {
     unset-env ASDF_DIR
     set paths = [$(cleaned_path)]
 
-    use asdftest _asdf; var asdf~ = \$_asdf:asdf~
-    use asdftest _asdf; var asdf~ = \$_asdf:asdf~
+    use ./asdf _asdf; var asdf~ = \$_asdf:asdf~
+    use ./asdf _asdf; var asdf~ = \$_asdf:asdf~
     echo \$E:PATH
   ")
   [ "$?" -eq 0 ]
@@ -101,7 +95,7 @@ cleaned_path() {
   output=$(elvish -norc -c "
     unset-env ASDF_DIR
     set paths = [$(cleaned_path)]
-    use asdftest _asdf; var asdf~ = \$_asdf:asdf~
+    use ./asdf _asdf; var asdf~ = \$_asdf:asdf~
     pprint \$asdf~
   ")
   [ "$?" -eq 0 ]
@@ -113,7 +107,7 @@ cleaned_path() {
   result=$(elvish -norc -c "
     set-env ASDF_DIR $(pwd) # checkstyle-ignore
     set paths = [$(cleaned_path)]
-    use asdftest _asdf; var asdf~ = \$_asdf:asdf~
+    use ./asdf _asdf; var asdf~ = \$_asdf:asdf~
     asdf info
   ")
   [ "$?" -eq 0 ]

--- a/test/asdf_elvish.bats
+++ b/test/asdf_elvish.bats
@@ -6,6 +6,16 @@ setup() {
   cd $(dirname "$BATS_TEST_DIRNAME")
   mkdir -p $HOME/.config/elvish/lib
   cp ./asdf.elv $HOME/.config/elvish/lib/asdftest.elv
+
+  local version=
+  version=$(elvish -version)
+
+  local ver_major= ver_minor= ver_patch=
+  IFS='.' read -r ver_major ver_minor ver_patch <<<"$version"
+
+  if ((ver_major == 0 && ver_minor <= 17)); then
+    skip "Elvish version is not at least 0.17"
+  fi
 }
 
 teardown() {


### PR DESCRIPTION
# Summary

Old versions of Elvish cause spectacular failures

![image](https://user-images.githubusercontent.com/24364012/210958282-aff696f0-2569-44a9-aa7a-f1744d74df52.png)

My patches fix that:

![image](https://user-images.githubusercontent.com/24364012/210958476-092d8c24-bee6-43ba-9ebc-657bfb4aa2cb.png)

The module handling was also improved. Rather than copying the `adsf.elv` file and munging with user config files (which was already broken in cases where `$XDG_CONFIG_HOME` was not set to `$HOME/.config`), it uses the files in place by using relative imports. Additionally, `XDG_CONFIG_HOME` and `XDG_DATA_HOME`, etc. were set to empty so user config files are never parsed (it seems the `-norc` flag of Elvish is limited), improving test isolation.
