### PR TITLE
ci: fix regex in `update_version_in_docs.bash` script

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -33,7 +33,7 @@ asdf primarily requires `git` & `curl`. Here is a _non-exhaustive_ list of comma
 ### Official Download
 
 ```shell:no-line-numbers
-git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.11.0
+git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.10.2
 ```
 
 ### Community Supported Download Methods

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -33,7 +33,7 @@ asdf primarily requires `git` & `curl`. Here is a _non-exhaustive_ list of comma
 ### Official Download
 
 ```shell:no-line-numbers
-git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.10.2
+git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.11.0
 ```
 
 ### Community Supported Download Methods

--- a/scripts/update_version_in_docs.bash
+++ b/scripts/update_version_in_docs.bash
@@ -3,4 +3,4 @@
 set -euo pipefail
 
 version=$(cat version.txt)
-sed -i "s/\(git clone.*--branch \).*\(\`.*|\)/\1v$version\2/" docs/guide/getting-started.md
+sed -i "s/\(git clone.*--branch \).*/\1v$version/" docs/guide/getting-started.md


### PR DESCRIPTION
The previous one was out of sync with the current doc formatting.