### PR TITLE
chore: Reduce ShellCheck Errors for tests directory

### DIFF
--- a/scripts/shellcheck.bash
+++ b/scripts/shellcheck.bash
@@ -23,6 +23,6 @@ shellcheck --shell bash --external-sources \
   test/fixtures/dummy_plugin/bin/*
 
 # check .bats files
-# TODO(jthegedus): unlock this check later
-# TODO  shellcheck --shell bats --external-sources \
-# TODO  test/*.bats
+shellcheck --shell bats --external-source \
+  --exclude SC2164 --severity warning \
+  test/*.bats

--- a/test/asdf_elvish.bats
+++ b/test/asdf_elvish.bats
@@ -20,7 +20,7 @@ setup() {
 }
 
 cleaned_path() {
-  echo $PATH | tr ':' '\n' | grep -v "asdf" | tr '\n' ' '
+  echo "$PATH" | tr ':' '\n' | grep -v "asdf" | tr '\n' ' '
 }
 
 @test "exports ASDF_DIR" {

--- a/test/asdf_elvish.bats
+++ b/test/asdf_elvish.bats
@@ -28,9 +28,8 @@ cleaned_path() {
     unset-env ASDF_DIR
     set paths = [$(cleaned_path)]
     use ./asdf _asdf; var asdf~ = \$_asdf:asdf~
-    echo \$E:ASDF_DIR
-  ")
-  [ "$?" -eq 0 ]
+    echo \$E:ASDF_DIR"
+  [ "$status" -eq 0 ]
   [ "$output" = "$HOME/.asdf" ]
 }
 
@@ -39,9 +38,8 @@ cleaned_path() {
     set-env ASDF_DIR \"/path/to/asdf\"
     set paths = [$(cleaned_path)]
     use ./asdf _asdf; var asdf~ = \$_asdf:asdf~
-    echo \$E:ASDF_DIR
-  ")
-  [ "$?" -eq 0 ]
+    echo \$E:ASDF_DIR"
+  [ "$status" -eq 0 ]
   [ "$output" = "/path/to/asdf" ]
 }
 
@@ -50,9 +48,8 @@ cleaned_path() {
     set-env ASDF_DATA_DIR \"/path/to/asdf-data\"
     set paths = [$(cleaned_path)]
     use ./asdf _asdf; var asdf~ = \$_asdf:asdf~
-    echo \$E:ASDF_DATA_DIR
-  ")
-  [ "$?" -eq 0 ]
+    echo \$E:ASDF_DATA_DIR"
+  [ "$status" -eq 0 ]
   [ "$output" = "/path/to/asdf-data" ]
 }
 
@@ -61,9 +58,8 @@ cleaned_path() {
     unset-env ASDF_DIR
     set paths = [$(cleaned_path)]
     use ./asdf _asdf; var asdf~ = \$_asdf:asdf~
-    echo \$E:PATH
-  ")
-  [ "$?" -eq 0 ]
+    echo \$E:PATH"
+  [ "$status" -eq 0 ]
   echo "$result"
   run echo "$result" | grep "asdf")
   [ "$output" != "" ]
@@ -74,9 +70,8 @@ cleaned_path() {
     unset-env ASDF_DIR
     set paths = [$(cleaned_path)]
     use ./asdf _asdf; var asdf~ = \$_asdf:asdf~
-    pprint \$_asdf:
-  ")
-  [ "$?" -eq 0 ]
+    pprint \$_asdf:"
+  [ "$status" -eq 0 ]
   [[ "$output" =~ "<ns " ]]
 }
 
@@ -98,9 +93,8 @@ cleaned_path() {
     unset-env ASDF_DIR
     set paths = [$(cleaned_path)]
     use ./asdf _asdf; var asdf~ = \$_asdf:asdf~
-    pprint \$asdf~
-  ")
-  [ "$?" -eq 0 ]
+    pprint \$asdf~"
+  [ "$status" -eq 0 ]
   echo "$output"
   [[ "$output" =~ "<closure " ]]
 }
@@ -110,9 +104,8 @@ cleaned_path() {
     set-env ASDF_DIR $(pwd) # checkstyle-ignore
     set paths = [$(cleaned_path)]
     use ./asdf _asdf; var asdf~ = \$_asdf:asdf~
-    asdf info
-  ")
-  [ "$?" -eq 0 ]
+    asdf info"
+  [ "$status" -eq 0 ]
   output=$(echo "$result" | grep "ASDF INSTALLED PLUGINS:")
   [ "$output" != "" ]
 }

--- a/test/asdf_elvish.bats
+++ b/test/asdf_elvish.bats
@@ -24,7 +24,7 @@ cleaned_path() {
 }
 
 @test "exports ASDF_DIR" {
-  output=$(elvish -norc -c "
+  run elvish -norc -c "
     unset-env ASDF_DIR
     set paths = [$(cleaned_path)]
     use ./asdf _asdf; var asdf~ = \$_asdf:asdf~
@@ -35,8 +35,8 @@ cleaned_path() {
 }
 
 @test "retains ASDF_DIR" {
-  output=$(elvish -norc -c "
-    set-env ASDF_DIR "/path/to/asdf"
+  run elvish -norc -c "
+    set-env ASDF_DIR \"/path/to/asdf\"
     set paths = [$(cleaned_path)]
     use ./asdf _asdf; var asdf~ = \$_asdf:asdf~
     echo \$E:ASDF_DIR
@@ -46,8 +46,8 @@ cleaned_path() {
 }
 
 @test "retains ASDF_DATA_DIR" {
-  output=$(elvish -norc -c "
-    set-env ASDF_DATA_DIR "/path/to/asdf-data"
+  run elvish -norc -c "
+    set-env ASDF_DATA_DIR \"/path/to/asdf-data\"
     set paths = [$(cleaned_path)]
     use ./asdf _asdf; var asdf~ = \$_asdf:asdf~
     echo \$E:ASDF_DATA_DIR
@@ -65,12 +65,12 @@ cleaned_path() {
   ")
   [ "$?" -eq 0 ]
   echo "$result"
-  output=$(echo "$result" | grep "asdf")
+  run echo "$result" | grep "asdf")
   [ "$output" != "" ]
 }
 
 @test "defines the _asdf namespace" {
-  output=$(elvish -norc -c "
+  run elvish -norc -c "
     unset-env ASDF_DIR
     set paths = [$(cleaned_path)]
     use ./asdf _asdf; var asdf~ = \$_asdf:asdf~
@@ -81,21 +81,20 @@ cleaned_path() {
 }
 
 @test "does not add paths to PATH more than once" {
-  result=$(elvish -norc -c "
+  run elvish -norc -c "
     unset-env ASDF_DIR
     set paths = [$(cleaned_path)]
 
     use ./asdf _asdf; var asdf~ = \$_asdf:asdf~
     use ./asdf _asdf; var asdf~ = \$_asdf:asdf~
-    echo \$E:PATH
-  ")
-  [ "$?" -eq 0 ]
-  output=$(echo $result | tr ':' '\n' | grep "asdf" | sort | uniq -d)
+    echo \$E:PATH"
+  [ "$status" -eq 0 ]
+  output=$(echo "$result" | tr ':' '\n' | grep "asdf" | sort | uniq -d)
   [ "$output" = "" ]
 }
 
 @test "defines the asdf function" {
-  output=$(elvish -norc -c "
+  run elvish -norc -c "
     unset-env ASDF_DIR
     set paths = [$(cleaned_path)]
     use ./asdf _asdf; var asdf~ = \$_asdf:asdf~
@@ -107,7 +106,7 @@ cleaned_path() {
 }
 
 @test "function calls asdf command" {
-  result=$(elvish -norc -c "
+ run elvish -norc -c "
     set-env ASDF_DIR $(pwd) # checkstyle-ignore
     set paths = [$(cleaned_path)]
     use ./asdf _asdf; var asdf~ = \$_asdf:asdf~

--- a/test/asdf_elvish.bats
+++ b/test/asdf_elvish.bats
@@ -3,12 +3,15 @@
 load test_helpers
 
 setup() {
+  # shellcheck disable=SC1007
   export XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_DATA_DIRS=
 
   local version=
   version=$(elvish -version)
 
+  # shellcheck disable=SC1007
   local ver_major= ver_minor= ver_patch=
+  # shellcheck disable=SC2034
   IFS='.' read -r ver_major ver_minor ver_patch <<<"$version"
 
   if ((ver_major == 0 && ver_minor <= 17)); then

--- a/test/asdf_fish.bats
+++ b/test/asdf_fish.bats
@@ -3,7 +3,7 @@
 load test_helpers
 
 setup() {
-  cd $(dirname "$BATS_TEST_DIRNAME")
+  cd "$(dirname "$BATS_TEST_DIRNAME")"
 }
 
 cleaned_path() {
@@ -11,7 +11,7 @@ cleaned_path() {
 }
 
 @test "exports ASDF_DIR" {
-  output=$(fish -c "
+  run fish -c "
     set -e asdf
     set -e ASDF_DIR
     set -e ASDF_DATA_DIR
@@ -25,22 +25,22 @@ cleaned_path() {
 }
 
 @test "adds asdf dirs to PATH" {
-  result=$(fish -c "
+  run fish -c "
     set -e asdf
     set -e ASDF_DIR
     set -e ASDF_DATA_DIR
     set PATH $(cleaned_path)
 
     . (pwd)/asdf.fish  # if the full path is not passed, status -f will return the relative path
-    echo \$PATH
- ")
-  [ "$?" -eq 0 ]
-  output=$(echo "$result" | grep "asdf")
+    echo \$PATH"
+
+  [ "$status" -eq 0 ]
+  output=$(echo "$output" | grep "asdf")
   [ "$output" != "" ]
 }
 
 @test "does not add paths to PATH more than once" {
-  result=$(fish -c "
+  run fish -c "
     set -e asdf
     set -e ASDF_DIR
     set -e ASDF_DATA_DIR
@@ -48,15 +48,14 @@ cleaned_path() {
 
     . asdf.fish
     . asdf.fish
-    echo \$PATH
-  ")
-  [ "$?" -eq 0 ]
-  output=$(echo $result | tr ' ' '\n' | grep "asdf" | sort | uniq -d)
+    echo \$PATH"
+  [ "$status" -eq 0 ]
+  output=$(echo "$output" | tr ' ' '\n' | grep "asdf" | sort | uniq -d)
   [ "$output" = "" ]
 }
 
 @test "defines the asdf function" {
-  output=$(fish -c "
+  run fish -c "
     set -e asdf
     set -e ASDF_DIR
     set PATH $(cleaned_path)
@@ -69,15 +68,14 @@ cleaned_path() {
 }
 
 @test "function calls asdf command" {
-  result=$(fish -c "
+  run fish -c "
     set -e asdf
     set -x ASDF_DIR $(pwd) # checkstyle-ignore
     set PATH $(cleaned_path)
 
     . asdf.fish
-    asdf info
-  ")
-  [ "$?" -eq 0 ]
-  output=$(echo "$result" | grep "ASDF INSTALLED PLUGINS:")
+    asdf info"
+  [ "$status" -eq 0 ]
+  output=$(echo "$output" | grep "ASDF INSTALLED PLUGINS:")
   [ "$output" != "" ]
 }

--- a/test/asdf_fish.bats
+++ b/test/asdf_fish.bats
@@ -18,9 +18,9 @@ cleaned_path() {
     set PATH $(cleaned_path)
 
     . asdf.fish
-    echo \$ASDF_DIR
-  ")
-  [ "$?" -eq 0 ]
+    echo \$ASDF_DIR"
+
+  [ "$status" -eq 0 ]
   [ "$output" != "" ]
 }
 
@@ -61,9 +61,8 @@ cleaned_path() {
     set PATH $(cleaned_path)
 
     . asdf.fish
-    type asdf
-  ")
-  [ "$?" -eq 0 ]
+    type asdf"
+  [ "$status" -eq 0 ]
   [[ "$output" =~ "is a function" ]]
 }
 

--- a/test/asdf_fish.bats
+++ b/test/asdf_fish.bats
@@ -7,7 +7,7 @@ setup() {
 }
 
 cleaned_path() {
-  echo $PATH | tr ':' '\n' | grep -v "asdf" | tr '\n' ' '
+  echo "$PATH" | tr ':' '\n' | grep -v "asdf" | tr '\n' ' '
 }
 
 @test "exports ASDF_DIR" {

--- a/test/asdf_nu.bats
+++ b/test/asdf_nu.bats
@@ -79,7 +79,7 @@ cleaned_path() {
     echo \$env.ASDF_DIR
   ")
 
-  [ "$?" -eq 0 ]
+  [ "$status" -eq 0 ]
   [ "$output" = "$PWD" ]
 }
 
@@ -91,9 +91,9 @@ cleaned_path() {
     let-env ASDF_NU_DIR = '$PWD'
 
     source asdf.nu
-    which asdf | get path | to text
-  ")
-  [ "$?" -eq 0 ]
+    which asdf | get path | to text"
+
+  [ "$status" -eq 0 ]
   [[ "$output" =~ "command" ]]
 }
 

--- a/test/asdf_nu.bats
+++ b/test/asdf_nu.bats
@@ -23,8 +23,7 @@ cleaned_path() {
 
     source asdf.nu
 
-    echo \$env.ASDF_DIR
-  ")
+    echo \$env.ASDF_DIR"
 
   [ "$status" -eq 0 ]
   output=$(echo "$output" | grep "asdf")
@@ -76,8 +75,7 @@ cleaned_path() {
 
     source asdf.nu
 
-    echo \$env.ASDF_DIR
-  ")
+    echo \$env.ASDF_DIR"
 
   [ "$status" -eq 0 ]
   [ "$output" = "$PWD" ]

--- a/test/asdf_nu.bats
+++ b/test/asdf_nu.bats
@@ -11,7 +11,7 @@ setup() {
 }
 
 cleaned_path() {
-  echo $PATH | tr ':' '\n' | grep -v "asdf" | tr '\n' ':'
+  echo "$PATH" | tr ':' '\n' | grep -v "asdf" | tr '\n' ':'
 }
 
 @test "exports ASDF_DIR" {

--- a/test/asdf_nu.bats
+++ b/test/asdf_nu.bats
@@ -3,11 +3,11 @@
 load test_helpers
 
 setup() {
-  cd $(dirname "$BATS_TEST_DIRNAME")
-
   if ! command -v nu; then
     skip "Nu is not installed"
   fi
+
+  cd "$(dirname "$BATS_TEST_DIRNAME")"
 }
 
 cleaned_path() {
@@ -15,7 +15,7 @@ cleaned_path() {
 }
 
 @test "exports ASDF_DIR" {
-  result=$(nu -c "
+  run nu -c "
     hide-env -i asdf
     hide-env -i ASDF_DIR
     let-env PATH = ( '$(cleaned_path)' | split row ':' )
@@ -26,13 +26,13 @@ cleaned_path() {
     echo \$env.ASDF_DIR
   ")
 
-  [ "$?" -eq 0 ]
-  output=$(echo "$result" | grep "asdf")
-  [ "$output" = $PWD ]
+  [ "$status" -eq 0 ]
+  output=$(echo "$output" | grep "asdf")
+  [ "$output" = "$PWD" ]
 }
 
 @test "adds asdf dirs to PATH" {
-  result=$(nu -c "
+  run nu -c "
     hide-env -i asdf
     hide-env -i ASDF_DIR
     let-env PATH = ( '$(cleaned_path)' | split row ':' )
@@ -41,17 +41,17 @@ cleaned_path() {
     source asdf.nu
 
 
-    \$env.PATH | to text
- ")
-  [ "$?" -eq 0 ]
-  output_bin=$(echo "$result" | grep "asdf/bin")
+    \$env.PATH | to text"
+
+  [ "$status" -eq 0 ]
+  output_bin=$(echo "$output" | grep "asdf/bin")
   [ "$output_bin" = "$PWD/bin" ]
-  output_shims=$(echo "$result" | grep "/shims")
+  output_shims=$(echo "$output" | grep "/shims")
   [ "$output_shims" = "$HOME/.asdf/shims" ]
 }
 
 @test "does not add paths to PATH more than once" {
-  result=$(nu -c "
+  run nu -c "
     hide-env -i asdf
     hide-env -i ASDF_DIR
     let-env PATH = ( '$(cleaned_path)' | split row ':' )
@@ -60,15 +60,15 @@ cleaned_path() {
     source asdf.nu
     source asdf.nu
 
-    echo \$env.PATH
-  ")
-  [ "$?" -eq 0 ]
-  output=$(echo $result | tr ' ' '\n' | grep "asdf" | sort | uniq -d)
+    echo \$env.PATH"
+
+  [ "$status" -eq 0 ]
+  output=$(echo "$output" | tr ' ' '\n' | grep "asdf" | sort | uniq -d)
   [ "$output" = "" ]
 }
 
 @test "retains ASDF_DIR" {
-  output=$(nu -c "
+  run nu -c "
     hide-env -i asdf
     let-env ASDF_DIR = ( pwd )
     let-env PATH = ( '$(cleaned_path)' | split row ':' )
@@ -84,7 +84,7 @@ cleaned_path() {
 }
 
 @test "defines the asdf function" {
-  output=$(nu -c "
+  run nu -c "
     hide-env -i asdf
     hide-env -i ASDF_DIR
     let-env PATH = ( '$(cleaned_path)' | split row ':' )
@@ -98,16 +98,16 @@ cleaned_path() {
 }
 
 @test "function calls asdf command" {
-  result=$(nu -c "
+  run nu -c "
     hide-env -i asdf
     hide-env -i ASDF_DIR
     let-env PATH = ( '$(cleaned_path)' | split row ':' )
     let-env ASDF_NU_DIR = '$PWD'
 
     source asdf.nu
-    asdf info
-  ")
-  [ "$?" -eq 0 ]
-  output=$(echo "$result" | grep "ASDF INSTALLED PLUGINS:")
+    asdf info"
+
+  [ "$status" -eq 0 ]
+  output=$(echo "$output" | grep "ASDF INSTALLED PLUGINS:")
   [ "$output" != "" ]
 }

--- a/test/asdf_sh.bats
+++ b/test/asdf_sh.bats
@@ -4,7 +4,7 @@ load test_helpers
 
 # Helper function to handle sourcing of asdf.sh
 source_asdf_sh() {
-  . $(dirname "$BATS_TEST_DIRNAME")/asdf.sh
+  . "$(dirname "$BATS_TEST_DIRNAME")/asdf.sh"
 }
 
 cleaned_path() {
@@ -21,8 +21,8 @@ cleaned_path() {
     echo $ASDF_DIR
   )
 
-  output=$(echo "$result" | grep "asdf")
-  [ "$?" -eq 0 ]
+  run grep 'asdf' <<<"$result"
+  [ "$status" -eq 0 ]
   [ "$output" != "" ]
 }
 
@@ -37,8 +37,8 @@ cleaned_path() {
     echo $ASDF_DIR
   )
 
-  output=$(echo "$result" | grep "asdf")
-  [ "$?" -eq 0 ]
+  run grep 'asdf' <<<"$result"
+  [ "$status" -eq 0 ]
   [ "$output" != "" ]
 }
 
@@ -52,8 +52,8 @@ cleaned_path() {
     echo $PATH
   )
 
-  output=$(echo "$result" | grep "asdf")
-  [ "$?" -eq 0 ]
+  run grep 'asdf' <<<"$result"
+  [ "$status" -eq 0 ]
   [ "$output" != "" ]
 }
 
@@ -68,8 +68,7 @@ cleaned_path() {
     echo $PATH
   )
 
-  output=$(echo $result | tr ':' '\n' | grep "asdf" | sort | uniq -d)
-  [ "$?" -eq 0 ]
+  output=$(echo "$result" | tr ':' '\n' | grep "asdf" | sort | uniq -d)
   [ "$output" = "" ]
 }
 

--- a/test/asdf_sh.bats
+++ b/test/asdf_sh.bats
@@ -18,7 +18,7 @@ cleaned_path() {
     PATH=$(cleaned_path)
 
     source_asdf_sh
-    echo $ASDF_DIR
+    echo "$ASDF_DIR"
   )
 
   run grep 'asdf' <<<"$result"
@@ -34,7 +34,7 @@ cleaned_path() {
     set -o nounset
 
     source_asdf_sh
-    echo $ASDF_DIR
+    echo "$ASDF_DIR"
   )
 
   run grep 'asdf' <<<"$result"
@@ -49,7 +49,7 @@ cleaned_path() {
     PATH=$(cleaned_path)
 
     source_asdf_sh
-    echo $PATH
+    echo "$PATH"
   )
 
   run grep 'asdf' <<<"$result"
@@ -65,7 +65,7 @@ cleaned_path() {
 
     source_asdf_sh
     source_asdf_sh
-    echo $PATH
+    echo "$PATH"
   )
 
   output=$(echo "$result" | tr ':' '\n' | grep "asdf" | sort | uniq -d)

--- a/test/asdf_sh.bats
+++ b/test/asdf_sh.bats
@@ -94,7 +94,7 @@ cleaned_path() {
     source_asdf_sh
     asdf info
   )
-  [ "$?" -eq 0 ]
+
   output=$(echo "$result" | grep "ASDF INSTALLED PLUGINS:")
   [ "$output" != "" ]
 }

--- a/test/asdf_sh.bats
+++ b/test/asdf_sh.bats
@@ -8,7 +8,7 @@ source_asdf_sh() {
 }
 
 cleaned_path() {
-  echo $PATH | tr ':' '\n' | grep -v "asdf" | tr '\n' ':'
+  echo "$PATH" | tr ':' '\n' | grep -v "asdf" | tr '\n' ':'
 }
 
 @test "exports ASDF_DIR" {

--- a/test/current_command.bats
+++ b/test/current_command.bats
@@ -121,7 +121,7 @@ foobar          1.0.0           $PROJECT_DIR/.tool-versions"
 
   run asdf current "y"
   [ "$status" -eq 0 ]
-  [[ "$output" =~ "2.1.0" ]]
+  [[ "$output" == *"2.1.0"* ]]
 }
 
 @test "with no plugins prints an error" {
@@ -134,8 +134,8 @@ foobar          1.0.0           $PROJECT_DIR/.tool-versions"
 }
 
 @test "current should handle comments" {
-  cd $PROJECT_DIR
-  echo "dummy 1.2.0  # this is a comment" >>$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  echo "dummy 1.2.0  # this is a comment" >>"$PROJECT_DIR/.tool-versions"
   expected="dummy           1.2.0           $PROJECT_DIR/.tool-versions"
 
   run asdf current "dummy"

--- a/test/current_command.bats
+++ b/test/current_command.bats
@@ -9,8 +9,8 @@ setup() {
   install_dummy_version "1.2.0"
   install_dummy_version "nightly-2000-01-01"
 
-  PROJECT_DIR=$HOME/project
-  mkdir $PROJECT_DIR
+  PROJECT_DIR="$HOME/project"
+  mkdir -p "$PROJECT_DIR"
 }
 
 teardown() {
@@ -48,10 +48,10 @@ teardown() {
 }
 
 @test "current should derive from the legacy file if enabled" {
-  cd $PROJECT_DIR
-  echo 'legacy_version_file = yes' >$HOME/.asdfrc
-  echo '1.2.0' >>$PROJECT_DIR/.dummy-version
-  expected="dummy           1.2.0           $PROJECT_DIR/.dummy-version"
+  cd "$PROJECT_DIR"
+  echo 'legacy_version_file = yes' >"$HOME/.asdfrc"
+  echo '1.2.0' >>"$PROJECT_DIR/.dummy-version"
+  expected="dummy           1.2.0           "$PROJECT_DIR/.dummy-version""
 
   run asdf current "dummy"
   [ "$status" -eq 0 ]

--- a/test/current_command.bats
+++ b/test/current_command.bats
@@ -18,8 +18,8 @@ teardown() {
 }
 
 @test "current should derive from the current .tool-versions" {
-  cd $PROJECT_DIR
-  echo 'dummy 1.1.0' >>$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  echo 'dummy 1.1.0' >>"$PROJECT_DIR/.tool-versions"
   expected="dummy           1.1.0           $PROJECT_DIR/.tool-versions"
 
   run asdf current "dummy"
@@ -28,8 +28,8 @@ teardown() {
 }
 
 @test "current should handle long version name" {
-  cd $PROJECT_DIR
-  echo "dummy nightly-2000-01-01" >>$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  echo "dummy nightly-2000-01-01" >>"$PROJECT_DIR/.tool-versions"
   expected="dummy           nightly-2000-01-01 $PROJECT_DIR/.tool-versions"
 
   run asdf current "dummy"
@@ -38,8 +38,8 @@ teardown() {
 }
 
 @test "current should handle multiple versions" {
-  cd $PROJECT_DIR
-  echo "dummy 1.2.0 1.1.0" >>$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  echo "dummy 1.2.0 1.1.0" >>"$PROJECT_DIR/.tool-versions"
   expected="dummy           1.2.0 1.1.0     $PROJECT_DIR/.tool-versions"
 
   run asdf current "dummy"
@@ -68,7 +68,7 @@ teardown() {
 }
 
 @test "current should error when no version is set" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
   expected="dummy           ______          No version is set. Run \"asdf <global|shell|local> dummy <version>\""
 
   run asdf current "dummy"
@@ -77,8 +77,8 @@ teardown() {
 }
 
 @test "current should error when a version is set that isn't installed" {
-  cd $PROJECT_DIR
-  echo 'dummy 9.9.9' >>$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  echo 'dummy 9.9.9' >>"$PROJECT_DIR/.tool-versions"
   expected="dummy           9.9.9           Not installed. Run \"asdf install dummy 9.9.9\""
 
   run asdf current "dummy"
@@ -96,9 +96,9 @@ teardown() {
 
   install_mock_plugin "baz"
 
-  cd $PROJECT_DIR
-  echo 'dummy 1.1.0' >>$PROJECT_DIR/.tool-versions
-  echo 'foobar 1.0.0' >>$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  echo 'dummy 1.1.0' >>"$PROJECT_DIR/.tool-versions"
+  echo 'foobar 1.0.0' >>"$PROJECT_DIR/.tool-versions"
 
   run asdf current
   expected="baz             ______          No version is set. Run \"asdf <global|shell|local> baz <version>\"
@@ -115,9 +115,9 @@ foobar          1.0.0           $PROJECT_DIR/.tool-versions"
   install_mock_plugin "y"
   install_mock_plugin_version "y" "2.1.0"
 
-  cd $PROJECT_DIR
-  echo 'dummy 1.1.0' >>$PROJECT_DIR/.tool-versions
-  echo 'y 2.1.0' >>$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  echo 'dummy 1.1.0' >>"$PROJECT_DIR/.tool-versions"
+  echo 'y 2.1.0' >>"$PROJECT_DIR/.tool-versions"
 
   run asdf current "y"
   [ "$status" -eq 0 ]

--- a/test/get_asdf_config_value.bats
+++ b/test/get_asdf_config_value.bats
@@ -19,8 +19,8 @@ EOM
 }
 
 teardown() {
-  rm $ASDF_CONFIG_FILE
-  rm $ASDF_CONFIG_DEFAULT_FILE
+  rm "$ASDF_CONFIG_FILE"
+  rm "$ASDF_CONFIG_DEFAULT_FILE"
   unset ASDF_CONFIG_DEFAULT_FILE
   unset ASDF_CONFIG_FILE
 }
@@ -40,7 +40,7 @@ teardown() {
 }
 
 @test "get_config returns config file complete value including '=' symbols" {
-  cat >>$ASDF_CONFIG_FILE <<-'EOM'
+  cat >>"$ASDF_CONFIG_FILE" <<-'EOM'
 key3 = VAR=val
 EOM
 

--- a/test/get_asdf_config_value.bats
+++ b/test/get_asdf_config_value.bats
@@ -31,12 +31,12 @@ teardown() {
 }
 
 @test "get_config returns default value when the key does not exist" {
-  [ $(get_asdf_config_value "key2") = "value2" ]
+  [ "$(get_asdf_config_value "key2")" = "value2" ]
 }
 
 @test "get_config returns config file value when key exists" {
-  [ $(get_asdf_config_value "key1") = "value1" ]
-  [ $(get_asdf_config_value "legacy_version_file") = "yes" ]
+  [ "$(get_asdf_config_value "key1")" = "value1" ]
+  [ "$(get_asdf_config_value "legacy_version_file")" = "yes" ]
 }
 
 @test "get_config returns config file complete value including '=' symbols" {
@@ -44,5 +44,5 @@ teardown() {
 key3 = VAR=val
 EOM
 
-  [ $(get_asdf_config_value "key3") = "VAR=val" ]
+  [ "$(get_asdf_config_value "key3")" = "VAR=val" ]
 }

--- a/test/get_asdf_config_value.bats
+++ b/test/get_asdf_config_value.bats
@@ -3,15 +3,15 @@
 load test_helpers
 
 setup() {
-  cd $BATS_TMPDIR
-  ASDF_CONFIG_FILE=$BATS_TMPDIR/asdfrc
-  cat >$ASDF_CONFIG_FILE <<-EOM
+  cd "$BATS_TMPDIR"
+  ASDF_CONFIG_FILE="$BATS_TMPDIR/asdfrc"
+  cat >"$ASDF_CONFIG_FILE" <<-EOM
 key1 = value1
 legacy_version_file = yes
 EOM
 
-  ASDF_CONFIG_DEFAULT_FILE=$BATS_TMPDIR/asdfrc_defaults
-  cat >$ASDF_CONFIG_DEFAULT_FILE <<-EOM
+  ASDF_CONFIG_DEFAULT_FILE="$BATS_TMPDIR/asdfrc_defaults"
+  cat >"$ASDF_CONFIG_DEFAULT_FILE" <<-EOM
 # i have  a comment, it's ok
 key2 = value2
 legacy_version_file = no

--- a/test/help_command.bats
+++ b/test/help_command.bats
@@ -9,8 +9,8 @@ setup() {
   run asdf install dummy 1.0
   run asdf install dummy 1.1
 
-  PROJECT_DIR=$HOME/project
-  mkdir $PROJECT_DIR
+  PROJECT_DIR="$HOME/project"
+  mkdir -p "$PROJECT_DIR"
 }
 
 teardown() {

--- a/test/help_command.bats
+++ b/test/help_command.bats
@@ -18,7 +18,7 @@ teardown() {
 }
 
 @test "help should show dummy plugin help" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
 
   run asdf help "dummy"
 
@@ -34,7 +34,7 @@ EOF
 }
 
 @test "help should show dummy plugin help specific to version when version is present" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
 
   run asdf help "dummy" "1.2.3"
 
@@ -48,12 +48,12 @@ Details specific for version 1.2.3
 EOF
   )"
   [ "$status" -eq 0 ]
-  echo $output
+  echo "$output"
   [ "$output" = "$expected_output" ]
 }
 
 @test "help should fail for unknown plugins" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
 
   run asdf help "sunny"
   [ "$status" -eq 1 ]
@@ -61,7 +61,7 @@ EOF
 }
 
 @test "help should fail when plugin doesn't have documentation callback" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
 
   run asdf help "legacy-dummy"
   [ "$status" -eq 1 ]
@@ -69,7 +69,7 @@ EOF
 }
 
 @test "help should show asdf help when no plugin name is provided" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
 
   run asdf help
 

--- a/test/info_command.bats
+++ b/test/info_command.bats
@@ -9,8 +9,8 @@ setup() {
   run asdf install dummy 1.0
   run asdf install dummy 1.1
 
-  PROJECT_DIR=$HOME/project
-  mkdir $PROJECT_DIR
+  PROJECT_DIR="$HOME/project"
+  mkdir -p "$PROJECT_DIR"
 }
 
 teardown() {

--- a/test/info_command.bats
+++ b/test/info_command.bats
@@ -18,7 +18,7 @@ teardown() {
 }
 
 @test "info should show os, shell and asdf debug information" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
 
   run asdf info
 

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -95,7 +95,7 @@ teardown() {
   run grep "asdf-plugin: dummy 1.0.0" $ASDF_DIR/shims/dummy
   [ "$status" -eq 0 ]
 
-  run grep "# asdf-plugin: dummy 1.0.0"$'\n'"# asdf-plugin: dummy 1.1.0" $ASDF_DIR/shims/dummy
+  run grep "# asdf-plugin: dummy 1.0.0"$'\n'"# asdf-plugin: dummy 1.1.0" "$ASDF_DIR/shims/dummy"
   [ "$status" -eq 0 ]
 
   lines_count=$(grep "asdf-plugin: dummy 1.1.0" $ASDF_DIR/shims/dummy | wc -l)

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -47,8 +47,8 @@ teardown() {
 @test "install_command set ASDF_CONCURRENCY" {
   run asdf install dummy 1.0.0
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/installs/dummy/1.0.0/env ]
-  run grep ASDF_CONCURRENCY $ASDF_DIR/installs/dummy/1.0.0/env
+  [ -f "$ASDF_DIR/installs/dummy/1.0.0/env" ]
+  run grep ASDF_CONCURRENCY "$ASDF_DIR/installs/dummy/1.0.0/env"
   [ "$status" -eq 0 ]
 }
 
@@ -67,16 +67,16 @@ teardown() {
 @test "install_command should create a shim with asdf-plugin metadata" {
   run asdf install dummy 1.0.0
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/installs/dummy/1.0.0/env ]
-  run grep "asdf-plugin: dummy 1.0.0" $ASDF_DIR/shims/dummy
+  [ -f "$ASDF_DIR/installs/dummy/1.0.0/env" ]
+  run grep "asdf-plugin: dummy 1.0.0" "$ASDF_DIR/shims/dummy"
   [ "$status" -eq 0 ]
 }
 
 @test "install_command should create a shim with asdf-plugin metadata for plugins without download script" {
   run asdf install legacy-dummy 1.0.0
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/installs/legacy-dummy/1.0.0/env ]
-  run grep "asdf-plugin: legacy-dummy 1.0.0" $ASDF_DIR/shims/dummy
+  [ -f "$ASDF_DIR/installs/legacy-dummy/1.0.0/env" ]
+  run grep "asdf-plugin: legacy-dummy 1.0.0" "$ASDF_DIR/shims/dummy"
   [ "$status" -eq 0 ]
 }
 
@@ -130,7 +130,7 @@ teardown() {
   run asdf install dummy
   [ "$status" -eq 1 ]
   [ "$output" = "No versions specified for dummy in config files or environment" ]
-  [ ! -f $ASDF_DIR/installs/dummy/1.1.0/version ]
+  [ ! -f "$ASDF_DIR/installs/dummy/1.1.0/version" ]
 }
 
 @test "install_command fails if the plugin is not installed" {
@@ -156,7 +156,7 @@ teardown() {
   run asdf install other-dummy
   [ "$status" -eq 1 ]
   [ "$output" = "No versions specified for other-dummy in config files or environment" ]
-  [ ! -f $ASDF_DIR/installs/dummy/1.0.0/version ]
+  [ ! -f "$ASDF_DIR/installs/dummy/1.0.0/version" ]
 }
 
 @test "install_command fails when two tools are specified with no versions" {
@@ -164,8 +164,8 @@ teardown() {
   run asdf install dummy other-dummy
   [ "$status" -eq 1 ]
   [ "$output" = "Dummy couldn't install version: other-dummy (on purpose)" ]
-  [ ! -f $ASDF_DIR/installs/dummy/1.0.0/version ]
-  [ ! -f $ASDF_DIR/installs/other-dummy/2.0.0/version ]
+  [ ! -f "$ASDF_DIR/installs/dummy/1.0.0/version" ]
+  [ ! -f "$ASDF_DIR/installs/other-dummy/2.0.0/version" ]
 }
 
 @test "install_command without arguments uses a parent directory .tool-versions file if present" {
@@ -199,7 +199,7 @@ teardown() {
 @test "install_command doesn't install system version" {
   run asdf install dummy system
   [ "$status" -eq 0 ]
-  [ ! -f $ASDF_DIR/installs/dummy/system/version ]
+  [ ! -f "$ASDF_DIR/installs/dummy/system/version" ]
 }
 
 @test "install command executes configured pre plugin install hook" {
@@ -226,8 +226,8 @@ EOM
   cd $PROJECT_DIR
   run asdf install
   [ "$status" -eq 0 ]
-  [ "$output" = "" ]
-  [ -f $ASDF_DIR/installs/dummy/1.2.0/version ]
+  [ -z "$output" ]
+  [ -f "$ASDF_DIR/installs/dummy/1.2.0/version" ]
 }
 
 @test "install command without arguments installs versions from legacy files in parent directories" {
@@ -239,8 +239,8 @@ EOM
 
   run asdf install
   [ "$status" -eq 0 ]
-  [ "$output" = "" ]
-  [ -f $ASDF_DIR/installs/dummy/1.2.0/version ]
+  [ -z "$output" ]
+  [ -f "$ASDF_DIR/installs/dummy/1.2.0/version" ]
 }
 
 @test "install_command latest installs latest stable version" {
@@ -282,7 +282,7 @@ EOM
   run asdf install dummy-broken 1.0.0
   echo $output
   [ "$status" -eq 1 ]
-  [ ! -d $ASDF_DIR/downloads/dummy-broken/1.1.0 ]
-  [ ! -d $ASDF_DIR/installs/dummy-broken/1.1.0 ]
+  [ ! -d "$ASDF_DIR/downloads/dummy-broken/1.1.0" ]
+  [ ! -d "$ASDF_DIR/installs/dummy-broken/1.1.0" ]
   [ "$output" = "Download failed!" ]
 }

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -29,7 +29,7 @@ teardown() {
 }
 
 @test "install_command without arguments installs even if the user is terrible and does not use newlines" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
   echo -n 'dummy 1.2.0' >".tool-versions"
   run asdf install
   [ "$status" -eq 0 ]
@@ -37,7 +37,7 @@ teardown() {
 }
 
 @test "install_command with only name installs the version in .tool-versions" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
   echo -n 'dummy 1.2.0' >".tool-versions"
   run asdf install dummy
   [ "$status" -eq 0 ]
@@ -84,15 +84,15 @@ teardown() {
   run asdf install dummy 1.1.0
   [ "$status" -eq 0 ]
 
-  run grep "asdf-plugin: dummy 1.1.0" $ASDF_DIR/shims/dummy
+  run grep "asdf-plugin: dummy 1.1.0" "$ASDF_DIR/shims/dummy"
   [ "$status" -eq 0 ]
 
-  run grep "asdf-plugin: dummy 1.0.0" $ASDF_DIR/shims/dummy
+  run grep "asdf-plugin: dummy 1.0.0" "$ASDF_DIR/shims/dummy"
   [ "$status" -eq 1 ]
 
   run asdf install dummy 1.0.0
   [ "$status" -eq 0 ]
-  run grep "asdf-plugin: dummy 1.0.0" $ASDF_DIR/shims/dummy
+  run grep "asdf-plugin: dummy 1.0.0" "$ASDF_DIR/shims/dummy"
   [ "$status" -eq 0 ]
 
   run grep "# asdf-plugin: dummy 1.0.0"$'\n'"# asdf-plugin: dummy 1.1.0" "$ASDF_DIR/shims/dummy"
@@ -103,8 +103,8 @@ teardown() {
 }
 
 @test "install_command without arguments should not generate shim for subdir" {
-  cd $PROJECT_DIR
-  echo 'dummy 1.0.0' >$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  echo 'dummy 1.0.0' >"$PROJECT_DIR/.tool-versions"
 
   run asdf install
   [ "$status" -eq 0 ]
@@ -114,14 +114,14 @@ teardown() {
 
 @test "install_command without arguments should generate shim that passes all arguments to executable" {
   # asdf lib needed to run generated shims
-  cp -rf $BATS_TEST_DIRNAME/../{bin,lib} $ASDF_DIR/
+  cp -rf "$BATS_TEST_DIRNAME"/../{bin,lib} "$ASDF_DIR/"
 
-  cd $PROJECT_DIR
-  echo 'dummy 1.0.0' >$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  echo 'dummy 1.0.0' >"$PROJECT_DIR/.tool-versions"
   run asdf install
 
   # execute the generated shim
-  run $ASDF_DIR/shims/dummy world hello
+  run "$ASDF_DIR/shims/dummy" world hello
   [ "$status" -eq 0 ]
   [ "$output" = "This is Dummy 1.0.0! hello world" ]
 }
@@ -134,8 +134,8 @@ teardown() {
 }
 
 @test "install_command fails if the plugin is not installed" {
-  cd $PROJECT_DIR
-  echo 'other_dummy 1.0.0' >$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  echo 'other_dummy 1.0.0' >"$PROJECT_DIR/.tool-versions"
 
   run asdf install
   [ "$status" -eq 1 ]
@@ -143,8 +143,8 @@ teardown() {
 }
 
 @test "install_command fails if the plugin is not installed without collisions" {
-  cd $PROJECT_DIR
-  printf "dummy 1.0.0\ndum 1.0.0" >$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  printf "dummy 1.0.0\ndum 1.0.0" >"$PROJECT_DIR/.tool-versions"
 
   run asdf install
   [ "$status" -eq 1 ]
@@ -152,7 +152,7 @@ teardown() {
 }
 
 @test "install_command fails when tool is specified but no version of the tool is configured in config file" {
-  echo 'dummy 1.0.0' >$PROJECT_DIR/.tool-versions
+  echo 'dummy 1.0.0' >"$PROJECT_DIR/.tool-versions"
   run asdf install other-dummy
   [ "$status" -eq 1 ]
   [ "$output" = "No versions specified for other-dummy in config files or environment" ]
@@ -160,7 +160,7 @@ teardown() {
 }
 
 @test "install_command fails when two tools are specified with no versions" {
-  printf 'dummy 1.0.0\nother-dummy 2.0.0' >$PROJECT_DIR/.tool-versions
+  printf 'dummy 1.0.0\nother-dummy 2.0.0' >"$PROJECT_DIR/.tool-versions"
   run asdf install dummy other-dummy
   [ "$status" -eq 1 ]
   [ "$output" = "Dummy couldn't install version: other-dummy (on purpose)" ]
@@ -170,12 +170,12 @@ teardown() {
 
 @test "install_command without arguments uses a parent directory .tool-versions file if present" {
   # asdf lib needed to run generated shims
-  cp -rf $BATS_TEST_DIRNAME/../{bin,lib} $ASDF_DIR/
+  cp -rf "$BATS_TEST_DIRNAME"/../{bin,lib} "$ASDF_DIR/"
 
-  echo 'dummy 1.0.0' >$PROJECT_DIR/.tool-versions
-  mkdir -p $PROJECT_DIR/child
+  echo 'dummy 1.0.0' >"$PROJECT_DIR/.tool-versions"
+  mkdir -p "$PROJECT_DIR/child"
 
-  cd $PROJECT_DIR/child
+  cd "$PROJECT_DIR/child"
 
   run asdf install
 
@@ -185,11 +185,11 @@ teardown() {
 }
 
 @test "install_command installs multiple tool versions when they are specified in a .tool-versions file" {
-  echo 'dummy 1.0.0 1.2.0' >$PROJECT_DIR/.tool-versions
-  cd $PROJECT_DIR
+  echo 'dummy 1.0.0 1.2.0' >"$PROJECT_DIR/.tool-versions"
+  cd "$PROJECT_DIR"
 
   run asdf install
-  echo $output
+  echo "$output"
   [ "$status" -eq 0 ]
 
   [ "$(cat "$ASDF_DIR/installs/dummy/1.0.0/version")" = "1.0.0" ]
@@ -203,7 +203,7 @@ teardown() {
 }
 
 @test "install command executes configured pre plugin install hook" {
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 pre_asdf_install_dummy = echo will install dummy $1
 EOM
 
@@ -212,7 +212,7 @@ EOM
 }
 
 @test "install command executes configured post plugin install hook" {
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 post_asdf_install_dummy = echo HEY $version FROM $plugin_name
 EOM
 
@@ -234,8 +234,8 @@ EOM
   echo 'legacy_version_file = yes' >"$HOME/.asdfrc"
   echo '1.2.0' >>"$PROJECT_DIR/.dummy-version"
 
-  mkdir -p $PROJECT_DIR/child
-  cd $PROJECT_DIR/child
+  mkdir -p "$PROJECT_DIR/child"
+  cd "$PROJECT_DIR/child"
 
   run asdf install
   [ "$status" -eq 0 ]
@@ -272,7 +272,7 @@ EOM
 @test "install_command keeps the download directory when always_keep_download setting is true" {
   echo 'always_keep_download = yes' >"$HOME/.asdfrc"
   run asdf install dummy 1.1.0
-  echo $output
+  echo "$output"
   [ "$status" -eq 0 ]
   [ -d "$ASDF_DIR/downloads/dummy/1.1.0" ]
   [ "$(cat "$ASDF_DIR/installs/dummy/1.1.0/version")" = "1.1.0" ]
@@ -280,7 +280,7 @@ EOM
 
 @test "install_command fails when download script exits with non-zero code" {
   run asdf install dummy-broken 1.0.0
-  echo $output
+  echo "$output"
   [ "$status" -eq 1 ]
   [ ! -d "$ASDF_DIR/downloads/dummy-broken/1.1.0" ]
   [ ! -d "$ASDF_DIR/installs/dummy-broken/1.1.0" ]

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -8,8 +8,8 @@ setup() {
   install_dummy_plugin
   install_dummy_broken_plugin
 
-  PROJECT_DIR=$HOME/project
-  mkdir $PROJECT_DIR
+  PROJECT_DIR="$HOME/project"
+  mkdir -p "$PROJECT_DIR"
 }
 
 teardown() {
@@ -221,9 +221,9 @@ EOM
 }
 
 @test "install command without arguments installs versions from legacy files" {
-  echo 'legacy_version_file = yes' >$HOME/.asdfrc
-  echo '1.2.0' >>$PROJECT_DIR/.dummy-version
-  cd $PROJECT_DIR
+  echo 'legacy_version_file = yes' >"$HOME/.asdfrc"
+  echo '1.2.0' >>"$PROJECT_DIR/.dummy-version"
+  cd "$PROJECT_DIR"
   run asdf install
   [ "$status" -eq 0 ]
   [ -z "$output" ]
@@ -231,8 +231,8 @@ EOM
 }
 
 @test "install command without arguments installs versions from legacy files in parent directories" {
-  echo 'legacy_version_file = yes' >$HOME/.asdfrc
-  echo '1.2.0' >>$PROJECT_DIR/.dummy-version
+  echo 'legacy_version_file = yes' >"$HOME/.asdfrc"
+  echo '1.2.0' >>"$PROJECT_DIR/.dummy-version"
 
   mkdir -p $PROJECT_DIR/child
   cd $PROJECT_DIR/child
@@ -270,7 +270,7 @@ EOM
 }
 
 @test "install_command keeps the download directory when always_keep_download setting is true" {
-  echo 'always_keep_download = yes' >$HOME/.asdfrc
+  echo 'always_keep_download = yes' >"$HOME/.asdfrc"
   run asdf install dummy 1.1.0
   echo $output
   [ "$status" -eq 0 ]

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -19,13 +19,13 @@ teardown() {
 @test "install_command installs the correct version" {
   run asdf install dummy 1.1.0
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.1.0/version) = "1.1.0" ]
+  [ "$(cat "$ASDF_DIR/installs/dummy/1.1.0/version")" = "1.1.0" ]
 }
 
 @test "install_command installs the correct version for plugins without download script" {
   run asdf install legacy-dummy 1.1.0
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/legacy-dummy/1.1.0/version) = "1.1.0" ]
+  [ "$(cat "$ASDF_DIR/installs/legacy-dummy/1.1.0/version")" = "1.1.0" ]
 }
 
 @test "install_command without arguments installs even if the user is terrible and does not use newlines" {
@@ -33,7 +33,7 @@ teardown() {
   echo -n 'dummy 1.2.0' >".tool-versions"
   run asdf install
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.2.0/version) = "1.2.0" ]
+  [ "$(cat "$ASDF_DIR/installs/dummy/1.2.0/version")" = "1.2.0" ]
 }
 
 @test "install_command with only name installs the version in .tool-versions" {
@@ -41,7 +41,7 @@ teardown() {
   echo -n 'dummy 1.2.0' >".tool-versions"
   run asdf install dummy
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.2.0/version) = "1.2.0" ]
+  [ "$(cat "$ASDF_DIR/installs/dummy/1.2.0/version")" = "1.2.0" ]
 }
 
 @test "install_command set ASDF_CONCURRENCY" {
@@ -61,7 +61,7 @@ teardown() {
   run asdf install
 
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.2.0/version) = "1.2.0" ]
+  [ "$(cat "$ASDF_DIR/installs/dummy/1.2.0/version")" = "1.2.0" ]
 }
 
 @test "install_command should create a shim with asdf-plugin metadata" {
@@ -98,7 +98,7 @@ teardown() {
   run grep "# asdf-plugin: dummy 1.0.0"$'\n'"# asdf-plugin: dummy 1.1.0" "$ASDF_DIR/shims/dummy"
   [ "$status" -eq 0 ]
 
-  lines_count=$(grep "asdf-plugin: dummy 1.1.0" $ASDF_DIR/shims/dummy | wc -l)
+  lines_count=$(grep "asdf-plugin: dummy 1.1.0" "$ASDF_DIR/shims/dummy" | wc -l)
   [ "$lines_count" -eq "1" ]
 }
 
@@ -180,7 +180,7 @@ teardown() {
   run asdf install
 
   # execute the generated shim
-  [ "$($ASDF_DIR/shims/dummy world hello)" = "This is Dummy 1.0.0! hello world" ]
+  [ "$("$ASDF_DIR/shims/dummy" world hello)" = "This is Dummy 1.0.0! hello world" ]
   [ "$status" -eq 0 ]
 }
 
@@ -192,8 +192,8 @@ teardown() {
   echo $output
   [ "$status" -eq 0 ]
 
-  [ $(cat $ASDF_DIR/installs/dummy/1.0.0/version) = "1.0.0" ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.2.0/version) = "1.2.0" ]
+  [ "$(cat "$ASDF_DIR/installs/dummy/1.0.0/version")" = "1.0.0" ]
+  [ "$(cat "$ASDF_DIR/installs/dummy/1.2.0/version")" = "1.2.0" ]
 }
 
 @test "install_command doesn't install system version" {
@@ -246,27 +246,27 @@ EOM
 @test "install_command latest installs latest stable version" {
   run asdf install dummy latest
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/2.0.0/version) = "2.0.0" ]
+  [ "$(cat "$ASDF_DIR/installs/dummy/2.0.0/version")" = "2.0.0" ]
 }
 
 @test "install_command latest:version installs latest stable version that matches the given string" {
   run asdf install dummy latest:1
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.1.0/version) = "1.1.0" ]
+  [ "$(cat "$ASDF_DIR/installs/dummy/1.1.0/version")" = "1.1.0" ]
 }
 
 @test "install_command deletes the download directory" {
   run asdf install dummy 1.1.0
   [ "$status" -eq 0 ]
-  [ ! -d $ASDF_DIR/downloads/dummy/1.1.0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.1.0/version) = "1.1.0" ]
+  [ ! -d "$ASDF_DIR/downloads/dummy/1.1.0" ]
+  [ "$(cat "$ASDF_DIR/installs/dummy/1.1.0/version")" = "1.1.0" ]
 }
 
 @test "install_command keeps the download directory when --keep-download flag is provided" {
   run asdf install dummy 1.1.0 --keep-download
   [ "$status" -eq 0 ]
-  [ -d $ASDF_DIR/downloads/dummy/1.1.0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.1.0/version) = "1.1.0" ]
+  [ -d "$ASDF_DIR/downloads/dummy/1.1.0" ]
+  [ "$(cat "$ASDF_DIR/installs/dummy/1.1.0/version")" = "1.1.0" ]
 }
 
 @test "install_command keeps the download directory when always_keep_download setting is true" {
@@ -274,8 +274,8 @@ EOM
   run asdf install dummy 1.1.0
   echo $output
   [ "$status" -eq 0 ]
-  [ -d $ASDF_DIR/downloads/dummy/1.1.0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.1.0/version) = "1.1.0" ]
+  [ -d "$ASDF_DIR/downloads/dummy/1.1.0" ]
+  [ "$(cat "$ASDF_DIR/installs/dummy/1.1.0/version")" = "1.1.0" ]
 }
 
 @test "install_command fails when download script exits with non-zero code" {

--- a/test/list_command.bats
+++ b/test/list_command.bats
@@ -25,8 +25,8 @@ teardown() {
 }
 
 @test "list_command should list plugins with installed versions and any selected versions marked with asterisk" {
-  cd $PROJECT_DIR
-  echo 'dummy 1.1.0' >>$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  echo 'dummy 1.1.0' >>"$PROJECT_DIR/.tool-versions"
   run asdf install dummy 1.0.0
   run asdf install dummy 1.1.0
 
@@ -95,14 +95,14 @@ teardown() {
 
 @test "list_all_command fails when list-all script exits with non-zero code" {
   run asdf list-all dummy-broken
-  echo $output
+  echo "$output"
   [ "$status" -eq 1 ]
   [[ "$output" == "Plugin dummy-broken's list-all callback script failed with output:"* ]]
 }
 
 @test "list_all_command displays stderr then stdout when failing" {
   run asdf list-all dummy-broken
-  echo $output
+  echo "$output"
   [[ "$output" == *"List-all failed!"* ]]
   [[ "$output" == *"Attempting to list versions" ]]
 }

--- a/test/list_command.bats
+++ b/test/list_command.bats
@@ -7,8 +7,8 @@ setup() {
   install_dummy_plugin
   install_dummy_broken_plugin
 
-  PROJECT_DIR=$HOME/project
-  mkdir $PROJECT_DIR
+  PROJECT_DIR="$HOME/project"
+  mkdir -p "$PROJECT_DIR"
 }
 
 teardown() {

--- a/test/plugin_add_command.bats
+++ b/test/plugin_add_command.bats
@@ -121,7 +121,7 @@ teardown() {
 @test "plugin_add command executes configured pre hook (generic)" {
   install_mock_plugin_repo "dummy"
 
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 pre_asdf_plugin_add = echo ADD ${@}
 EOM
 
@@ -135,7 +135,7 @@ plugin add path=${ASDF_DIR}/plugins/dummy source_url=${BASE_DIR}/repo-dummy"
 @test "plugin_add command executes configured pre hook (specific)" {
   install_mock_plugin_repo "dummy"
 
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 pre_asdf_plugin_add_dummy = echo ADD
 EOM
 
@@ -149,7 +149,7 @@ plugin add path=${ASDF_DIR}/plugins/dummy source_url=${BASE_DIR}/repo-dummy"
 @test "plugin_add command executes configured post hook (generic)" {
   install_mock_plugin_repo "dummy"
 
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 post_asdf_plugin_add = echo ADD ${@}
 EOM
 
@@ -163,7 +163,7 @@ ADD dummy"
 @test "plugin_add command executes configured post hook (specific)" {
   install_mock_plugin_repo "dummy"
 
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 post_asdf_plugin_add_dummy = echo ADD
 EOM
 

--- a/test/plugin_add_command.bats
+++ b/test/plugin_add_command.bats
@@ -64,8 +64,8 @@ teardown() {
 }
 
 @test "plugin_add command with no URL specified adds a plugin when short name repository is enabled" {
-  export ASDF_CONFIG_DEFAULT_FILE=$HOME/.asdfrc
-  echo "disable_plugin_short_name_repository=no" >$ASDF_CONFIG_DEFAULT_FILE
+  export ASDF_CONFIG_DEFAULT_FILE="$HOME/.asdfrc"
+  echo "disable_plugin_short_name_repository=no" >"$ASDF_CONFIG_DEFAULT_FILE"
 
   run asdf plugin add "elixir"
   [ "$status" -eq 0 ]
@@ -76,8 +76,8 @@ teardown() {
 }
 
 @test "plugin_add command with no URL specified fails to add a plugin when disabled" {
-  export ASDF_CONFIG_DEFAULT_FILE=$HOME/.asdfrc
-  echo "disable_plugin_short_name_repository=yes" >$ASDF_CONFIG_DEFAULT_FILE
+  export ASDF_CONFIG_DEFAULT_FILE="$HOME/.asdfrc"
+  echo "disable_plugin_short_name_repository=yes" >"$ASDF_CONFIG_DEFAULT_FILE"
   local expected="Short-name plugin repository is disabled"
 
   run asdf plugin add "elixir"

--- a/test/plugin_extension_command.bats
+++ b/test/plugin_extension_command.bats
@@ -29,7 +29,7 @@ teardown() {
 }
 
 @test "asdf help shows extension commands for plugin with hyphens in the name" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
 
   plugin_name=dummy-hyphenated
   install_mock_plugin $plugin_name

--- a/test/plugin_list_all_command.bats
+++ b/test/plugin_list_all_command.bats
@@ -13,8 +13,8 @@ teardown() {
 }
 
 @test "plugin_list_all should exit before syncing the plugin repo if disabled" {
-  export ASDF_CONFIG_DEFAULT_FILE=$HOME/.asdfrc
-  echo 'disable_plugin_short_name_repository=yes' >$ASDF_CONFIG_DEFAULT_FILE
+  export ASDF_CONFIG_DEFAULT_FILE="$HOME/.asdfrc"
+  echo 'disable_plugin_short_name_repository=yes' >"$ASDF_CONFIG_DEFAULT_FILE"
   local expected="Short-name plugin repository is disabled"
 
   run asdf plugin list all
@@ -23,8 +23,8 @@ teardown() {
 }
 
 @test "plugin_list_all should sync repo when check_duration set to 0" {
-  export ASDF_CONFIG_DEFAULT_FILE=$HOME/.asdfrc
-  echo 'plugin_repository_last_check_duration = 0' >$ASDF_CONFIG_DEFAULT_FILE
+  export ASDF_CONFIG_DEFAULT_FILE="$HOME/.asdfrc"
+  echo 'plugin_repository_last_check_duration = 0' >"$ASDF_CONFIG_DEFAULT_FILE"
   local expected_plugin_repo_sync="updating plugin repository..."
   local expected_plugins_list="\
 bar                           http://example.com/bar
@@ -38,8 +38,8 @@ foo                           http://example.com/foo"
 }
 
 @test "plugin_list_all no immediate repo sync expected because check_duration is greater than 0" {
-  export ASDF_CONFIG_DEFAULT_FILE=$HOME/.asdfrc
-  echo 'plugin_repository_last_check_duration = 10' >$ASDF_CONFIG_DEFAULT_FILE
+  export ASDF_CONFIG_DEFAULT_FILE="$HOME/.asdfrc"
+  echo 'plugin_repository_last_check_duration = 10' >"$ASDF_CONFIG_DEFAULT_FILE"
   local expected="\
 bar                           http://example.com/bar
 dummy                        *http://example.com/dummy
@@ -51,8 +51,8 @@ foo                           http://example.com/foo"
 }
 
 @test "plugin_list_all skips repo sync because check_duration is set to never" {
-  export ASDF_CONFIG_DEFAULT_FILE=$HOME/.asdfrc
-  echo 'plugin_repository_last_check_duration = never' >$ASDF_CONFIG_DEFAULT_FILE
+  export ASDF_CONFIG_DEFAULT_FILE="$HOME/.asdfrc"
+  echo 'plugin_repository_last_check_duration = never' >"$ASDF_CONFIG_DEFAULT_FILE"
   local expected="\
 bar                           http://example.com/bar
 dummy                        *http://example.com/dummy

--- a/test/plugin_list_all_command.bats
+++ b/test/plugin_list_all_command.bats
@@ -33,8 +33,8 @@ foo                           http://example.com/foo"
 
   run asdf plugin list all
   [ "$status" -eq 0 ]
-  [[ "$output" =~ "$expected_plugin_repo_sync" ]]
-  [[ "$output" =~ "$expected_plugins_list" ]]
+  [[ "$output" == *"$expected_plugin_repo_sync"* ]]
+  [[ "$output" == *"$expected_plugins_list"* ]]
 }
 
 @test "plugin_list_all no immediate repo sync expected because check_duration is greater than 0" {

--- a/test/plugin_update_command.bats
+++ b/test/plugin_update_command.bats
@@ -86,31 +86,31 @@ teardown() {
   [ "$(cat "$ASDF_DIR/installs/dummy/1.1/version")" = "1.1" ]
   run asdf plugin-update dummy
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/installs/dummy/1.1/version ]
+  [ -f "$ASDF_DIR/installs/dummy/1.1/version" ]
   run asdf plugin-update --all
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/installs/dummy/1.1/version ]
+  [ -f "$ASDF_DIR/installs/dummy/1.1/version" ]
 }
 
 @test "asdf plugin-update should not remove plugins" {
   # dummy plugin is already installed
   run asdf plugin-update dummy
   [ "$status" -eq 0 ]
-  [ -d $ASDF_DIR/plugins/dummy ]
+  [ -d "$ASDF_DIR/plugins/dummy" ]
   run asdf plugin-update --all
   [ "$status" -eq 0 ]
-  [ -d $ASDF_DIR/plugins/dummy ]
+  [ -d "$ASDF_DIR/plugins/dummy" ]
 }
 
 @test "asdf plugin-update should not remove shims" {
   run asdf install dummy 1.1
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
   run asdf plugin-update dummy
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
   run asdf plugin-update --all
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
 }
 
 @test "asdf plugin-update done for all plugins" {

--- a/test/plugin_update_command.bats
+++ b/test/plugin_update_command.bats
@@ -83,7 +83,7 @@ teardown() {
 @test "asdf plugin-update should not remove plugin versions" {
   run asdf install dummy 1.1
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.1/version) = "1.1" ]
+  [ "$(cat "$ASDF_DIR/installs/dummy/1.1/version")" = "1.1" ]
   run asdf plugin-update dummy
   [ "$status" -eq 0 ]
   [ -f $ASDF_DIR/installs/dummy/1.1/version ]

--- a/test/plugin_update_command.bats
+++ b/test/plugin_update_command.bats
@@ -157,7 +157,7 @@ teardown() {
 }
 
 @test "asdf plugin-update executes configured pre hook (generic)" {
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 pre_asdf_plugin_update = echo UPDATE ${@}
 EOM
 
@@ -173,7 +173,7 @@ EOM
 }
 
 @test "asdf plugin-update executes configured pre hook (specific)" {
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 pre_asdf_plugin_update_dummy = echo UPDATE
 EOM
 
@@ -189,7 +189,7 @@ EOM
 }
 
 @test "asdf plugin-update executes configured post hook (generic)" {
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 post_asdf_plugin_update = echo UPDATE ${@}
 EOM
 
@@ -206,7 +206,7 @@ UPDATE dummy"
 }
 
 @test "asdf plugin-update executes configured post hook (specific)" {
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 post_asdf_plugin_update_dummy = echo UPDATE
 EOM
 

--- a/test/remove_command.bats
+++ b/test/remove_command.bats
@@ -57,7 +57,7 @@ teardown() {
   run asdf install dummy 1.0
 
   # make an unrelated shim
-  echo "# asdf-plugin: gummy" >$ASDF_DIR/shims/gummy
+  echo "# asdf-plugin: gummy" >"$ASDF_DIR/shims/gummy"
 
   run asdf plugin-remove dummy
   [ "$status" -eq 0 ]

--- a/test/remove_command.bats
+++ b/test/remove_command.bats
@@ -77,7 +77,7 @@ teardown() {
 @test "plugin_remove_command executes configured pre hook (generic)" {
   install_dummy_plugin
 
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 pre_asdf_plugin_remove = echo REMOVE ${@}
 EOM
 
@@ -91,7 +91,7 @@ plugin-remove ${ASDF_DIR}/plugins/dummy"
 @test "plugin_remove_command executes configured pre hook (specific)" {
   install_dummy_plugin
 
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 pre_asdf_plugin_remove_dummy = echo REMOVE
 EOM
 
@@ -105,7 +105,7 @@ plugin-remove ${ASDF_DIR}/plugins/dummy"
 @test "plugin_remove_command executes configured post hook (generic)" {
   install_dummy_plugin
 
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 post_asdf_plugin_remove = echo REMOVE ${@}
 EOM
 
@@ -119,7 +119,7 @@ REMOVE dummy"
 @test "plugin_remove_command executes configured post hook (specific)" {
   install_dummy_plugin
 
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 post_asdf_plugin_remove_dummy = echo REMOVE
 EOM
 

--- a/test/remove_command.bats
+++ b/test/remove_command.bats
@@ -34,22 +34,22 @@ teardown() {
   install_dummy_plugin
   run asdf install dummy 1.0
   [ "$status" -eq 0 ]
-  [ -d $ASDF_DIR/installs/dummy ]
+  [ -d "$ASDF_DIR/installs/dummy" ]
 
   run asdf plugin-remove dummy
   [ "$status" -eq 0 ]
-  [ ! -d $ASDF_DIR/installs/dummy ]
+  [ ! -d "$ASDF_DIR/installs/dummy" ]
 }
 
 @test "plugin_remove_command should also remove shims for that plugin" {
   install_dummy_plugin
   run asdf install dummy 1.0
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
 
   run asdf plugin-remove dummy
   [ "$status" -eq 0 ]
-  [ ! -f $ASDF_DIR/shims/dummy ]
+  [ ! -f "$ASDF_DIR/shims/dummy" ]
 }
 
 @test "plugin_remove_command should not remove unrelated shims" {
@@ -63,7 +63,7 @@ teardown() {
   [ "$status" -eq 0 ]
 
   # unrelated shim should exist
-  [ -f $ASDF_DIR/shims/gummy ]
+  [ -f "$ASDF_DIR/shims/gummy" ]
 }
 
 @test "plugin_remove_command executes pre-plugin-remove script" {

--- a/test/shim_env_command.bats
+++ b/test/shim_env_command.bats
@@ -6,9 +6,9 @@ setup() {
   setup_asdf_dir
   install_dummy_plugin
 
-  PROJECT_DIR=$HOME/project
-  mkdir -p $PROJECT_DIR
-  cd $PROJECT_DIR
+  PROJECT_DIR="$HOME/project"
+  mkdir -p "$PROJECT_DIR"
+  cd "$PROJECT_DIR"
 
   # asdf lib needed to run generated shims
   cp -rf $BATS_TEST_DIRNAME/../{bin,lib} $ASDF_DIR/
@@ -37,20 +37,20 @@ teardown() {
   echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
   run asdf install
 
-  echo "export FOO=bar" >$ASDF_DIR/plugins/dummy/bin/exec-env
-  chmod +x $ASDF_DIR/plugins/dummy/bin/exec-env
+  echo "export FOO=bar" >"$ASDF_DIR/plugins/dummy/bin/exec-env"
+  chmod +x "$ASDF_DIR/plugins/dummy/bin/exec-env"
 
   run asdf env dummy
   [ "$status" -eq 0 ]
-  echo $output | grep 'FOO=bar'
+  echo "$output" | grep 'FOO=bar'
 }
 
 @test "asdf env should ignore plugin custom environment on system version" {
   echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
   run asdf install
 
-  echo "export FOO=bar" >$ASDF_DIR/plugins/dummy/bin/exec-env
-  chmod +x $ASDF_DIR/plugins/dummy/bin/exec-env
+  echo "export FOO=bar" >"$ASDF_DIR/plugins/dummy/bin/exec-env"
+  chmod +x "$ASDF_DIR/plugins/dummy/bin/exec-env"
 
   echo "dummy system" >$PROJECT_DIR/.tool-versions
 

--- a/test/shim_env_command.bats
+++ b/test/shim_env_command.bats
@@ -79,5 +79,4 @@ teardown() {
 
   # Should not contain duplicate colon
   run grep '::' <(echo "$path_line")
-  [ "$duplicate_colon" = "" ]
 }

--- a/test/shim_env_command.bats
+++ b/test/shim_env_command.bats
@@ -57,7 +57,7 @@ teardown() {
   run asdf env dummy
   [ "$status" -eq 0 ]
 
-  run grep 'FOO=bar' <(echo $output)
+  run grep 'FOO=bar' <(echo "$output")
   [ "$output" = "" ]
   [ "$status" -eq 1 ]
 

--- a/test/shim_env_command.bats
+++ b/test/shim_env_command.bats
@@ -11,7 +11,7 @@ setup() {
   cd "$PROJECT_DIR"
 
   # asdf lib needed to run generated shims
-  cp -rf $BATS_TEST_DIRNAME/../{bin,lib} $ASDF_DIR/
+  cp -rf "$BATS_TEST_DIRNAME"/../{bin,lib} "$ASDF_DIR/"
 }
 
 teardown() {
@@ -25,7 +25,7 @@ teardown() {
 }
 
 @test "asdf env should execute under the environment used for a shim" {
-  echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
+  echo "dummy 1.0" >"$PROJECT_DIR/.tool-versions"
   run asdf install
 
   run asdf env dummy which dummy
@@ -34,7 +34,7 @@ teardown() {
 }
 
 @test "asdf env should execute under plugin custom environment used for a shim" {
-  echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
+  echo "dummy 1.0" >"$PROJECT_DIR/.tool-versions"
   run asdf install
 
   echo "export FOO=bar" >"$ASDF_DIR/plugins/dummy/bin/exec-env"
@@ -46,13 +46,13 @@ teardown() {
 }
 
 @test "asdf env should ignore plugin custom environment on system version" {
-  echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
+  echo "dummy 1.0" >"$PROJECT_DIR/.tool-versions"
   run asdf install
 
   echo "export FOO=bar" >"$ASDF_DIR/plugins/dummy/bin/exec-env"
   chmod +x "$ASDF_DIR/plugins/dummy/bin/exec-env"
 
-  echo "dummy system" >$PROJECT_DIR/.tool-versions
+  echo "dummy system" >"$PROJECT_DIR/.tool-versions"
 
   run asdf env dummy
   [ "$status" -eq 0 ]
@@ -67,7 +67,7 @@ teardown() {
 }
 
 @test "asdf env should set PATH correctly" {
-  echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
+  echo "dummy 1.0" >"$PROJECT_DIR/.tool-versions"
   run asdf install
 
   run asdf env dummy

--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -394,8 +394,8 @@ teardown() {
 
   exec_path="$ASDF_DIR/plugins/dummy/bin/exec-path"
 
-  echo 'echo $3 # always same path' >$exec_path
-  chmod +x $exec_path
+  echo 'echo $3 # always same path' >"$exec_path"
+  chmod +x "$exec_path"
 
   echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
 

--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -6,9 +6,9 @@ setup() {
   setup_asdf_dir
   install_dummy_plugin
 
-  PROJECT_DIR=$HOME/project
-  mkdir -p $PROJECT_DIR
-  cd $PROJECT_DIR
+  PROJECT_DIR="$HOME/project"
+  mkdir -p "$PROJECT_DIR"
+  cd "$PROJECT_DIR"
 
   # asdf lib needed to run generated shims
   cp -rf $BATS_TEST_DIRNAME/../{bin,lib} $ASDF_DIR/
@@ -201,18 +201,18 @@ teardown() {
   echo "echo System" >$PROJECT_DIR/foo/dummy
   chmod +x $PROJECT_DIR/foo/dummy
 
-  run env PATH=$PATH:$PROJECT_DIR/foo $ASDF_DIR/shims/dummy hello
+  run env PATH=$PATH:$PROJECT_DIR/foo "$ASDF_DIR/shims/dummy" hello
   [ "$output" = "System" ]
 }
 
 @test "shim exec should use path executable when specified version path:<path>" {
   run asdf install dummy 1.0
 
-  CUSTOM_DUMMY_PATH=$PROJECT_DIR/foo
-  CUSTOM_DUMMY_BIN_PATH=$CUSTOM_DUMMY_PATH/bin
-  mkdir -p $CUSTOM_DUMMY_BIN_PATH
-  echo "echo System" >$CUSTOM_DUMMY_BIN_PATH/dummy
-  chmod +x $CUSTOM_DUMMY_BIN_PATH/dummy
+  CUSTOM_DUMMY_PATH="$PROJECT_DIR/foo"
+  CUSTOM_DUMMY_BIN_PATH="$CUSTOM_DUMMY_PATH/bin"
+  mkdir -p "$CUSTOM_DUMMY_BIN_PATH"
+  echo "echo System" >"$CUSTOM_DUMMY_BIN_PATH/dummy"
+  chmod +x "$CUSTOM_DUMMY_BIN_PATH/dummy"
 
   echo "dummy path:$CUSTOM_DUMMY_PATH" >$PROJECT_DIR/.tool-versions
 
@@ -230,16 +230,16 @@ teardown() {
   echo "echo System" >$PROJECT_DIR/foo/dummy
   chmod +x $PROJECT_DIR/foo/dummy
 
-  run env PATH=$PATH:$PROJECT_DIR/foo $ASDF_DIR/shims/dummy hello
+  run env PATH=$PATH:$PROJECT_DIR/foo "$ASDF_DIR/shims/dummy" hello
   [ "$output" = "System" ]
 }
 
 @test "shim exec should use custom exec-env for tool" {
   run asdf install dummy 2.0.0
-  echo "export FOO=sourced" >$ASDF_DIR/plugins/dummy/bin/exec-env
-  mkdir $ASDF_DIR/plugins/dummy/shims
-  echo 'echo $FOO custom' >$ASDF_DIR/plugins/dummy/shims/foo
-  chmod +x $ASDF_DIR/plugins/dummy/shims/foo
+  echo "export FOO=sourced" >"$ASDF_DIR/plugins/dummy/bin/exec-env"
+  mkdir "$ASDF_DIR/plugins/dummy/shims"
+  echo 'echo $FOO custom' >"$ASDF_DIR/plugins/dummy/shims/foo"
+  chmod +x "$ASDF_DIR/plugins/dummy/shims/foo"
   run asdf reshim dummy 2.0.0
 
   echo "dummy 2.0.0" >$PROJECT_DIR/.tool-versions
@@ -249,10 +249,10 @@ teardown() {
 
 @test "shim exec with custom exec-env using ASDF_INSTALL_PATH" {
   run asdf install dummy 2.0.0
-  echo 'export FOO=$ASDF_INSTALL_PATH/foo' >$ASDF_DIR/plugins/dummy/bin/exec-env
-  mkdir $ASDF_DIR/plugins/dummy/shims
-  echo 'echo $FOO custom' >$ASDF_DIR/plugins/dummy/shims/foo
-  chmod +x $ASDF_DIR/plugins/dummy/shims/foo
+  echo 'export FOO=$ASDF_INSTALL_PATH/foo' >"$ASDF_DIR/plugins/dummy/bin/exec-env"
+  mkdir "$ASDF_DIR/plugins/dummy/shims"
+  echo 'echo $FOO custom' >"$ASDF_DIR/plugins/dummy/shims/foo"
+  chmod +x "$ASDF_DIR/plugins/dummy/shims/foo"
   run asdf reshim dummy 2.0.0
 
   echo "dummy 2.0.0" >$PROJECT_DIR/.tool-versions
@@ -262,10 +262,10 @@ teardown() {
 
 @test "shim exec doest not use custom exec-env for system version" {
   run asdf install dummy 2.0.0
-  echo "export FOO=sourced" >$ASDF_DIR/plugins/dummy/bin/exec-env
-  mkdir $ASDF_DIR/plugins/dummy/shims
-  echo 'echo $FOO custom' >$ASDF_DIR/plugins/dummy/shims/foo
-  chmod +x $ASDF_DIR/plugins/dummy/shims/foo
+  echo "export FOO=sourced" >"$ASDF_DIR/plugins/dummy/bin/exec-env"
+  mkdir "$ASDF_DIR/plugins/dummy/shims"
+  echo 'echo $FOO custom' >"$ASDF_DIR/plugins/dummy/shims/foo"
+  chmod +x "$ASDF_DIR/plugins/dummy/shims/foo"
   run asdf reshim dummy 2.0.0
 
   echo "dummy system" >$PROJECT_DIR/.tool-versions
@@ -274,7 +274,7 @@ teardown() {
   echo 'echo x$FOO System' >$PROJECT_DIR/sys/foo
   chmod +x $PROJECT_DIR/sys/foo
 
-  run env PATH=$PATH:$PROJECT_DIR/sys $ASDF_DIR/shims/foo
+  run env "PATH=$PATH:$PROJECT_DIR/sys" "$ASDF_DIR/shims/foo"
   [ "$output" = "x System" ]
 }
 
@@ -329,16 +329,16 @@ teardown() {
   echo 'which dummy' >$PROJECT_DIR/sys/dummy
   chmod +x $PROJECT_DIR/sys/dummy
 
-  run env PATH=$PATH:$PROJECT_DIR/sys $ASDF_DIR/shims/dummy
-  echo $status $output
+  run env "PATH=$PATH:$PROJECT_DIR/sys" "$ASDF_DIR/shims/dummy"
+  echo "$status $output"
   [ "$output" = "$ASDF_DIR/shims/dummy" ]
 }
 
 @test "shim exec can take version from legacy file if configured" {
   run asdf install dummy 2.0.0
 
-  echo "legacy_version_file = yes" >$HOME/.asdfrc
-  echo "2.0.0" >$PROJECT_DIR/.dummy-version
+  echo "legacy_version_file = yes" >"$HOME/.asdfrc"
+  echo "2.0.0" >"$PROJECT_DIR/.dummy-version"
 
   run $ASDF_DIR/shims/dummy world hello
   [ "$output" = "This is Dummy 2.0.0! hello world" ]
@@ -346,7 +346,7 @@ teardown() {
 
 @test "shim exec can take version from environment variable" {
   run asdf install dummy 2.0.0
-  run env ASDF_DUMMY_VERSION=2.0.0 $ASDF_DIR/shims/dummy world hello
+  run env ASDF_DUMMY_VERSION=2.0.0 "$ASDF_DIR/shims/dummy" world hello
   [ "$output" = "This is Dummy 2.0.0! hello world" ]
 }
 
@@ -430,7 +430,7 @@ EOM
 pre_dummy_dummy = pre $1 no $plugin_name $2
 EOM
 
-  run env PATH=$PATH:$HOME/hook $ASDF_DIR/shims/dummy hello world
+  run env PATH="$PATH:$HOME/hook" "$ASDF_DIR/shims/dummy" hello world
   [ "$output" = "hello no dummy world" ]
   [ "$status" -eq 1 ]
 }

--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -65,7 +65,7 @@ teardown() {
 
   run asdf reshim dummy 1.0
 
-  run echo $(echo hello | $ASDF_DIR/shims/upper)
+  run echo "$(echo hello | "$ASDF_DIR/shims/upper")"
   [ "$output" = "HELLO" ]
   [ "$status" -eq 0 ]
 }
@@ -379,9 +379,9 @@ teardown() {
   echo "echo custom/dummy" >$exec_path
   chmod +x $exec_path
 
-  mkdir $(dirname $custom_dummy)
-  echo "echo CUSTOM" >$custom_dummy
-  chmod +x $custom_dummy
+  mkdir "$(dirname "$custom_dummy")"
+  echo "echo CUSTOM" >"$custom_dummy"
+  chmod +x "$custom_dummy"
 
   echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
 

--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -60,8 +60,8 @@ teardown() {
   echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
   run asdf install
 
-  echo "tr [:lower:] [:upper:]" >$ASDF_DIR/installs/dummy/1.0/bin/upper
-  chmod +x $ASDF_DIR/installs/dummy/1.0/bin/upper
+  echo "tr [:lower:] [:upper:]" >"$ASDF_DIR/installs/dummy/1.0/bin/upper"
+  chmod +x "$ASDF_DIR/installs/dummy/1.0/bin/upper"
 
   run asdf reshim dummy 1.0
 

--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -11,7 +11,7 @@ setup() {
   cd "$PROJECT_DIR"
 
   # asdf lib needed to run generated shims
-  cp -rf $BATS_TEST_DIRNAME/../{bin,lib} $ASDF_DIR/
+  cp -rf "$BATS_TEST_DIRNAME"/../{bin,lib} "$ASDF_DIR/"
 }
 
 teardown() {
@@ -25,7 +25,7 @@ teardown() {
 }
 
 @test "asdf exec should pass all arguments to executable" {
-  echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
+  echo "dummy 1.0" >"$PROJECT_DIR/.tool-versions"
   run asdf install
 
   run asdf exec dummy world hello
@@ -34,7 +34,7 @@ teardown() {
 }
 
 @test "asdf exec should pass all arguments to executable even if shim is not in PATH" {
-  echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
+  echo "dummy 1.0" >"$PROJECT_DIR/.tool-versions"
   run asdf install
 
   path=$(echo "$PATH" | sed -e "s|$(asdf_data_dir)/shims||g; s|::|:|g")
@@ -48,16 +48,16 @@ teardown() {
 }
 
 @test "shim exec should pass all arguments to executable" {
-  echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
+  echo "dummy 1.0" >"$PROJECT_DIR/.tool-versions"
   run asdf install
 
-  run $ASDF_DIR/shims/dummy world hello
+  run "$ASDF_DIR/shims/dummy" world hello
   [ "$output" = "This is Dummy 1.0! hello world" ]
   [ "$status" -eq 0 ]
 }
 
 @test "shim exec should pass stdin to executable" {
-  echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
+  echo "dummy 1.0" >"$PROJECT_DIR/.tool-versions"
   run asdf install
 
   echo "tr [:lower:] [:upper:]" >"$ASDF_DIR/installs/dummy/1.0/bin/upper"
@@ -73,9 +73,9 @@ teardown() {
 @test "shim exec should fail if no version is selected" {
   run asdf install dummy 1.0
 
-  touch $PROJECT_DIR/.tool-versions
+  touch "$PROJECT_DIR/.tool-versions"
 
-  run $ASDF_DIR/shims/dummy world hello
+  run "$ASDF_DIR/shims/dummy" world hello
   [ "$status" -eq 126 ]
   echo "$output" | grep -q "No version is set for command dummy" 2>/dev/null
 }
@@ -84,9 +84,9 @@ teardown() {
   run asdf install dummy 1.0
   run asdf install dummy 2.0.0
 
-  touch $PROJECT_DIR/.tool-versions
+  touch "$PROJECT_DIR/.tool-versions"
 
-  run $ASDF_DIR/shims/dummy world hello
+  run "$ASDF_DIR/shims/dummy" world hello
   [ "$status" -eq 126 ]
 
   echo "$output" | grep -q "No version is set for command dummy" 2>/dev/null
@@ -97,14 +97,14 @@ teardown() {
 
 @test "shim exec should suggest different plugins providing same tool when no version is selected" {
   # Another fake plugin with 'dummy' executable
-  cp -rf $ASDF_DIR/plugins/dummy $ASDF_DIR/plugins/mummy
+  cp -rf "$ASDF_DIR/plugins/dummy" "$ASDF_DIR/plugins/mummy"
 
   run asdf install dummy 1.0
   run asdf install mummy 3.0
 
-  touch $PROJECT_DIR/.tool-versions
+  touch "$PROJECT_DIR/.tool-versions"
 
-  run $ASDF_DIR/shims/dummy world hello
+  run "$ASDF_DIR/shims/dummy" world hello
   [ "$status" -eq 126 ]
 
   echo "$output" | grep -q "No version is set for command dummy" 2>/dev/null
@@ -116,9 +116,9 @@ teardown() {
 @test "shim exec should suggest to install missing version" {
   run asdf install dummy 1.0
 
-  echo "dummy 2.0.0 1.3" >$PROJECT_DIR/.tool-versions
+  echo "dummy 2.0.0 1.3" >"$PROJECT_DIR/.tool-versions"
 
-  run $ASDF_DIR/shims/dummy world hello
+  run "$ASDF_DIR/shims/dummy" world hello
   [ "$status" -eq 126 ]
   echo "$output" | grep -q "No preset version installed for command dummy" 2>/dev/null
   echo "$output" | grep -q "Please install a version by running one of the following:" 2>/dev/null
@@ -132,9 +132,9 @@ teardown() {
   run asdf install dummy 2.0.0
   run asdf install dummy 3.0
 
-  echo "dummy 1.0 3.0 2.0.0" >$PROJECT_DIR/.tool-versions
+  echo "dummy 1.0 3.0 2.0.0" >"$PROJECT_DIR/.tool-versions"
 
-  run $ASDF_DIR/shims/dummy world hello
+  run "$ASDF_DIR/shims/dummy" world hello
   [ "$status" -eq 0 ]
 
   echo "$output" | grep -q "This is Dummy 3.0! hello world" 2>/dev/null
@@ -143,10 +143,10 @@ teardown() {
 @test "shim exec should only use the first version found for a plugin" {
   run asdf install dummy 3.0
 
-  echo "dummy 3.0" >$PROJECT_DIR/.tool-versions
-  echo "dummy 1.0" >>$PROJECT_DIR/.tool-versions
+  echo "dummy 3.0" >"$PROJECT_DIR/.tool-versions"
+  echo "dummy 1.0" >>"$PROJECT_DIR/.tool-versions"
 
-  run $ASDF_DIR/shims/dummy world hello
+  run "$ASDF_DIR/shims/dummy" world hello
   [ "$status" -eq 0 ]
 
   echo "$output" | grep -q "This is Dummy 3.0! hello world" 2>/dev/null
@@ -154,40 +154,40 @@ teardown() {
 
 @test "shim exec should determine correct executable on two projects using different plugins that provide the same tool" {
   # Another fake plugin with 'dummy' executable
-  cp -rf $ASDF_DIR/plugins/dummy $ASDF_DIR/plugins/mummy
-  sed -i -e 's/Dummy/Mummy/' $ASDF_DIR/plugins/mummy/bin/install
+  cp -rf "$ASDF_DIR/plugins/dummy" "$ASDF_DIR/plugins/mummy"
+  sed -i -e 's/Dummy/Mummy/' "$ASDF_DIR/plugins/mummy/bin/install"
 
   run asdf install mummy 3.0
   run asdf install dummy 1.0
 
-  mkdir $PROJECT_DIR/{A,B}
-  echo "dummy 1.0" >$PROJECT_DIR/A/.tool-versions
-  echo "mummy 3.0" >$PROJECT_DIR/B/.tool-versions
+  mkdir "$PROJECT_DIR"/{A,B}
+  echo "dummy 1.0" >"$PROJECT_DIR/A/.tool-versions"
+  echo "mummy 3.0" >"$PROJECT_DIR/B/.tool-versions"
 
-  cd $PROJECT_DIR/A
-  run $ASDF_DIR/shims/dummy world hello
+  cd "$PROJECT_DIR"/A
+  run "$ASDF_DIR/shims/dummy" world hello
   [ "$output" = "This is Dummy 1.0! hello world" ]
   [ "$status" -eq 0 ]
 
-  cd $PROJECT_DIR/B
-  run $ASDF_DIR/shims/dummy world hello
+  cd "$PROJECT_DIR"/B
+  run "$ASDF_DIR/shims/dummy" world hello
   [ "$output" = "This is Mummy 3.0! hello world" ]
   [ "$status" -eq 0 ]
 }
 
 @test "shim exec should determine correct executable on a project with two plugins set that provide the same tool" {
   # Another fake plugin with 'dummy' executable
-  cp -rf $ASDF_DIR/plugins/dummy $ASDF_DIR/plugins/mummy
-  sed -i -e 's/Dummy/Mummy/' $ASDF_DIR/plugins/mummy/bin/install
+  cp -rf "$ASDF_DIR/plugins/dummy" "$ASDF_DIR/plugins/mummy"
+  sed -i -e 's/Dummy/Mummy/' "$ASDF_DIR/plugins/mummy/bin/install"
 
   run asdf install dummy 1.0
   run asdf install mummy 3.0
 
-  echo "dummy 2.0.0" >$PROJECT_DIR/.tool-versions
-  echo "mummy 3.0" >>$PROJECT_DIR/.tool-versions
-  echo "dummy 1.0" >>$PROJECT_DIR/.tool-versions
+  echo "dummy 2.0.0" >"$PROJECT_DIR/.tool-versions"
+  echo "mummy 3.0" >>"$PROJECT_DIR/.tool-versions"
+  echo "dummy 1.0" >>"$PROJECT_DIR/.tool-versions"
 
-  run $ASDF_DIR/shims/dummy world hello
+  run "$ASDF_DIR/shims/dummy" world hello
   [ "$output" = "This is Mummy 3.0! hello world" ]
   [ "$status" -eq 0 ]
 }
@@ -195,11 +195,11 @@ teardown() {
 @test "shim exec should fallback to system executable when specified version is system" {
   run asdf install dummy 1.0
 
-  echo "dummy system" >$PROJECT_DIR/.tool-versions
+  echo "dummy system" >"$PROJECT_DIR/.tool-versions"
 
-  mkdir $PROJECT_DIR/foo/
-  echo "echo System" >$PROJECT_DIR/foo/dummy
-  chmod +x $PROJECT_DIR/foo/dummy
+  mkdir "$PROJECT_DIR/foo/"
+  echo "echo System" >"$PROJECT_DIR/foo/dummy"
+  chmod +x "$PROJECT_DIR/foo/dummy"
 
   run env PATH=$PATH:$PROJECT_DIR/foo "$ASDF_DIR/shims/dummy" hello
   [ "$output" = "System" ]
@@ -214,21 +214,21 @@ teardown() {
   echo "echo System" >"$CUSTOM_DUMMY_BIN_PATH/dummy"
   chmod +x "$CUSTOM_DUMMY_BIN_PATH/dummy"
 
-  echo "dummy path:$CUSTOM_DUMMY_PATH" >$PROJECT_DIR/.tool-versions
+  echo "dummy path:$CUSTOM_DUMMY_PATH" >"$PROJECT_DIR/.tool-versions"
 
-  run $ASDF_DIR/shims/dummy hello
+  run "$ASDF_DIR/shims/dummy" hello
   [ "$output" = "System" ]
 }
 
 @test "shim exec should execute system if set first" {
   run asdf install dummy 2.0.0
 
-  echo "dummy system" >$PROJECT_DIR/.tool-versions
-  echo "dummy 2.0.0" >>$PROJECT_DIR/.tool-versions
+  echo "dummy system" >"$PROJECT_DIR/.tool-versions"
+  echo "dummy 2.0.0" >>"$PROJECT_DIR/.tool-versions"
 
-  mkdir $PROJECT_DIR/foo/
-  echo "echo System" >$PROJECT_DIR/foo/dummy
-  chmod +x $PROJECT_DIR/foo/dummy
+  mkdir "$PROJECT_DIR/foo/"
+  echo "echo System" >"$PROJECT_DIR/foo/dummy"
+  chmod +x "$PROJECT_DIR/foo/dummy"
 
   run env PATH=$PATH:$PROJECT_DIR/foo "$ASDF_DIR/shims/dummy" hello
   [ "$output" = "System" ]
@@ -242,8 +242,8 @@ teardown() {
   chmod +x "$ASDF_DIR/plugins/dummy/shims/foo"
   run asdf reshim dummy 2.0.0
 
-  echo "dummy 2.0.0" >$PROJECT_DIR/.tool-versions
-  run $ASDF_DIR/shims/foo
+  echo "dummy 2.0.0" >"$PROJECT_DIR/.tool-versions"
+  run "$ASDF_DIR/shims/foo"
   [ "$output" = "sourced custom" ]
 }
 
@@ -255,8 +255,8 @@ teardown() {
   chmod +x "$ASDF_DIR/plugins/dummy/shims/foo"
   run asdf reshim dummy 2.0.0
 
-  echo "dummy 2.0.0" >$PROJECT_DIR/.tool-versions
-  run $ASDF_DIR/shims/foo
+  echo "dummy 2.0.0" >"$PROJECT_DIR/.tool-versions"
+  run "$ASDF_DIR/shims/foo"
   [ "$output" = "$ASDF_DIR/installs/dummy/2.0.0/foo custom" ]
 }
 
@@ -268,11 +268,11 @@ teardown() {
   chmod +x "$ASDF_DIR/plugins/dummy/shims/foo"
   run asdf reshim dummy 2.0.0
 
-  echo "dummy system" >$PROJECT_DIR/.tool-versions
+  echo "dummy system" >"$PROJECT_DIR/.tool-versions"
 
-  mkdir $PROJECT_DIR/sys/
-  echo 'echo x$FOO System' >$PROJECT_DIR/sys/foo
-  chmod +x $PROJECT_DIR/sys/foo
+  mkdir "$PROJECT_DIR/sys/"
+  echo 'echo x$FOO System' >"$PROJECT_DIR/sys/foo"
+  chmod +x "$PROJECT_DIR/sys/foo"
 
   run env "PATH=$PATH:$PROJECT_DIR/sys" "$ASDF_DIR/shims/foo"
   [ "$output" = "x System" ]
@@ -281,53 +281,53 @@ teardown() {
 @test "shim exec should prepend the plugin paths on execution" {
   run asdf install dummy 2.0.0
 
-  mkdir $ASDF_DIR/plugins/dummy/shims
-  echo 'which dummy' >$ASDF_DIR/plugins/dummy/shims/foo
-  chmod +x $ASDF_DIR/plugins/dummy/shims/foo
+  mkdir "$ASDF_DIR/plugins/dummy/shims"
+  echo 'which dummy' >"$ASDF_DIR/plugins/dummy/shims/foo"
+  chmod +x "$ASDF_DIR/plugins/dummy/shims/foo"
   run asdf reshim dummy 2.0.0
 
-  echo "dummy 2.0.0" >$PROJECT_DIR/.tool-versions
+  echo "dummy 2.0.0" >"$PROJECT_DIR/.tool-versions"
 
-  run $ASDF_DIR/shims/foo
+  run "$ASDF_DIR/shims/foo"
   [ "$output" = "$ASDF_DIR/installs/dummy/2.0.0/bin/dummy" ]
 }
 
 @test "shim exec should be able to find other shims in path" {
-  cp -rf $ASDF_DIR/plugins/dummy $ASDF_DIR/plugins/gummy
+  cp -rf "$ASDF_DIR/plugins/dummy" "$ASDF_DIR/plugins/gummy"
 
-  echo "dummy 2.0.0" >$PROJECT_DIR/.tool-versions
-  echo "gummy 2.0.0" >>$PROJECT_DIR/.tool-versions
+  echo "dummy 2.0.0" >"$PROJECT_DIR/.tool-versions"
+  echo "gummy 2.0.0" >>"$PROJECT_DIR/.tool-versions"
 
   run asdf install
 
-  mkdir $ASDF_DIR/plugins/{dummy,gummy}/shims
+  mkdir "$ASDF_DIR/plugins/"{dummy,gummy}/shims
 
-  echo 'which dummy' >$ASDF_DIR/plugins/dummy/shims/foo
-  chmod +x $ASDF_DIR/plugins/dummy/shims/foo
+  echo 'which dummy' >"$ASDF_DIR/plugins/dummy/shims/foo"
+  chmod +x "$ASDF_DIR/plugins/dummy/shims/foo"
 
-  echo 'which gummy' >$ASDF_DIR/plugins/dummy/shims/bar
-  chmod +x $ASDF_DIR/plugins/dummy/shims/bar
+  echo 'which gummy' >"$ASDF_DIR/plugins/dummy/shims/bar"
+  chmod +x "$ASDF_DIR/plugins/dummy/shims/bar"
 
-  touch $ASDF_DIR/plugins/gummy/shims/gummy
-  chmod +x $ASDF_DIR/plugins/gummy/shims/gummy
+  touch "$ASDF_DIR/plugins/gummy/shims/gummy"
+  chmod +x "$ASDF_DIR/plugins/gummy/shims/gummy"
 
   run asdf reshim
 
-  run $ASDF_DIR/shims/foo
+  run "$ASDF_DIR/shims/foo"
   [ "$output" = "$ASDF_DIR/installs/dummy/2.0.0/bin/dummy" ]
 
-  run $ASDF_DIR/shims/bar
+  run "$ASDF_DIR/shims/bar"
   [ "$output" = "$ASDF_DIR/shims/gummy" ]
 }
 
 @test "shim exec should remove shim_path from path on system version execution" {
   run asdf install dummy 2.0.0
 
-  echo "dummy system" >$PROJECT_DIR/.tool-versions
+  echo "dummy system" >"$PROJECT_DIR/.tool-versions"
 
-  mkdir $PROJECT_DIR/sys/
-  echo 'which dummy' >$PROJECT_DIR/sys/dummy
-  chmod +x $PROJECT_DIR/sys/dummy
+  mkdir "$PROJECT_DIR/sys/"
+  echo 'which dummy' >"$PROJECT_DIR/sys/dummy"
+  chmod +x "$PROJECT_DIR/sys/dummy"
 
   run env "PATH=$PATH:$PROJECT_DIR/sys" "$ASDF_DIR/shims/dummy"
   echo "$status $output"
@@ -340,7 +340,7 @@ teardown() {
   echo "legacy_version_file = yes" >"$HOME/.asdfrc"
   echo "2.0.0" >"$PROJECT_DIR/.dummy-version"
 
-  run $ASDF_DIR/shims/dummy world hello
+  run "$ASDF_DIR/shims/dummy" world hello
   [ "$output" = "This is Dummy 2.0.0! hello world" ]
 }
 
@@ -354,19 +354,19 @@ teardown() {
   exec_path="$ASDF_DIR/plugins/dummy/bin/list-bin-paths"
   custom_path="$ASDF_DIR/installs/dummy/1.0/custom"
 
-  echo "echo bin custom" >$exec_path
-  chmod +x $exec_path
+  echo "echo bin custom" >"$exec_path"
+  chmod +x "$exec_path"
 
   run asdf install dummy 1.0
-  echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
+  echo "dummy 1.0" >"$PROJECT_DIR/.tool-versions"
 
-  mkdir $custom_path
-  echo "echo CUSTOM" >$custom_path/foo
-  chmod +x $custom_path/foo
+  mkdir "$custom_path"
+  echo "echo CUSTOM" >"$custom_path/foo"
+  chmod +x "$custom_path/foo"
 
   run asdf reshim dummy 1.0
 
-  run $ASDF_DIR/shims/foo
+  run "$ASDF_DIR/shims/foo"
   [ "$output" = "CUSTOM" ]
 }
 
@@ -376,16 +376,16 @@ teardown() {
   exec_path="$ASDF_DIR/plugins/dummy/bin/exec-path"
   custom_dummy="$ASDF_DIR/installs/dummy/1.0/custom/dummy"
 
-  echo "echo custom/dummy" >$exec_path
-  chmod +x $exec_path
+  echo "echo custom/dummy" >"$exec_path"
+  chmod +x "$exec_path"
 
   mkdir "$(dirname "$custom_dummy")"
   echo "echo CUSTOM" >"$custom_dummy"
   chmod +x "$custom_dummy"
 
-  echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
+  echo "dummy 1.0" >"$PROJECT_DIR/.tool-versions"
 
-  run $ASDF_DIR/shims/dummy
+  run "$ASDF_DIR/shims/dummy"
   [ "$output" = "CUSTOM" ]
 }
 
@@ -397,21 +397,21 @@ teardown() {
   echo 'echo $3 # always same path' >"$exec_path"
   chmod +x "$exec_path"
 
-  echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
+  echo "dummy 1.0" >"$PROJECT_DIR/.tool-versions"
 
-  run $ASDF_DIR/shims/dummy
+  run "$ASDF_DIR/shims/dummy"
   [ "$output" = "This is Dummy 1.0!" ]
 }
 
 @test "shim exec executes configured pre-hook" {
   run asdf install dummy 1.0
-  echo dummy 1.0 >$PROJECT_DIR/.tool-versions
+  echo dummy 1.0 >"$PROJECT_DIR/.tool-versions"
 
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 pre_dummy_dummy = echo PRE $version $1 $2
 EOM
 
-  run $ASDF_DIR/shims/dummy hello world
+  run "$ASDF_DIR/shims/dummy" hello world
   [ "$status" -eq 0 ]
   echo "$output" | grep "PRE 1.0 hello world"
   echo "$output" | grep "This is Dummy 1.0! world hello"
@@ -419,14 +419,14 @@ EOM
 
 @test "shim exec doesnt execute command if pre-hook failed" {
   run asdf install dummy 1.0
-  echo dummy 1.0 >$PROJECT_DIR/.tool-versions
+  echo dummy 1.0 >"$PROJECT_DIR/.tool-versions"
 
-  mkdir $HOME/hook
+  mkdir "$HOME/hook"
   pre_cmd="$HOME/hook/pre"
   echo 'echo $* && false' >"$pre_cmd"
   chmod +x "$pre_cmd"
 
-  cat >$HOME/.asdfrc <<'EOM'
+  cat >"$HOME/.asdfrc" <<'EOM'
 pre_dummy_dummy = pre $1 no $plugin_name $2
 EOM
 
@@ -439,11 +439,11 @@ EOM
 @test "asdf exec should not crash when POSIXLY_CORRECT=1" {
   export POSIXLY_CORRECT=1
 
-  echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
+  echo "dummy 1.0" >"$PROJECT_DIR/.tool-versions"
   run asdf install
 
   run asdf exec dummy world hello
-  echo $output
+  echo "$output"
   [ "$output" = "This is Dummy 1.0! hello world" ]
   [ "$status" -eq 0 ]
 }

--- a/test/shim_versions_command.bats
+++ b/test/shim_versions_command.bats
@@ -16,7 +16,7 @@ teardown() {
 }
 
 @test "shim_versions_command should list plugins and versions where command is available" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
   run asdf install dummy 3.0
   run asdf install dummy 1.0
   run asdf reshim dummy

--- a/test/shim_versions_command.bats
+++ b/test/shim_versions_command.bats
@@ -6,9 +6,9 @@ setup() {
   setup_asdf_dir
   install_dummy_plugin
 
-  PROJECT_DIR=$HOME/project
-  mkdir -p $PROJECT_DIR
-  cd $PROJECT_DIR
+  PROJECT_DIR="$HOME/project"
+  mkdir -p "$PROJECT_DIR"
+  cd "$PROJECT_DIR"
 }
 
 teardown() {

--- a/test/test_helpers.bash
+++ b/test/test_helpers.bash
@@ -22,7 +22,7 @@ setup_asdf_dir() {
   ASDF_BIN="$(dirname "$BATS_TEST_DIRNAME")/bin"
 
   # shellcheck disable=SC2031
-  PATH="$ASDF_BIN:$ASDF_DIR/shims:$PATH"
+  PATH="$ASDF_BIN:"$ASDF_DIR/shims":$PATH"
 }
 
 install_mock_plugin() {

--- a/test/uninstall_command.bats
+++ b/test/uninstall_command.bats
@@ -23,7 +23,7 @@ teardown() {
 @test "uninstall_command should remove the plugin with that version from asdf" {
   run asdf install dummy 1.1.0
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.1.0/version) = "1.1.0" ]
+  [ "$(cat "$ASDF_DIR/installs/dummy/1.1.0/version")" = "1.1.0" ]
   run asdf uninstall dummy 1.1.0
   [ ! -f $ASDF_DIR/installs/dummy/1.1.0/version ]
 }

--- a/test/uninstall_command.bats
+++ b/test/uninstall_command.bats
@@ -25,7 +25,7 @@ teardown() {
   [ "$status" -eq 0 ]
   [ "$(cat "$ASDF_DIR/installs/dummy/1.1.0/version")" = "1.1.0" ]
   run asdf uninstall dummy 1.1.0
-  [ ! -f $ASDF_DIR/installs/dummy/1.1.0/version ]
+  [ ! -f "$ASDF_DIR/installs/dummy/1.1.0/version" ]
 }
 
 @test "uninstall_command should invoke the plugin bin/uninstall if available" {
@@ -41,29 +41,29 @@ teardown() {
 
 @test "uninstall_command should remove the plugin shims if no other version is installed" {
   run asdf install dummy 1.1.0
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
   run asdf uninstall dummy 1.1.0
-  [ ! -f $ASDF_DIR/shims/dummy ]
+  [ ! -f "$ASDF_DIR/shims/dummy" ]
 }
 
 @test "uninstall_command should leave the plugin shims if other version is installed" {
   run asdf install dummy 1.0.0
-  [ -f $ASDF_DIR/installs/dummy/1.0.0/bin/dummy ]
+  [ -f "$ASDF_DIR/installs/dummy/1.0.0/bin/dummy" ]
 
   run asdf install dummy 1.1.0
-  [ -f $ASDF_DIR/installs/dummy/1.1.0/bin/dummy ]
+  [ -f "$ASDF_DIR/installs/dummy/1.1.0/bin/dummy" ]
 
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
   run asdf uninstall dummy 1.0.0
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
 }
 
 @test "uninstall_command should remove relevant asdf-plugin metadata" {
   run asdf install dummy 1.0.0
-  [ -f $ASDF_DIR/installs/dummy/1.0.0/bin/dummy ]
+  [ -f "$ASDF_DIR/installs/dummy/1.0.0/bin/dummy" ]
 
   run asdf install dummy 1.1.0
-  [ -f $ASDF_DIR/installs/dummy/1.1.0/bin/dummy ]
+  [ -f "$ASDF_DIR/installs/dummy/1.1.0/bin/dummy" ]
 
   run asdf uninstall dummy 1.0.0
   run grep "asdf-plugin: dummy 1.1.0" $ASDF_DIR/shims/dummy
@@ -74,13 +74,13 @@ teardown() {
 
 @test "uninstall_command should not remove other unrelated shims" {
   run asdf install dummy 1.0.0
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
 
-  touch $ASDF_DIR/shims/gummy
-  [ -f $ASDF_DIR/shims/gummy ]
+  touch "$ASDF_DIR/shims/gummy"
+  [ -f "$ASDF_DIR/shims/gummy" ]
 
   run asdf uninstall dummy 1.0.0
-  [ -f $ASDF_DIR/shims/gummy ]
+  [ -f "$ASDF_DIR/shims/gummy" ]
 }
 
 @test "uninstall command executes configured pre hook" {

--- a/test/uninstall_command.bats
+++ b/test/uninstall_command.bats
@@ -6,8 +6,8 @@ setup() {
   setup_asdf_dir
   install_dummy_plugin
 
-  PROJECT_DIR=$HOME/project
-  mkdir $PROJECT_DIR
+  PROJECT_DIR="$HOME/project"
+  mkdir -p "$PROJECT_DIR"
 }
 
 teardown() {

--- a/test/uninstall_command.bats
+++ b/test/uninstall_command.bats
@@ -31,9 +31,9 @@ teardown() {
 @test "uninstall_command should invoke the plugin bin/uninstall if available" {
   run asdf install dummy 1.1.0
   [ "$status" -eq 0 ]
-  mkdir -p $ASDF_DIR/plugins/dummy/bin
-  echo "echo custom uninstall" >$ASDF_DIR/plugins/dummy/bin/uninstall
-  chmod 755 $ASDF_DIR/plugins/dummy/bin/uninstall
+  mkdir -p "$ASDF_DIR/plugins/dummy/bin"
+  echo "echo custom uninstall" >"$ASDF_DIR/plugins/dummy/bin/uninstall"
+  chmod 755 "$ASDF_DIR/plugins/dummy/bin/uninstall"
   run asdf uninstall dummy 1.1.0
   [ "$output" = "custom uninstall" ]
   [ "$status" -eq 0 ]
@@ -66,9 +66,9 @@ teardown() {
   [ -f "$ASDF_DIR/installs/dummy/1.1.0/bin/dummy" ]
 
   run asdf uninstall dummy 1.0.0
-  run grep "asdf-plugin: dummy 1.1.0" $ASDF_DIR/shims/dummy
+  run grep "asdf-plugin: dummy 1.1.0" "$ASDF_DIR/shims/dummy"
   [ "$status" -eq 0 ]
-  run grep "asdf-plugin: dummy 1.0.0" $ASDF_DIR/shims/dummy
+  run grep "asdf-plugin: dummy 1.0.0" "$ASDF_DIR/shims/dummy"
   [ "$status" -eq 1 ]
 }
 
@@ -84,7 +84,7 @@ teardown() {
 }
 
 @test "uninstall command executes configured pre hook" {
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 pre_asdf_uninstall_dummy = echo will uninstall dummy $1
 EOM
 
@@ -94,12 +94,12 @@ EOM
 }
 
 @test "uninstall command executes configured post hook" {
-  cat >$HOME/.asdfrc <<-'EOM'
+  cat >"$HOME/.asdfrc" <<-'EOM'
 post_asdf_uninstall_dummy = echo removed dummy $1
 EOM
 
   run asdf install dummy 1.0.0
   run asdf uninstall dummy 1.0.0
-  echo $output
+  echo "$output"
   [ "$output" = "removed dummy 1.0.0" ]
 }

--- a/test/update_command.bats
+++ b/test/update_command.bats
@@ -29,12 +29,13 @@ teardown() {
 @test "asdf update --head should checkout the master branch" {
   run asdf update --head
   [ "$status" -eq 0 ]
-  cd $ASDF_DIR
-  [ $(git rev-parse --abbrev-ref HEAD) = "master" ]
+  cd "$ASDF_DIR"
+  [ "$(git rev-parse --abbrev-ref HEAD)" = "master" ]
 }
 
 @test "asdf update should checkout the latest non-RC tag" {
-  local tag=$(git tag | grep -vi "rc" | tail -1)
+  local tag=
+  tag=$(git tag | grep -vi "rc" | tail -1)
   if [ -n "$tag" ]; then
     run asdf update
     [ "$status" -eq 0 ]
@@ -45,7 +46,8 @@ teardown() {
 }
 
 @test "asdf update should checkout the latest tag when configured with use_release_candidates = yes" {
-  local tag=$(git tag | tail -1)
+  local tag=
+  tag=$(git tag | tail -1)
   if [ -n "$tag" ]; then
     export ASDF_CONFIG_DEFAULT_FILE=$BATS_TMPDIR/asdfrc_defaults
     echo "use_release_candidates = yes" >$ASDF_CONFIG_DEFAULT_FILE
@@ -80,7 +82,7 @@ teardown() {
 @test "asdf update should not remove plugin versions" {
   run asdf install dummy 1.1.0
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.1.0/version) = "1.1.0" ]
+  [ "$(cat "$ASDF_DIR/installs/dummy/1.1.0/version")" = "1.1.0" ]
   run asdf update
   [ "$status" -eq 0 ]
   [ -f $ASDF_DIR/installs/dummy/1.1.0/version ]

--- a/test/update_command.bats
+++ b/test/update_command.bats
@@ -39,9 +39,8 @@ teardown() {
   if [ -n "$tag" ]; then
     run asdf update
     [ "$status" -eq 0 ]
-    cd $ASDF_DIR
-    git tag | grep $tag
-    [ "$?" -eq 0 ]
+    cd "$ASDF_DIR"
+    git tag | grep "$tag"
   fi
 }
 
@@ -53,9 +52,8 @@ teardown() {
     echo "use_release_candidates = yes" >$ASDF_CONFIG_DEFAULT_FILE
     run asdf update
     [ "$status" -eq 0 ]
-    cd $ASDF_DIR
-    git tag | grep $tag
-    [ "$?" -eq 0 ]
+    cd "$ASDF_DIR"
+    git tag | grep "$tag"
   fi
 }
 
@@ -85,29 +83,29 @@ teardown() {
   [ "$(cat "$ASDF_DIR/installs/dummy/1.1.0/version")" = "1.1.0" ]
   run asdf update
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/installs/dummy/1.1.0/version ]
+  [ -f "$ASDF_DIR/installs/dummy/1.1.0/version" ]
   run asdf update --head
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/installs/dummy/1.1.0/version ]
+  [ -f "$ASDF_DIR/installs/dummy/1.1.0/version" ]
 }
 
 @test "asdf update should not remove plugins" {
   # dummy plugin is already installed
   run asdf update
   [ "$status" -eq 0 ]
-  [ -d $ASDF_DIR/plugins/dummy ]
+  [ -d "$ASDF_DIR/plugins/dummy" ]
   run asdf update --head
   [ "$status" -eq 0 ]
-  [ -d $ASDF_DIR/plugins/dummy ]
+  [ -d "$ASDF_DIR/plugins/dummy" ]
 }
 
 @test "asdf update should not remove shims" {
   run asdf install dummy 1.1.0
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
   run asdf update
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
   run asdf update --head
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
 }

--- a/test/update_command.bats
+++ b/test/update_command.bats
@@ -58,14 +58,14 @@ teardown() {
 }
 
 @test "asdf update is a noop for when updates are disabled" {
-  touch $ASDF_DIR/asdf_updates_disabled
+  touch "$ASDF_DIR/asdf_updates_disabled"
   run asdf update
   [ "$status" -eq 42 ]
   [ "$(echo -e "Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf.")" = "$output" ]
 }
 
 @test "asdf update is a noop for non-git repos" {
-  rm -rf $ASDF_DIR/.git/
+  rm -rf "$ASDF_DIR/.git/"
   run asdf update
   [ "$status" -eq 42 ]
   [ "$(echo -e "Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf.")" = "$output" ]

--- a/test/update_command.bats
+++ b/test/update_command.bats
@@ -4,8 +4,8 @@ load test_helpers
 
 setup() {
   BASE_DIR=$(mktemp -dt asdf.XXXX)
-  HOME=$BASE_DIR/home
-  ASDF_DIR=$HOME/.asdf
+  HOME="$BASE_DIR/home"
+  ASDF_DIR="$HOME/.asdf"
   git clone -o local "$(dirname "$BATS_TEST_DIRNAME")" "$ASDF_DIR"
   git --git-dir "$ASDF_DIR/.git" remote add origin https://github.com/asdf-vm/asdf.git
   mkdir -p "$ASDF_DIR/plugins"
@@ -15,11 +15,11 @@ setup() {
   ASDF_BIN="$ASDF_DIR/bin"
 
   # shellcheck disable=SC2031
-  PATH=$ASDF_BIN:$ASDF_DIR/shims:$PATH
+  PATH="$ASDF_BIN:$ASDF_DIR/shims":$PATH
   install_dummy_plugin
 
-  PROJECT_DIR=$HOME/project
-  mkdir $PROJECT_DIR
+  PROJECT_DIR="$HOME/project"
+  mkdir -p "$PROJECT_DIR"
 }
 
 teardown() {
@@ -48,8 +48,8 @@ teardown() {
   local tag=
   tag=$(git tag | tail -1)
   if [ -n "$tag" ]; then
-    export ASDF_CONFIG_DEFAULT_FILE=$BATS_TMPDIR/asdfrc_defaults
-    echo "use_release_candidates = yes" >$ASDF_CONFIG_DEFAULT_FILE
+    export ASDF_CONFIG_DEFAULT_FILE="$BATS_TMPDIR/asdfrc_defaults"
+    echo "use_release_candidates = yes" >"$ASDF_CONFIG_DEFAULT_FILE"
     run asdf update
     [ "$status" -eq 0 ]
     cd "$ASDF_DIR"

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -291,7 +291,7 @@ teardown() {
   mkdir -p $ASDF_DIR/plugins/foo
   run get_executable_path "foo" "system" "ls"
   [ "$status" -eq 0 ]
-  [ "$output" = $(which ls) ]
+  [ "$output" = "$(which ls)" ]
 }
 
 @test "get_executable_path for system version should not use asdf shims" {

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -235,7 +235,7 @@ teardown() {
 
   run find_versions "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
-  [[ "$output" =~ "0.1.0|$HOME/.dummy-version" ]]
+  [[ "$output" =~ 0.1.0|"$HOME"/.dummy-version ]]
 }
 
 @test "get_preset_version_for returns the current version" {
@@ -370,7 +370,7 @@ teardown() {
 
   run resolve_symlink bar
   [ "$status" -eq 0 ]
-  [ "$output" = $PWD/foo ]
+  [ "$output" = "$PWD/foo" ]
   rm -f foo bar
 }
 
@@ -380,7 +380,7 @@ teardown() {
 
   run resolve_symlink baz/bar
   [ "$status" -eq 0 ]
-  [ "$output" = $PWD/baz/../foo ]
+  [ "$output" = "$PWD/baz/../foo" ]
   rm -f foo bar
 }
 
@@ -390,7 +390,7 @@ teardown() {
 
   run resolve_symlink bar
   [ "$status" -eq 0 ]
-  [ "$output" = $PWD/foo ]
+  [ "$output" = "$PWD/foo" ]
   rm -f foo bar
 }
 

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -8,8 +8,8 @@ setup() {
   install_dummy_version "0.1.0"
   install_dummy_version "0.2.0"
 
-  PROJECT_DIR=$HOME/project
-  mkdir -p $PROJECT_DIR
+  PROJECT_DIR="$HOME/project"
+  mkdir -p "$PROJECT_DIR"
 
   cd $HOME
 }
@@ -150,9 +150,9 @@ teardown() {
 }
 
 @test "find_versions should return the legacy file if supported" {
-  echo "legacy_version_file = yes" >$HOME/.asdfrc
-  echo "dummy 0.1.0" >$HOME/.tool-versions
-  echo "0.2.0" >$PROJECT_DIR/.dummy-version
+  echo "legacy_version_file = yes" >"$HOME/.asdfrc"
+  echo "dummy 0.1.0" >"$HOME/.tool-versions"
+  echo "0.2.0" >"$PROJECT_DIR/.dummy-version"
 
   run find_versions "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
@@ -169,10 +169,10 @@ teardown() {
 }
 
 @test "find_versions should return .tool-versions if unsupported" {
-  echo "dummy 0.1.0" >$HOME/.tool-versions
-  echo "0.2.0" >$PROJECT_DIR/.dummy-version
-  echo "legacy_version_file = yes" >$HOME/.asdfrc
-  rm $ASDF_DIR/plugins/dummy/bin/list-legacy-filenames
+  echo "dummy 0.1.0" >"$HOME/.tool-versions"
+  echo "0.2.0" >"$PROJECT_DIR/.dummy-version"
+  echo "legacy_version_file = yes" >"$HOME/.asdfrc"
+  rm "$ASDF_DIR/plugins/dummy/bin/list-legacy-filenames"
 
   run find_versions "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
@@ -229,9 +229,9 @@ teardown() {
 
 @test "find_versions should check \$HOME legacy files before \$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME" {
   ASDF_DEFAULT_TOOL_VERSIONS_FILENAME="$PROJECT_DIR/global-tool-versions"
-  echo "dummy 0.2.0" >$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
-  echo "dummy 0.1.0" >$HOME/.dummy-version
-  echo "legacy_version_file = yes" >$HOME/.asdfrc
+  echo "dummy 0.2.0" >"$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME"
+  echo "dummy 0.1.0" >"$HOME/.dummy-version"
+  echo "legacy_version_file = yes" >"$HOME/.asdfrc"
 
   run find_versions "dummy" $PROJECT_DIR
   [ "$status" -eq 0 ]
@@ -307,11 +307,11 @@ teardown() {
 }
 
 @test "get_executable_path for non system version should return relative path from plugin" {
-  mkdir -p $ASDF_DIR/plugins/foo
-  mkdir -p $ASDF_DIR/installs/foo/1.0.0/bin
-  executable_path=$ASDF_DIR/installs/foo/1.0.0/bin/dummy
-  touch $executable_path
-  chmod +x $executable_path
+  mkdir -p "$ASDF_DIR/plugins/foo"
+  mkdir -p "$ASDF_DIR/installs/foo/1.0.0/bin"
+  executable_path="$ASDF_DIR/installs/foo/1.0.0/bin/dummy"
+  touch "$executable_path"
+  chmod +x "$executable_path"
 
   run get_executable_path "foo" "1.0.0" "bin/dummy"
   [ "$status" -eq 0 ]
@@ -319,11 +319,11 @@ teardown() {
 }
 
 @test "get_executable_path for ref:version installed version should resolve to ref-version" {
-  mkdir -p $ASDF_DIR/plugins/foo
-  mkdir -p $ASDF_DIR/installs/foo/ref-master/bin
-  executable_path=$ASDF_DIR/installs/foo/ref-master/bin/dummy
-  touch $executable_path
-  chmod +x $executable_path
+  mkdir -p "$ASDF_DIR/plugins/foo"
+  mkdir -p "$ASDF_DIR/installs/foo/ref-master/bin"
+  executable_path="$ASDF_DIR/installs/foo/ref-master/bin/dummy"
+  touch "$executable_path"
+  chmod +x "$executable_path"
 
   run get_executable_path "foo" "ref:master" "bin/dummy"
   [ "$status" -eq 0 ]

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -11,7 +11,7 @@ setup() {
   PROJECT_DIR="$HOME/project"
   mkdir -p "$PROJECT_DIR"
 
-  cd $HOME
+  cd "$HOME"
 }
 
 teardown() {
@@ -42,7 +42,7 @@ teardown() {
   run get_download_path foo version "1.0.0"
   [ "$status" -eq 0 ]
   download_path=${output#$HOME/}
-  echo $download_path
+  echo "$download_path"
   [ "$download_path" = ".asdf/downloads/foo/1.0.0" ]
 }
 
@@ -83,15 +83,15 @@ teardown() {
 }
 
 @test "check_if_version_exists should be noop if version is system" {
-  mkdir -p $ASDF_DIR/plugins/foo
+  mkdir -p "$ASDF_DIR/plugins/foo"
   run check_if_version_exists "foo" "system"
   [ "$status" -eq 0 ]
   [ "$output" = "" ]
 }
 
 @test "check_if_version_exists should be ok for ref:version install" {
-  mkdir -p $ASDF_DIR/plugins/foo
-  mkdir -p $ASDF_DIR/installs/foo/ref-master
+  mkdir -p "$ASDF_DIR/plugins/foo"
+  mkdir -p "$ASDF_DIR/installs/foo/ref-master"
   run check_if_version_exists "foo" "ref:master"
   [ "$status" -eq 0 ]
   [ "$output" = "" ]
@@ -110,8 +110,8 @@ teardown() {
 }
 
 @test "parse_asdf_version_file should output version" {
-  echo "dummy 0.1.0" >$PROJECT_DIR/.tool-versions
-  run parse_asdf_version_file $PROJECT_DIR/.tool-versions dummy
+  echo "dummy 0.1.0" >"$PROJECT_DIR/.tool-versions"
+  run parse_asdf_version_file "$PROJECT_DIR/.tool-versions" dummy
   [ "$status" -eq 0 ]
   [ "$output" = "0.1.0" ]
 }
@@ -119,7 +119,7 @@ teardown() {
 @test "parse_asdf_version_file should output path on project with spaces" {
   PROJECT_DIR="$PROJECT_DIR/outer space"
   mkdir -p "$PROJECT_DIR"
-  cd $outer
+
   echo "dummy 0.1.0" >"$PROJECT_DIR/.tool-versions"
   run parse_asdf_version_file "$PROJECT_DIR/.tool-versions" dummy
   [ "$status" -eq 0 ]
@@ -127,24 +127,24 @@ teardown() {
 }
 
 @test "parse_asdf_version_file should output path version with spaces" {
-  echo "dummy path:/some/dummy path" >$PROJECT_DIR/.tool-versions
-  run parse_asdf_version_file $PROJECT_DIR/.tool-versions dummy
+  echo "dummy path:/some/dummy path" >"$PROJECT_DIR/.tool-versions"
+  run parse_asdf_version_file "$PROJECT_DIR/.tool-versions" dummy
   [ "$status" -eq 0 ]
   [ "$output" = "path:/some/dummy path" ]
 }
 
 @test "parse_asdf_version_file should output path version with tilda" {
-  echo "dummy path:~/some/dummy path" >$PROJECT_DIR/.tool-versions
-  run parse_asdf_version_file $PROJECT_DIR/.tool-versions dummy
+  echo "dummy path:~/some/dummy path" >"$PROJECT_DIR/.tool-versions"
+  run parse_asdf_version_file "$PROJECT_DIR/.tool-versions dummy"
   [ "$status" -eq 0 ]
   [ "$output" = "path:$HOME/some/dummy path" ]
 }
 
 @test "find_versions should return .tool-versions if legacy is disabled" {
-  echo "dummy 0.1.0" >$PROJECT_DIR/.tool-versions
-  echo "0.2.0" >$PROJECT_DIR/.dummy-version
+  echo "dummy 0.1.0" >"$PROJECT_DIR/.tool-versions"
+  echo "0.2.0" >"$PROJECT_DIR/.dummy-version"
 
-  run find_versions "dummy" $PROJECT_DIR
+  run find_versions "dummy" "$PROJECT_DIR"
   [ "$status" -eq 0 ]
   [ "$output" = "0.1.0|$PROJECT_DIR/.tool-versions" ]
 }
@@ -154,16 +154,16 @@ teardown() {
   echo "dummy 0.1.0" >"$HOME/.tool-versions"
   echo "0.2.0" >"$PROJECT_DIR/.dummy-version"
 
-  run find_versions "dummy" $PROJECT_DIR
+  run find_versions "dummy" "$PROJECT_DIR"
   [ "$status" -eq 0 ]
   [ "$output" = "0.2.0|$PROJECT_DIR/.dummy-version" ]
 }
 
 @test "find_versions skips .tool-version file that don't list the plugin" {
-  echo "dummy 0.1.0" >$HOME/.tool-versions
-  echo "another_plugin 0.3.0" >$PROJECT_DIR/.tool-versions
+  echo "dummy 0.1.0" >"$HOME/.tool-versions"
+  echo "another_plugin 0.3.0" >"$PROJECT_DIR/.tool-versions"
 
-  run find_versions "dummy" $PROJECT_DIR
+  run find_versions "dummy" "$PROJECT_DIR"
   [ "$status" -eq 0 ]
   [ "$output" = "0.1.0|$HOME/.tool-versions" ]
 }
@@ -174,7 +174,7 @@ teardown() {
   echo "legacy_version_file = yes" >"$HOME/.asdfrc"
   rm "$ASDF_DIR/plugins/dummy/bin/list-legacy-filenames"
 
-  run find_versions "dummy" $PROJECT_DIR
+  run find_versions "dummy" "$PROJECT_DIR"
   [ "$status" -eq 0 ]
   [ "$output" = "0.1.0|$HOME/.tool-versions" ]
 }
@@ -182,9 +182,9 @@ teardown() {
 @test "find_versions should return the version set by environment variable" {
   export ASDF_DUMMY_VERSION=0.2.0
 
-  run find_versions "dummy" $PROJECT_DIR
+  run find_versions "dummy" "$PROJECT_DIR"
   [ "$status" -eq 0 ]
-  echo $output
+  echo "$output"
   [ "$output" = "0.2.0|ASDF_DUMMY_VERSION environment variable" ]
 }
 
@@ -220,9 +220,9 @@ teardown() {
 
 @test "find_versions should return \$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME if set" {
   ASDF_DEFAULT_TOOL_VERSIONS_FILENAME="$PROJECT_DIR/global-tool-versions"
-  echo "dummy 0.1.0" >$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
+  echo "dummy 0.1.0" >"$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME"
 
-  run find_versions "dummy" $PROJECT_DIR
+  run find_versions "dummy" "$PROJECT_DIR"
   [ "$status" -eq 0 ]
   [ "$output" = "0.1.0|$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME" ]
 }
@@ -233,13 +233,13 @@ teardown() {
   echo "dummy 0.1.0" >"$HOME/.dummy-version"
   echo "legacy_version_file = yes" >"$HOME/.asdfrc"
 
-  run find_versions "dummy" $PROJECT_DIR
+  run find_versions "dummy" "$PROJECT_DIR"
   [ "$status" -eq 0 ]
   [[ "$output" =~ 0.1.0|"$HOME"/.dummy-version ]]
 }
 
 @test "get_preset_version_for returns the current version" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
   echo "dummy 0.2.0" >.tool-versions
   run get_preset_version_for "dummy"
   [ "$status" -eq 0 ]
@@ -247,16 +247,16 @@ teardown() {
 }
 
 @test "get_preset_version_for returns the global version from home when project is outside of home" {
-  echo "dummy 0.1.0" >$HOME/.tool-versions
+  echo "dummy 0.1.0" >"$HOME/.tool-versions"
   PROJECT_DIR=$BASE_DIR/project
-  mkdir -p $PROJECT_DIR
+  mkdir -p "$PROJECT_DIR"
   run get_preset_version_for "dummy"
   [ "$status" -eq 0 ]
   [ "$output" = "0.1.0" ]
 }
 
 @test "get_preset_version_for returns the tool version from env if ASDF_{TOOL}_VERSION is defined" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
   echo "dummy 0.2.0" >.tool-versions
   ASDF_DUMMY_VERSION=3.0.0 run get_preset_version_for "dummy"
   [ "$status" -eq 0 ]
@@ -264,40 +264,40 @@ teardown() {
 }
 
 @test "get_preset_version_for should return branch reference version" {
-  cd $PROJECT_DIR
-  echo "dummy ref:master" >$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  echo "dummy ref:master" >"$PROJECT_DIR/.tool-versions"
   run get_preset_version_for "dummy"
   [ "$status" -eq 0 ]
   [ "$output" = "ref:master" ]
 }
 
 @test "get_preset_version_for should return path version" {
-  cd $PROJECT_DIR
-  echo "dummy path:/some/place with spaces" >$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  echo "dummy path:/some/place with spaces" >"$PROJECT_DIR/.tool-versions"
   run get_preset_version_for "dummy"
   [ "$status" -eq 0 ]
   [ "$output" = "path:/some/place with spaces" ]
 }
 
 @test "get_preset_version_for should return path version with tilda" {
-  cd $PROJECT_DIR
-  echo "dummy path:~/some/place with spaces" >$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  echo "dummy path:~/some/place with spaces" >"$PROJECT_DIR/.tool-versions"
   run get_preset_version_for "dummy"
   [ "$status" -eq 0 ]
   [ "$output" = "path:$HOME/some/place with spaces" ]
 }
 
 @test "get_executable_path for system version should return system path" {
-  mkdir -p $ASDF_DIR/plugins/foo
+  mkdir -p "$ASDF_DIR/plugins/foo"
   run get_executable_path "foo" "system" "ls"
   [ "$status" -eq 0 ]
   [ "$output" = "$(which ls)" ]
 }
 
 @test "get_executable_path for system version should not use asdf shims" {
-  mkdir -p $ASDF_DIR/plugins/foo
-  touch $ASDF_DIR/shims/dummy_executable
-  chmod +x $ASDF_DIR/shims/dummy_executable
+  mkdir -p "$ASDF_DIR/plugins/foo"
+  touch "$ASDF_DIR/shims/dummy_executable"
+  chmod +x "$ASDF_DIR/shims/dummy_executable"
 
   run which dummy_executable
   [ "$status" -eq 0 ]
@@ -331,8 +331,8 @@ teardown() {
 }
 
 @test "find_tool_versions will find a .tool-versions path if it exists in current directory" {
-  echo "dummy 0.1.0" >$PROJECT_DIR/.tool-versions
-  cd $PROJECT_DIR
+  echo "dummy 0.1.0" >"$PROJECT_DIR/.tool-versions"
+  cd "$PROJECT_DIR"
 
   run find_tool_versions
   [ "$status" -eq 0 ]
@@ -340,9 +340,9 @@ teardown() {
 }
 
 @test "find_tool_versions will find a .tool-versions path if it exists in parent directory" {
-  echo "dummy 0.1.0" >$PROJECT_DIR/.tool-versions
-  mkdir -p $PROJECT_DIR/child
-  cd $PROJECT_DIR/child
+  echo "dummy 0.1.0" >"$PROJECT_DIR/.tool-versions"
+  mkdir -p "$PROJECT_DIR/child"
+  cd "$PROJECT_DIR"/child
 
   run find_tool_versions
   [ "$status" -eq 0 ]
@@ -366,7 +366,7 @@ teardown() {
 
 @test "resolve_symlink converts the symlink path to the real file path" {
   touch foo
-  ln -s $PWD/foo bar
+  ln -s "$PWD/foo" bar
 
   run resolve_symlink bar
   [ "$status" -eq 0 ]
@@ -444,17 +444,17 @@ EOF
 }
 
 @test "with_shim_executable doesn't crash when executable names contain dashes" {
-  cd $PROJECT_DIR
-  echo "dummy 0.1.0" >$PROJECT_DIR/.tool-versions
-  mkdir -p $ASDF_DIR/installs/dummy/0.1.0/bin
-  touch $ASDF_DIR/installs/dummy/0.1.0/bin/test-dash
-  chmod +x $ASDF_DIR/installs/dummy/0.1.0/bin/test-dash
+  cd "$PROJECT_DIR"
+  echo "dummy 0.1.0" >"$PROJECT_DIR/.tool-versions"
+  mkdir -p "$ASDF_DIR/installs/dummy/0.1.0/bin"
+  touch "$ASDF_DIR/installs/dummy/0.1.0/bin/test-dash"
+  chmod +x "$ASDF_DIR/installs/dummy/0.1.0/bin/test-dash"
   run asdf reshim dummy 0.1.0
 
   message="callback invoked"
 
   function callback() {
-    echo $message
+    echo "$message"
   }
 
   run with_shim_executable test-dash callback

--- a/test/version_commands.bats
+++ b/test/version_commands.bats
@@ -115,7 +115,7 @@ teardown() {
 
   run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(ls $PROJECT_DIR/.tool-versions* | wc -l)" -eq 1 ]
+  [ "$(ls "$PROJECT_DIR/.tool-versions"* | wc -l)" -eq 1 ]
 }
 
 @test "local should overwrite the existing version if it's set" {

--- a/test/version_commands.bats
+++ b/test/version_commands.bats
@@ -15,11 +15,11 @@ setup() {
   install_dummy_legacy_version "2.0.0"
   install_dummy_legacy_version "5.1.0"
 
-  PROJECT_DIR=$HOME/project
-  mkdir -p $PROJECT_DIR
+  PROJECT_DIR="$HOME/project"
+  mkdir -p "$PROJECT_DIR"
 
-  CHILD_DIR=$PROJECT_DIR/child-dir
-  mkdir -p $CHILD_DIR
+  CHILD_DIR="$PROJECT_DIR/child-dir"
+  mkdir -p "$CHILD_DIR"
 
   cd $PROJECT_DIR
 

--- a/test/version_commands.bats
+++ b/test/version_commands.bats
@@ -53,19 +53,19 @@ teardown() {
 @test "local should create a local .tool-versions file if it doesn't exist" {
   run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.1.0" ]
 }
 
 @test "[local - dummy_plugin] with latest should use the latest installed version" {
   run asdf local "dummy" "latest"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 2.0.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 2.0.0" ]
 }
 
 @test "[local - dummy_plugin] with latest:version should use the latest valid installed version" {
   run asdf local "dummy" "latest:1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.0.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.0.0" ]
 }
 
 @test "[local - dummy_plugin] with latest:version should return an error for invalid versions" {
@@ -77,13 +77,13 @@ teardown() {
 @test "[local - dummy_legacy_plugin] with latest should use the latest installed version" {
   run asdf local "legacy-dummy" "latest"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "legacy-dummy 5.1.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "legacy-dummy 5.1.0" ]
 }
 
 @test "[local - dummy_legacy_plugin] with latest:version should use the latest valid installed version" {
   run asdf local "legacy-dummy" "latest:1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "legacy-dummy 1.0.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "legacy-dummy 1.0.0" ]
 }
 
 @test "[local - dummy_legacy_plugin] with latest:version should return an error for invalid versions" {
@@ -95,7 +95,7 @@ teardown() {
 @test "local should allow multiple versions" {
   run asdf local "dummy" "1.1.0" "1.0.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0 1.0.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.1.0 1.0.0" ]
 }
 
 @test "local should create a local .tool-versions file if it doesn't exist when the directory name contains whitespace" {
@@ -123,7 +123,7 @@ teardown() {
 
   run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.1.0" ]
 }
 
 @test "local should append trailing newline before appending new version when missing" {
@@ -131,7 +131,7 @@ teardown() {
 
   run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = $'foobar 1.0.0\ndummy 1.1.0' ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = $'foobar 1.0.0\ndummy 1.1.0' ]
 }
 
 @test "local should not append trailing newline before appending new version when one present" {
@@ -139,7 +139,7 @@ teardown() {
 
   run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = $'foobar 1.0.0\ndummy 1.1.0' ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = $'foobar 1.0.0\ndummy 1.1.0' ]
 }
 
 @test "local should fail to set a path:dir if dir does not exists " {
@@ -152,7 +152,7 @@ teardown() {
   mkdir -p $PROJECT_DIR/local
   run asdf local "dummy" "path:$PROJECT_DIR/local"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy path:$PROJECT_DIR/local" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy path:$PROJECT_DIR/local" ]
 }
 
 @test "local -p/--parent should set should emit an error when called with incorrect arity" {
@@ -178,7 +178,7 @@ teardown() {
   touch $PROJECT_DIR/.tool-versions
   run asdf local -p "dummy" "1.1.0" "1.0.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0 1.0.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.1.0 1.0.0" ]
 }
 
 @test "local -p/--parent should overwrite the existing version if it's set" {
@@ -186,7 +186,7 @@ teardown() {
   echo 'dummy 1.0.0' >>$PROJECT_DIR/.tool-versions
   run asdf local -p "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.1.0" ]
 }
 
 @test "local -p/--parent should set the version if it's unset" {
@@ -194,25 +194,25 @@ teardown() {
   touch $PROJECT_DIR/.tool-versions
   run asdf local -p "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.1.0" ]
 }
 
 @test "global should create a global .tool-versions file if it doesn't exist" {
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "dummy 1.1.0" ]
+  [ "$(cat "$HOME/.tool-versions")" = "dummy 1.1.0" ]
 }
 
 @test "[global - dummy_plugin] with latest should use the latest installed version" {
   run asdf global "dummy" "latest"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "dummy 2.0.0" ]
+  [ "$(cat "$HOME/.tool-versions")" = "dummy 2.0.0" ]
 }
 
 @test "[global - dummy_plugin] with latest:version should use the latest valid installed version" {
   run asdf global "dummy" "latest:1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "dummy 1.0.0" ]
+  [ "$(cat "$HOME/.tool-versions")" = "dummy 1.0.0" ]
 }
 
 @test "[global - dummy_plugin] with latest:version should return an error for invalid versions" {
@@ -224,13 +224,13 @@ teardown() {
 @test "[global - dummy_legacy_plugin] with latest should use the latest installed version" {
   run asdf global "legacy-dummy" "latest"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "legacy-dummy 5.1.0" ]
+  [ "$(cat "$HOME/.tool-versions")" = "legacy-dummy 5.1.0" ]
 }
 
 @test "[global - dummy_legacy_plugin] with latest:version should use the latest valid installed version" {
   run asdf global "legacy-dummy" "latest:1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "legacy-dummy 1.0.0" ]
+  [ "$(cat "$HOME/.tool-versions")" = "legacy-dummy 1.0.0" ]
 }
 
 @test "[global - dummy_legacy_plugin] with latest:version should return an error for invalid versions" {
@@ -242,14 +242,14 @@ teardown() {
 @test "global should accept multiple versions" {
   run asdf global "dummy" "1.1.0" "1.0.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "dummy 1.1.0 1.0.0" ]
+  [ "$(cat "$HOME/.tool-versions")" = "dummy 1.1.0 1.0.0" ]
 }
 
 @test "global should overwrite the existing version if it's set" {
   echo 'dummy 1.0.0' >>$HOME/.tool-versions
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "dummy 1.1.0" ]
+  [ "$(cat "$HOME/.tool-versions")" = "dummy 1.1.0" ]
 }
 
 @test "global should append trailing newline before appending new version when missing" {
@@ -257,7 +257,7 @@ teardown() {
 
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = $'foobar 1.0.0\ndummy 1.1.0' ]
+  [ "$(cat "$HOME/.tool-versions")" = $'foobar 1.0.0\ndummy 1.1.0' ]
 }
 
 @test "global should not append trailing newline before appending new version when one present" {
@@ -265,7 +265,7 @@ teardown() {
 
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = $'foobar 1.0.0\ndummy 1.1.0' ]
+  [ "$(cat "$HOME/.tool-versions")" = $'foobar 1.0.0\ndummy 1.1.0' ]
 }
 
 @test "global should fail to set a path:dir if dir does not exists " {
@@ -278,15 +278,15 @@ teardown() {
   mkdir -p $PROJECT_DIR/local
   run asdf global "dummy" "path:$PROJECT_DIR/local"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "dummy path:$PROJECT_DIR/local" ]
+  [ "$(cat "$HOME/.tool-versions")" = "dummy path:$PROJECT_DIR/local" ]
 }
 
 @test "local should write to ASDF_DEFAULT_TOOL_VERSIONS_FILENAME" {
   export ASDF_DEFAULT_TOOL_VERSIONS_FILENAME="local-tool-versions"
   run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $ASDF_DEFAULT_TOOL_VERSIONS_FILENAME)" = "dummy 1.1.0" ]
-  [ "$(cat .tool-versions)" = "" ]
+  [ "$(cat "$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME")" = "dummy 1.1.0" ]
+  [ -z "$(cat .tool-versions)" ]
   unset ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
 }
 
@@ -295,8 +295,8 @@ teardown() {
   echo 'dummy 1.0.0' >>"$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME"
   run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $ASDF_DEFAULT_TOOL_VERSIONS_FILENAME)" = "dummy 1.1.0" ]
-  [ "$(cat .tool-versions)" = "" ]
+  [ "$(cat "$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME")" = "dummy 1.1.0" ]
+  [ -z "$(cat .tool-versions)" ]
   unset ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
 }
 
@@ -304,8 +304,8 @@ teardown() {
   export ASDF_DEFAULT_TOOL_VERSIONS_FILENAME="global-tool-versions"
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME)" = "dummy 1.1.0" ]
-  [ "$(cat $HOME/.tool-versions)" = "" ]
+  [ "$(cat "$HOME/$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME")" = "dummy 1.1.0" ]
+  [ -z "$(cat "$HOME/.tool-versions")" ]
   unset ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
 }
 
@@ -314,8 +314,8 @@ teardown() {
   echo 'dummy 1.0.0' >>"$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME"
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME)" = "dummy 1.1.0" ]
-  [ "$(cat $HOME/.tool-versions)" = "" ]
+  [ "$(cat "$HOME/$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME")" = "dummy 1.1.0" ]
+  [ -z "$(cat "$HOME/.tool-versions")" ]
   unset ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
 }
 
@@ -347,8 +347,8 @@ teardown() {
 
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ -L $HOME/.tool-versions ]
-  [ "$(cat $HOME/other-dir/.tool-versions)" = "dummy 1.1.0" ]
+  [ -L "$HOME/.tool-versions" ]
+  [ "$(cat "$HOME/other-dir/.tool-versions")" = "dummy 1.1.0" ]
 }
 
 @test "global should preserve symlinks when updating versions" {
@@ -359,28 +359,28 @@ teardown() {
   run asdf global "dummy" "1.1.0"
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ -L $HOME/.tool-versions ]
-  [ "$(cat $HOME/other-dir/.tool-versions)" = "dummy 1.1.0" ]
+  [ -L "$HOME/.tool-versions" ]
+  [ "$(cat "$HOME/other-dir/.tool-versions")" = "dummy 1.1.0" ]
 }
 
 @test "shell wrapper function should export ENV var" {
-  . $(dirname "$BATS_TEST_DIRNAME")/asdf.sh
+  . "$(dirname "$BATS_TEST_DIRNAME")/asdf.sh"
   asdf shell "dummy" "1.1.0"
-  [ $(echo $ASDF_DUMMY_VERSION) = "1.1.0" ]
+  [ "$(echo "$ASDF_DUMMY_VERSION")" = "1.1.0" ]
   unset ASDF_DUMMY_VERSION
 }
 
 @test "shell wrapper function with --unset should unset ENV var" {
-  . $(dirname "$BATS_TEST_DIRNAME")/asdf.sh
+  . "$(dirname "$BATS_TEST_DIRNAME")/asdf.sh"
   asdf shell "dummy" "1.1.0"
-  [ $(echo $ASDF_DUMMY_VERSION) = "1.1.0" ]
+  [ "$(echo "$ASDF_DUMMY_VERSION")" = "1.1.0" ]
   asdf shell "dummy" --unset
-  [ -z "$(echo $ASDF_DUMMY_VERSION)" ]
+  [ -z "$(echo "$ASDF_DUMMY_VERSION")" ]
   unset ASDF_DUMMY_VERSION
 }
 
 @test "shell wrapper function should return an error for missing plugins" {
-  . $(dirname "$BATS_TEST_DIRNAME")/asdf.sh
+  . "$(dirname "$BATS_TEST_DIRNAME")/asdf.sh"
   expected="No such plugin: nonexistent
 version 1.0.0 is not installed for nonexistent"
 
@@ -451,16 +451,16 @@ false"
 }
 
 @test "[shell - dummy_plugin] wrapper function should support latest" {
-  . $(dirname "$BATS_TEST_DIRNAME")/asdf.sh
+  . "$(dirname "$BATS_TEST_DIRNAME")/asdf.sh"
   asdf shell "dummy" "latest"
-  [ $(echo $ASDF_DUMMY_VERSION) = "2.0.0" ]
+  [ "$(echo "$ASDF_DUMMY_VERSION")" = "2.0.0" ]
   unset ASDF_DUMMY_VERSION
 }
 
 @test "[shell - dummy_legacy_plugin] wrapper function should support latest" {
-  . $(dirname "$BATS_TEST_DIRNAME")/asdf.sh
+  . "$(dirname "$BATS_TEST_DIRNAME")/asdf.sh"
   asdf shell "legacy-dummy" "latest"
-  [ $(echo $ASDF_LEGACY_DUMMY_VERSION) = "5.1.0" ]
+  [ "$(echo "$ASDF_LEGACY_DUMMY_VERSION")" = "5.1.0" ]
   unset ASDF_LEGACY_DUMMY_VERSION
 }
 
@@ -468,26 +468,26 @@ false"
   echo 'dummy 1.0.0' >>$HOME/.tool-versions
   run asdf global "dummy" "1.0.0" "latest"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "dummy 1.0.0 2.0.0" ]
+  [ "$(cat "$HOME/.tool-versions")" = "dummy 1.0.0 2.0.0" ]
 }
 
 @test "[global - dummy_legacy_plugin] should support latest" {
   echo 'legacy-dummy 1.0.0' >>$HOME/.tool-versions
   run asdf global "legacy-dummy" "1.0.0" "latest"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "legacy-dummy 1.0.0 5.1.0" ]
+  [ "$(cat "$HOME/.tool-versions")" = "legacy-dummy 1.0.0 5.1.0" ]
 }
 
 @test "[local - dummy_plugin] should support latest" {
   echo 'dummy 1.0.0' >>$PROJECT_DIR/.tool-versions
   run asdf local "dummy" "1.0.0" "latest"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.0.0 2.0.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.0.0 2.0.0" ]
 }
 
 @test "[local - dummy_legacy_plugin] should support latest" {
   echo 'legacy-dummy 1.0.0' >>$PROJECT_DIR/.tool-versions
   run asdf local "legacy-dummy" "1.0.0" "latest"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "legacy-dummy 1.0.0 5.1.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "legacy-dummy 1.0.0 5.1.0" ]
 }

--- a/test/version_commands.bats
+++ b/test/version_commands.bats
@@ -21,10 +21,10 @@ setup() {
   CHILD_DIR="$PROJECT_DIR/child-dir"
   mkdir -p "$CHILD_DIR"
 
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
 
   # asdf lib needed to run asdf.sh
-  cp -rf $BATS_TEST_DIRNAME/../{bin,lib} $ASDF_DIR/
+  cp -rf $BATS_TEST_DIRNAME/../{bin,lib} "$ASDF_DIR/"
 }
 
 teardown() {
@@ -111,7 +111,7 @@ teardown() {
 }
 
 @test "local should not create a duplicate .tool-versions file if such file exists" {
-  echo 'dummy 1.0.0' >>$PROJECT_DIR/.tool-versions
+  echo 'dummy 1.0.0' >>"$PROJECT_DIR/.tool-versions"
 
   run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
@@ -119,7 +119,7 @@ teardown() {
 }
 
 @test "local should overwrite the existing version if it's set" {
-  echo 'dummy 1.0.0' >>$PROJECT_DIR/.tool-versions
+  echo 'dummy 1.0.0' >>"$PROJECT_DIR/.tool-versions"
 
   run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
@@ -127,7 +127,7 @@ teardown() {
 }
 
 @test "local should append trailing newline before appending new version when missing" {
-  echo -n 'foobar 1.0.0' >>$PROJECT_DIR/.tool-versions
+  echo -n 'foobar 1.0.0' >>"$PROJECT_DIR/.tool-versions"
 
   run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
@@ -135,7 +135,7 @@ teardown() {
 }
 
 @test "local should not append trailing newline before appending new version when one present" {
-  echo 'foobar 1.0.0' >>$PROJECT_DIR/.tool-versions
+  echo 'foobar 1.0.0' >>"$PROJECT_DIR/.tool-versions"
 
   run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
@@ -149,7 +149,7 @@ teardown() {
 }
 
 @test "local should set a path:dir if dir exists " {
-  mkdir -p $PROJECT_DIR/local
+  mkdir -p "$PROJECT_DIR/local"
   run asdf local "dummy" "path:$PROJECT_DIR/local"
   [ "$status" -eq 0 ]
   [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy path:$PROJECT_DIR/local" ]
@@ -174,24 +174,24 @@ teardown() {
 }
 
 @test "local -p/--parent should allow multiple versions" {
-  cd $CHILD_DIR
-  touch $PROJECT_DIR/.tool-versions
+  cd "$CHILD_DIR"
+  touch "$PROJECT_DIR/.tool-versions"
   run asdf local -p "dummy" "1.1.0" "1.0.0"
   [ "$status" -eq 0 ]
   [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.1.0 1.0.0" ]
 }
 
 @test "local -p/--parent should overwrite the existing version if it's set" {
-  cd $CHILD_DIR
-  echo 'dummy 1.0.0' >>$PROJECT_DIR/.tool-versions
+  cd "$CHILD_DIR"
+  echo 'dummy 1.0.0' >>"$PROJECT_DIR/.tool-versions"
   run asdf local -p "dummy" "1.1.0"
   [ "$status" -eq 0 ]
   [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.1.0" ]
 }
 
 @test "local -p/--parent should set the version if it's unset" {
-  cd $CHILD_DIR
-  touch $PROJECT_DIR/.tool-versions
+  cd "$CHILD_DIR"
+  touch "$PROJECT_DIR/.tool-versions"
   run asdf local -p "dummy" "1.1.0"
   [ "$status" -eq 0 ]
   [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.1.0" ]
@@ -246,14 +246,14 @@ teardown() {
 }
 
 @test "global should overwrite the existing version if it's set" {
-  echo 'dummy 1.0.0' >>$HOME/.tool-versions
+  echo 'dummy 1.0.0' >>"$HOME/.tool-versions"
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
   [ "$(cat "$HOME/.tool-versions")" = "dummy 1.1.0" ]
 }
 
 @test "global should append trailing newline before appending new version when missing" {
-  echo -n 'foobar 1.0.0' >>$HOME/.tool-versions
+  echo -n 'foobar 1.0.0' >>"$HOME/.tool-versions"
 
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
@@ -261,7 +261,7 @@ teardown() {
 }
 
 @test "global should not append trailing newline before appending new version when one present" {
-  echo 'foobar 1.0.0' >>$HOME/.tool-versions
+  echo 'foobar 1.0.0' >>"$HOME/.tool-versions"
 
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
@@ -275,7 +275,7 @@ teardown() {
 }
 
 @test "global should set a path:dir if dir exists " {
-  mkdir -p $PROJECT_DIR/local
+  mkdir -p "$PROJECT_DIR/local"
   run asdf global "dummy" "path:$PROJECT_DIR/local"
   [ "$status" -eq 0 ]
   [ "$(cat "$HOME/.tool-versions")" = "dummy path:$PROJECT_DIR/local" ]
@@ -341,9 +341,9 @@ teardown() {
 }
 
 @test "global should preserve symlinks when setting versions" {
-  mkdir $HOME/other-dir
-  touch $HOME/other-dir/.tool-versions
-  ln -s other-dir/.tool-versions $HOME/.tool-versions
+  mkdir "$HOME/other-dir"
+  touch "$HOME/other-dir"
+  ln -s other-dir/.tool-versions "$HOME/.tool-versions"
 
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
@@ -352,9 +352,9 @@ teardown() {
 }
 
 @test "global should preserve symlinks when updating versions" {
-  mkdir $HOME/other-dir
-  touch $HOME/other-dir/.tool-versions
-  ln -s other-dir/.tool-versions $HOME/.tool-versions
+  mkdir "$HOME/other-dir"
+  touch "$HOME/other-dir"
+  ln -s other-dir/.tool-versions "$HOME/.tool-versions"
 
   run asdf global "dummy" "1.1.0"
   run asdf global "dummy" "1.1.0"
@@ -465,28 +465,28 @@ false"
 }
 
 @test "[global - dummy_plugin] should support latest" {
-  echo 'dummy 1.0.0' >>$HOME/.tool-versions
+  echo 'dummy 1.0.0' >>"$HOME/.tool-versions"
   run asdf global "dummy" "1.0.0" "latest"
   [ "$status" -eq 0 ]
   [ "$(cat "$HOME/.tool-versions")" = "dummy 1.0.0 2.0.0" ]
 }
 
 @test "[global - dummy_legacy_plugin] should support latest" {
-  echo 'legacy-dummy 1.0.0' >>$HOME/.tool-versions
+  echo 'legacy-dummy 1.0.0' >>"$HOME/.tool-versions"
   run asdf global "legacy-dummy" "1.0.0" "latest"
   [ "$status" -eq 0 ]
   [ "$(cat "$HOME/.tool-versions")" = "legacy-dummy 1.0.0 5.1.0" ]
 }
 
 @test "[local - dummy_plugin] should support latest" {
-  echo 'dummy 1.0.0' >>$PROJECT_DIR/.tool-versions
+  echo 'dummy 1.0.0' >>"$PROJECT_DIR/.tool-versions"
   run asdf local "dummy" "1.0.0" "latest"
   [ "$status" -eq 0 ]
   [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.0.0 2.0.0" ]
 }
 
 @test "[local - dummy_legacy_plugin] should support latest" {
-  echo 'legacy-dummy 1.0.0' >>$PROJECT_DIR/.tool-versions
+  echo 'legacy-dummy 1.0.0' >>"$PROJECT_DIR/.tool-versions"
   run asdf local "legacy-dummy" "1.0.0" "latest"
   [ "$status" -eq 0 ]
   [ "$(cat "$PROJECT_DIR/.tool-versions")" = "legacy-dummy 1.0.0 5.1.0" ]

--- a/test/where_command.bats
+++ b/test/where_command.bats
@@ -27,7 +27,7 @@ function teardown() {
 }
 
 @test "where shows install location of current version if no version specified" {
-  echo 'dummy 2.1' >>$HOME/.tool-versions
+  echo 'dummy 2.1' >>"$HOME/.tool-versions"
 
   run asdf where 'dummy'
 
@@ -36,7 +36,7 @@ function teardown() {
 }
 
 @test "where shows install location of first current version if not version specified and multiple current versions" {
-  echo 'dummy 2.1 1.0' >>$HOME/.tool-versions
+  echo 'dummy 2.1 1.0' >>"$HOME/.tool-versions"
   run asdf where 'dummy'
   [ "$status" -eq 0 ]
   [ "$output" = "$ASDF_DIR/installs/dummy/2.1" ]

--- a/test/which_command.bats
+++ b/test/which_command.bats
@@ -8,9 +8,9 @@ setup() {
   run asdf install dummy 1.0
   run asdf install dummy 1.1
 
-  PROJECT_DIR=$HOME/project
-  mkdir $PROJECT_DIR
-  echo 'dummy 1.0' >>$PROJECT_DIR/.tool-versions
+  PROJECT_DIR="$HOME/project"
+  mkdir -p "$PROJECT_DIR"
+  echo 'dummy 1.0' >>"$PROJECT_DIR/.tool-versions"
 }
 
 teardown() {
@@ -53,7 +53,7 @@ teardown() {
   touch $PROJECT_DIR/sys/dummy
   chmod +x $PROJECT_DIR/sys/dummy
 
-  run env PATH=$PATH:$PROJECT_DIR/sys asdf which "dummy"
+  run env "PATH=$PATH:$PROJECT_DIR/sys" asdf which "dummy"
   [ "$status" -eq 0 ]
   [ "$output" = "$PROJECT_DIR/sys/dummy" ]
 }
@@ -87,10 +87,10 @@ teardown() {
 @test "which should return the path set by the legacy file" {
   cd $PROJECT_DIR
 
-  echo 'dummy 1.0' >>$HOME/.tool-versions
-  echo '1.1' >>$PROJECT_DIR/.dummy-version
-  rm $PROJECT_DIR/.tool-versions
-  echo 'legacy_version_file = yes' >$HOME/.asdfrc
+  echo 'dummy 1.0' >>"$HOME/.tool-versions"
+  echo '1.1' >>"$PROJECT_DIR/.dummy-version"
+  rm "$PROJECT_DIR/.tool-versions"
+  echo 'legacy_version_file = yes' >"$HOME/.asdfrc"
 
   run asdf which "dummy"
   [ "$status" -eq 0 ]
@@ -102,7 +102,7 @@ teardown() {
   echo 'dummy 1.0' >$PROJECT_DIR/.tool-versions
   rm "$ASDF_DIR/installs/dummy/1.0/bin/dummy"
 
-  run env PATH=$PATH:$ASDF_DIR/shims asdf which dummy
+  run env PATH="$PATH:$ASDF_DIR/shims" asdf which dummy
   [ "$status" -eq 1 ]
   [ "$output" = "No dummy executable found for dummy 1.0" ]
 }

--- a/test/which_command.bats
+++ b/test/which_command.bats
@@ -18,7 +18,7 @@ teardown() {
 }
 
 @test "which should show dummy 1.0 main binary" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
 
   run asdf which "dummy"
   [ "$status" -eq 0 ]
@@ -26,7 +26,7 @@ teardown() {
 }
 
 @test "which should fail for unknown binary" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
 
   run asdf which "sunny"
   [ "$status" -eq 1 ]
@@ -34,7 +34,7 @@ teardown() {
 }
 
 @test "which should show dummy 1.0 other binary" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
 
   echo "echo bin bin/subdir" >"$ASDF_DIR/plugins/dummy/bin/list-bin-paths"
   chmod +x "$ASDF_DIR/plugins/dummy/bin/list-bin-paths"
@@ -46,12 +46,12 @@ teardown() {
 }
 
 @test "which should show path of system version" {
-  echo 'dummy system' >$PROJECT_DIR/.tool-versions
-  cd $PROJECT_DIR
+  echo 'dummy system' >"$PROJECT_DIR/.tool-versions"
+  cd "$PROJECT_DIR"
 
-  mkdir $PROJECT_DIR/sys
-  touch $PROJECT_DIR/sys/dummy
-  chmod +x $PROJECT_DIR/sys/dummy
+  mkdir "$PROJECT_DIR/sys"
+  touch "$PROJECT_DIR/sys/dummy"
+  chmod +x "$PROJECT_DIR/sys/dummy"
 
   run env "PATH=$PATH:$PROJECT_DIR/sys" asdf which "dummy"
   [ "$status" -eq 0 ]
@@ -59,8 +59,8 @@ teardown() {
 }
 
 @test "which report when missing executable on system version" {
-  echo 'dummy system' >$PROJECT_DIR/.tool-versions
-  cd $PROJECT_DIR
+  echo 'dummy system' >"$PROJECT_DIR/.tool-versions"
+  cd "$PROJECT_DIR"
 
   run asdf which "dummy"
   [ "$status" -eq 1 ]
@@ -68,7 +68,7 @@ teardown() {
 }
 
 @test "which should inform when no binary is found" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
 
   run asdf which "bazbat"
   [ "$status" -eq 1 ]
@@ -76,7 +76,7 @@ teardown() {
 }
 
 @test "which should use path returned by exec-path when present" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
   install_dummy_exec_path_script "dummy"
 
   run asdf which "dummy"
@@ -85,7 +85,7 @@ teardown() {
 }
 
 @test "which should return the path set by the legacy file" {
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR"
 
   echo 'dummy 1.0' >>"$HOME/.tool-versions"
   echo '1.1' >>"$PROJECT_DIR/.dummy-version"
@@ -98,8 +98,8 @@ teardown() {
 }
 
 @test "which should not return shim path" {
-  cd $PROJECT_DIR
-  echo 'dummy 1.0' >$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  echo 'dummy 1.0' >"$PROJECT_DIR/.tool-versions"
   rm "$ASDF_DIR/installs/dummy/1.0/bin/dummy"
 
   run env PATH="$PATH:$ASDF_DIR/shims" asdf which dummy


### PR DESCRIPTION
# Summary

The PR is broken into two parts. The first part includes all the hunks that contain a `(`, `)`, `[`. (sort of like `git diff -U0 | grepdiff -E '[()[]' --output-matching=hunk | git apply --cached --unidiff-zero`)

Commit 2 is only supposed to contain changes with `"`. But it looks like the separation isn't exact

Partially addresses #1396. It doesn't fix the probably completely since the test has been reenabled only to `warning` (info lints are ignored)

