### PR TITLE
chore: fix ShellCheck errors in tests

### DIFF
--- a/test/asdf_elvish.bats
+++ b/test/asdf_elvish.bats
@@ -3,16 +3,17 @@
 load test_helpers
 
 setup() {
-  export XDG_CONFIG_HOME= XDG_DATA_HOME= XDG_DATA_DIRS=
+  export XDG_CONFIG_HOME=
+  export XDG_DATA_HOME=
+  export XDG_DATA_DIRS=
 
-  local version=
-  version=$(elvish -version)
+  local ver_major=
+  local ver_minor=
+  local ver_patch=
+  IFS='.' read -r ver_major ver_minor ver_patch <<<"$(elvish -version)"
 
-  local ver_major= ver_minor= ver_patch=
-  IFS='.' read -r ver_major ver_minor ver_patch <<<"$version"
-
-  if ((ver_major == 0 && ver_minor <= 17)); then
-    skip "Elvish version is not at least 0.17"
+  if ((ver_major == 0 && ver_minor < 18)); then
+    skip "Elvish version is not at least 0.18. Found ${ver_major}.${ver_minor}.${ver_patch}"
   fi
 }
 

--- a/test/current_command.bats
+++ b/test/current_command.bats
@@ -134,8 +134,8 @@ foobar          1.0.0           $PROJECT_DIR/.tool-versions"
 }
 
 @test "current should handle comments" {
-  cd $PROJECT_DIR
-  echo "dummy 1.2.0  # this is a comment" >>$PROJECT_DIR/.tool-versions
+  cd "$PROJECT_DIR"
+  echo "dummy 1.2.0  # this is a comment" >>"$PROJECT_DIR/.tool-versions"
   expected="dummy           1.2.0           $PROJECT_DIR/.tool-versions"
 
   run asdf current "dummy"

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -95,7 +95,7 @@ teardown() {
   run grep "asdf-plugin: dummy 1.0.0" $ASDF_DIR/shims/dummy
   [ "$status" -eq 0 ]
 
-  run grep "# asdf-plugin: dummy 1.0.0"$'\n'"# asdf-plugin: dummy 1.1.0" $ASDF_DIR/shims/dummy
+  run grep "# asdf-plugin: dummy 1.0.0"$'\n'"# asdf-plugin: dummy 1.1.0" "$ASDF_DIR/shims/dummy"
   [ "$status" -eq 0 ]
 
   lines_count=$(grep "asdf-plugin: dummy 1.1.0" $ASDF_DIR/shims/dummy | wc -l)

--- a/test/remove_command.bats
+++ b/test/remove_command.bats
@@ -57,7 +57,7 @@ teardown() {
   run asdf install dummy 1.0
 
   # make an unrelated shim
-  echo "# asdf-plugin: gummy" >$ASDF_DIR/shims/gummy
+  echo "# asdf-plugin: gummy" >"$ASDF_DIR/shims/gummy"
 
   run asdf plugin-remove dummy
   [ "$status" -eq 0 ]

--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -394,8 +394,8 @@ teardown() {
 
   exec_path="$ASDF_DIR/plugins/dummy/bin/exec-path"
 
-  echo 'echo $3 # always same path' >$exec_path
-  chmod +x $exec_path
+  echo 'echo $3 # always same path' >"$exec_path"
+  chmod +x "$exec_path"
 
   echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
 

--- a/test/version_commands.bats
+++ b/test/version_commands.bats
@@ -115,7 +115,7 @@ teardown() {
 
   run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(ls $PROJECT_DIR/.tool-versions* | wc -l)" -eq 1 ]
+  [ "$(ls "$PROJECT_DIR/.tool-versions"* | wc -l)" -eq 1 ]
 }
 
 @test "local should overwrite the existing version if it's set" {


### PR DESCRIPTION
# Summary

This PR is the **first** of a [multi-part series](https://github.com/asdf-vm/asdf/compare/master...hyperupcall:asdf:shellcheck-tests) that fixes various issues with the tests. I broke this change up as to be easier to review, and it seemed similar to #1349, in which different PRs were preferred over a single larger one.

Here is a description of each commit/part:

- ~~Parts 1-5 are quite trivial and fix up obvious mistakes like quoting.~~
- Parts 1 does a few miscellaneous fixes
- Parts 2-5 are quite trivial and fix up obvious mistakes like quoting.
- Part 6 has the first non-obvious changes that remove use of `$?` by using the `run` function provided by Bats 
- Part 7 fixes all errors and warnings shown by Bats. The significant code change is that some regex comparison were changed to glob comparisons.
- Part 8 enables ShellCheck for warnings and errors
- Part 9 (the last commit) Fixes all infos, and enables ShellCheck to lint infos as well

At the end of the commit series, some lints were disabled:
- Codes [SC2031](https://www.shellcheck.net/wiki/SC2030) and [SC2030](https://www.shellcheck.net/wiki/SC2031), and [SC2164](https://www.shellcheck.net/wiki/SC2164) were disabled as being false positives, due to the Bats environment taking care of that for us.
- [SC2012](https://www.shellcheck.net/wiki/SC2012) was also disabled at the top of `test/reshim_command.bats` since I wanted to be sure not to break any tests and the conversion to `find` isn't as trivial as the other fixes - it can be fixed later.

Partially addresses #1396
