### PR TITLE
fix!: remove `use_release_candidate` option

### DIFF
--- a/defaults
+++ b/defaults
@@ -1,7 +1,6 @@
 # See the docs for explanations: https://asdf-vm.com/manage/configuration.html
 
 legacy_version_file = no
-use_release_candidates = no
 always_keep_download = no
 plugin_repository_last_check_duration = 60
 disable_plugin_short_name_repository = no

--- a/docs/manage/configuration.md
+++ b/docs/manage/configuration.md
@@ -69,15 +69,6 @@ Plugins **with support** can read the versions files used by other version manag
 | `no` <Badge type="tip" text="default" vertical="middle" /> | Use `.tool-versions` to read versions                                      |
 | `yes`                                                      | Use plugin fallback to legacy version files (`.ruby-version`) if available |
 
-### `use_release_candidates`
-
-Configure the `asdf update` command to upgrade to the latest Release Candidate instead of the latest Semantic Version.
-
-| Options                                                    | Description               |
-| :--------------------------------------------------------- | :------------------------ |
-| `no` <Badge type="tip" text="default" vertical="middle" /> | Semantic Version is used  |
-| `yes`                                                      | Release Candidate is used |
-
 ### `always_keep_download`
 
 Configure the `asdf install` command to keep or delete the source code or binary it downloads.

--- a/docs/pt-br/manage/configuration.md
+++ b/docs/pt-br/manage/configuration.md
@@ -48,7 +48,6 @@ legacy_version_file = yes
 **Configurações**
 
 - `legacy_version_file` - por padrão é `no`. Se definido como `yes`, fará com que os plug-ins que suportam esse recurso leiam os arquivos de versão usados por outros gerenciadores de versão (por exemplo, `.ruby-version` no caso do `rbenv` do Ruby).
-- `use_release_candidates` - por padrão é `no`. Se definido como `yes`, fará com que o comando `asdf update` atualize para o mais recente em vez da versão semântica mais recente.
 
 - `always_keep_download` - por padrão é `no`. Se definido como `yes`, fará com que o `asdf install` sempre mantenha o código-fonte ou binário baixado. Se definido como `no`, o código fonte ou binário baixado por `asdf install` será excluído após a instalação bem sucedida.
 

--- a/docs/zh-hans/manage/configuration.md
+++ b/docs/zh-hans/manage/configuration.md
@@ -54,7 +54,6 @@ python 3.7.2 2.7.15 system
 
 ```:no-line-numbers
 legacy_version_file = no
-use_release_candidates = no
 always_keep_download = no
 plugin_repository_last_check_duration = 60
 ```
@@ -67,15 +66,6 @@ plugin_repository_last_check_duration = 60
 | :------------------------------------------------------ | :------------------------------------------------------- |
 | `no` <Badge type="tip" text="默认" vertical="middle" /> | 从 `.tool-versions` 文件读取版本                         |
 | `yes`                                                   | 如果可行的话，从传统版本文件读取版本（`.ruby-versions`） |
-
-### `use_release_candidates`
-
-配置 `asdf update` 命令以升级到最新的候选版本，而不是最新的语义版本。
-
-| 选项                                                    | 描述           |
-| :------------------------------------------------------ | :------------- |
-| `no` <Badge type="tip" text="默认" vertical="middle" /> | 语义版本被使用 |
-| `yes`                                                   | 候选版本被使用 |
 
 ### `always_keep_download`
 

--- a/lib/commands/command-update.bash
+++ b/lib/commands/command-update.bash
@@ -26,26 +26,19 @@ do_update() {
     printf "Updated asdf to latest on the master branch\n"
   else
     # Update to latest release
+    local sha_of_tag
+    local tag
+
+    # fetch tags from remote
     git fetch origin --tags || exit 1
 
-    if [ "$(get_asdf_config_value "use_release_candidates")" = "yes" ]; then
-      # Use the latest tag whether or not it is an RC
-      tag=$(git tag | sort_versions | sed '$!d') || exit 1
-    else
-      # Exclude RC tags when selecting latest tag
-      tag=$(git tag | sort_versions | grep -vi "rc" | sed '$!d') || exit 1
-    fi
+    sha_of_tag=$(git rev-list --tags --max-count=1) || exit 1
+    tag=$(git describe --tags "$sha_of_tag") || exit 1
 
     # Update
     git checkout "$tag" || exit 1
     printf "Updated asdf to release %s\n" "$tag"
   fi
-}
-
-# stolen from https://github.com/rbenv/ruby-build/pull/631/files#diff-fdcfb8a18714b33b07529b7d02b54f1dR942
-sort_versions() {
-  sed 'h; s/[+-]/./g; s/.p\([[:digit:]]\)/.z\1/; s/$/.z/; G; s/\n/ /' |
-    LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
 update_command "$@"


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

Now we are using [release-please](https://github.com/google-github-actions/release-please-action) & GitHub Releases to manage our changelog generation and release pipeline we're no longer using release candidates (as they were originally intended) with asdf core.

People who wish to test the latest code should use `HEAD` via `asdf update --head`.

If `HEAD` is too unstable for people and they want an RC equivalent, then we have two options:

1. we can implement `asdf update <sha>`
2. we can recommend users `cd` to asdf installation and perform a manual `git checkout <sha>`

Given no users have raised missing the RC I feel we are safe to go with option 2 here. We can add `asdf update <sha>` in future if it becomes necessary to do so.

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->

This also removes `sort_versions` from the repository 🎉 

Related:
- https://github.com/asdf-vm/asdf/issues/1428 - we were discussing removing `sort_versions` which this PR does

Fixes #1515