### PR TITLE
ci: only test on latest GitHub Runners

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,14 +11,8 @@ env:
   NUSHELL_VERSION: 0.73.0
 
 jobs:
-  nix:
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - macos-latest
-          - ubuntu-latest
-    runs-on: ${{ matrix.os }}
+  ubuntu:
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -26,11 +20,6 @@ jobs:
           fetch-depth: 0
 
       - name: Install test dependencies
-        if: runner.os == 'macos'
-        run: brew install coreutils fish elvish nushell
-
-      - name: Install test dependencies
-        if: runner.os == 'linux'
         run: |
           sudo add-apt-repository -y ppa:fish-shell/nightly-master
           sudo apt-get update
@@ -53,6 +42,27 @@ jobs:
 
           # Add $HOME/bin to path
           echo "$HOME/bin" >>"$GITHUB_PATH"
+
+      - name: Install bats
+        run: |
+          git clone --depth 1 --branch "v$(grep -Eo "^\\s*bats\\s*.*$" ".tool-versions" | cut -d ' ' -f2-)" https://github.com/bats-core/bats-core.git $HOME/bats-core
+          echo "$HOME/bats-core/bin" >>"$GITHUB_PATH"
+
+      - name: Run tests
+        run: bats test
+        env:
+          GITHUB_API_TOKEN: ${{ github.token }}
+          
+  macos:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install test dependencies
+        run: brew install coreutils fish elvish nushell
 
       - name: Install bats
         run: |


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

GitHub have deprecated the macOS 10.15 runner.

https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/

I am not sure of the value we're getting here. I originally wanted to execute our tests on each version of a Runner just to be certain about what we support, but it is clear, given GitHubs eager deprecation of macOS 15.10 that it is largely pointless and just wasteful of general resources and our time (on small PRs).

Related:
- https://github.com/asdf-vm/asdf/pull/1420

Performance of macOS Runner is still very poor:
- https://github.com/actions/runner-images/issues/1336
- https://github.com/actions/runner-images/issues/2247
- https://github.com/actions/runner-images/issues/2707
- https://github.com/actions/runner-images/issues/3885

Our `macos` jobs consistently take 100%-300% more time to complete than `ubuntu` 

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->

GitHub should provide an option for Runners which executes on all current supported runners so as they deprecate our pipelines change, `ubuntu-all` & `macos-all` 🤔 Immutability of that is probably bad.