### PR TITLE
chore: Fix ShellCheck errors in tests

### DIFF
--- a/test/get_asdf_config_value.bats
+++ b/test/get_asdf_config_value.bats
@@ -31,12 +31,12 @@ teardown() {
 }
 
 @test "get_config returns default value when the key does not exist" {
-  [ $(get_asdf_config_value "key2") = "value2" ]
+  [ "$(get_asdf_config_value "key2")" = "value2" ]
 }
 
 @test "get_config returns config file value when key exists" {
-  [ $(get_asdf_config_value "key1") = "value1" ]
-  [ $(get_asdf_config_value "legacy_version_file") = "yes" ]
+  [ "$(get_asdf_config_value "key1")" = "value1" ]
+  [ "$(get_asdf_config_value "legacy_version_file")" = "yes" ]
 }
 
 @test "get_config returns config file complete value including '=' symbols" {
@@ -44,5 +44,5 @@ teardown() {
 key3 = VAR=val
 EOM
 
-  [ $(get_asdf_config_value "key3") = "VAR=val" ]
+  [ "$(get_asdf_config_value "key3")" = "VAR=val" ]
 }

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -19,13 +19,13 @@ teardown() {
 @test "install_command installs the correct version" {
   run asdf install dummy 1.1.0
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.1.0/version) = "1.1.0" ]
+  [ "$(cat "$ASDF_DIR/installs/dummy/1.1.0/version")" = "1.1.0" ]
 }
 
 @test "install_command installs the correct version for plugins without download script" {
   run asdf install legacy-dummy 1.1.0
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/legacy-dummy/1.1.0/version) = "1.1.0" ]
+  [ "$(cat "$ASDF_DIR/installs/legacy-dummy/1.1.0/version")" = "1.1.0" ]
 }
 
 @test "install_command without arguments installs even if the user is terrible and does not use newlines" {
@@ -33,7 +33,7 @@ teardown() {
   echo -n 'dummy 1.2.0' >".tool-versions"
   run asdf install
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.2.0/version) = "1.2.0" ]
+  [ "$(cat "$ASDF_DIR/installs/dummy/1.2.0/version")" = "1.2.0" ]
 }
 
 @test "install_command with only name installs the version in .tool-versions" {
@@ -41,7 +41,7 @@ teardown() {
   echo -n 'dummy 1.2.0' >".tool-versions"
   run asdf install dummy
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.2.0/version) = "1.2.0" ]
+  [ "$(cat "$ASDF_DIR/installs/dummy/1.2.0/version")" = "1.2.0" ]
 }
 
 @test "install_command set ASDF_CONCURRENCY" {
@@ -61,7 +61,7 @@ teardown() {
   run asdf install
 
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.2.0/version) = "1.2.0" ]
+  [ "$(cat "$ASDF_DIR/installs/dummy/1.2.0/version")" = "1.2.0" ]
 }
 
 @test "install_command should create a shim with asdf-plugin metadata" {
@@ -98,7 +98,7 @@ teardown() {
   run grep "# asdf-plugin: dummy 1.0.0"$'\n'"# asdf-plugin: dummy 1.1.0" "$ASDF_DIR/shims/dummy"
   [ "$status" -eq 0 ]
 
-  lines_count=$(grep "asdf-plugin: dummy 1.1.0" $ASDF_DIR/shims/dummy | wc -l)
+  lines_count=$(grep "asdf-plugin: dummy 1.1.0" "$ASDF_DIR/shims/dummy" | wc -l)
   [ "$lines_count" -eq "1" ]
 }
 
@@ -180,7 +180,7 @@ teardown() {
   run asdf install
 
   # execute the generated shim
-  [ "$($ASDF_DIR/shims/dummy world hello)" = "This is Dummy 1.0.0! hello world" ]
+  [ "$("$ASDF_DIR/shims/dummy" world hello)" = "This is Dummy 1.0.0! hello world" ]
   [ "$status" -eq 0 ]
 }
 
@@ -192,8 +192,8 @@ teardown() {
   echo $output
   [ "$status" -eq 0 ]
 
-  [ $(cat $ASDF_DIR/installs/dummy/1.0.0/version) = "1.0.0" ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.2.0/version) = "1.2.0" ]
+  [ "$(cat "$ASDF_DIR/installs/dummy/1.0.0/version")" = "1.0.0" ]
+  [ "$(cat "$ASDF_DIR/installs/dummy/1.2.0/version")" = "1.2.0" ]
 }
 
 @test "install_command doesn't install system version" {
@@ -246,27 +246,27 @@ EOM
 @test "install_command latest installs latest stable version" {
   run asdf install dummy latest
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/2.0.0/version) = "2.0.0" ]
+  [ "$(cat "$ASDF_DIR/installs/dummy/2.0.0/version")" = "2.0.0" ]
 }
 
 @test "install_command latest:version installs latest stable version that matches the given string" {
   run asdf install dummy latest:1
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.1.0/version) = "1.1.0" ]
+  [ "$(cat "$ASDF_DIR/installs/dummy/1.1.0/version")" = "1.1.0" ]
 }
 
 @test "install_command deletes the download directory" {
   run asdf install dummy 1.1.0
   [ "$status" -eq 0 ]
-  [ ! -d $ASDF_DIR/downloads/dummy/1.1.0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.1.0/version) = "1.1.0" ]
+  [ ! -d "$ASDF_DIR/downloads/dummy/1.1.0" ]
+  [ "$(cat "$ASDF_DIR/installs/dummy/1.1.0/version")" = "1.1.0" ]
 }
 
 @test "install_command keeps the download directory when --keep-download flag is provided" {
   run asdf install dummy 1.1.0 --keep-download
   [ "$status" -eq 0 ]
-  [ -d $ASDF_DIR/downloads/dummy/1.1.0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.1.0/version) = "1.1.0" ]
+  [ -d "$ASDF_DIR/downloads/dummy/1.1.0" ]
+  [ "$(cat "$ASDF_DIR/installs/dummy/1.1.0/version")" = "1.1.0" ]
 }
 
 @test "install_command keeps the download directory when always_keep_download setting is true" {
@@ -274,8 +274,8 @@ EOM
   run asdf install dummy 1.1.0
   echo $output
   [ "$status" -eq 0 ]
-  [ -d $ASDF_DIR/downloads/dummy/1.1.0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.1.0/version) = "1.1.0" ]
+  [ -d "$ASDF_DIR/downloads/dummy/1.1.0" ]
+  [ "$(cat "$ASDF_DIR/installs/dummy/1.1.0/version")" = "1.1.0" ]
 }
 
 @test "install_command fails when download script exits with non-zero code" {

--- a/test/plugin_update_command.bats
+++ b/test/plugin_update_command.bats
@@ -83,7 +83,7 @@ teardown() {
 @test "asdf plugin-update should not remove plugin versions" {
   run asdf install dummy 1.1
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.1/version) = "1.1" ]
+  [ "$(cat "$ASDF_DIR/installs/dummy/1.1/version")" = "1.1" ]
   run asdf plugin-update dummy
   [ "$status" -eq 0 ]
   [ -f $ASDF_DIR/installs/dummy/1.1/version ]

--- a/test/shim_env_command.bats
+++ b/test/shim_env_command.bats
@@ -57,7 +57,7 @@ teardown() {
   run asdf env dummy
   [ "$status" -eq 0 ]
 
-  run grep 'FOO=bar' <(echo $output)
+  run grep 'FOO=bar' <(echo "$output")
   [ "$output" = "" ]
   [ "$status" -eq 1 ]
 

--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -65,7 +65,7 @@ teardown() {
 
   run asdf reshim dummy 1.0
 
-  run echo $(echo hello | $ASDF_DIR/shims/upper)
+  run echo "$(echo hello | "$ASDF_DIR/shims/upper")"
   [ "$output" = "HELLO" ]
   [ "$status" -eq 0 ]
 }
@@ -379,9 +379,9 @@ teardown() {
   echo "echo custom/dummy" >$exec_path
   chmod +x $exec_path
 
-  mkdir $(dirname $custom_dummy)
-  echo "echo CUSTOM" >$custom_dummy
-  chmod +x $custom_dummy
+  mkdir "$(dirname "$custom_dummy")"
+  echo "echo CUSTOM" >"$custom_dummy"
+  chmod +x "$custom_dummy"
 
   echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
 

--- a/test/uninstall_command.bats
+++ b/test/uninstall_command.bats
@@ -23,7 +23,7 @@ teardown() {
 @test "uninstall_command should remove the plugin with that version from asdf" {
   run asdf install dummy 1.1.0
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.1.0/version) = "1.1.0" ]
+  [ "$(cat "$ASDF_DIR/installs/dummy/1.1.0/version")" = "1.1.0" ]
   run asdf uninstall dummy 1.1.0
   [ ! -f $ASDF_DIR/installs/dummy/1.1.0/version ]
 }

--- a/test/update_command.bats
+++ b/test/update_command.bats
@@ -29,12 +29,13 @@ teardown() {
 @test "asdf update --head should checkout the master branch" {
   run asdf update --head
   [ "$status" -eq 0 ]
-  cd $ASDF_DIR
-  [ $(git rev-parse --abbrev-ref HEAD) = "master" ]
+  cd "$ASDF_DIR"
+  [ "$(git rev-parse --abbrev-ref HEAD)" = "master" ]
 }
 
 @test "asdf update should checkout the latest non-RC tag" {
-  local tag=$(git tag | grep -vi "rc" | tail -1)
+  local tag=
+  tag=$(git tag | grep -vi "rc" | tail -1)
   if [ -n "$tag" ]; then
     run asdf update
     [ "$status" -eq 0 ]
@@ -45,7 +46,8 @@ teardown() {
 }
 
 @test "asdf update should checkout the latest tag when configured with use_release_candidates = yes" {
-  local tag=$(git tag | tail -1)
+  local tag=
+  tag=$(git tag | tail -1)
   if [ -n "$tag" ]; then
     export ASDF_CONFIG_DEFAULT_FILE=$BATS_TMPDIR/asdfrc_defaults
     echo "use_release_candidates = yes" >$ASDF_CONFIG_DEFAULT_FILE
@@ -80,7 +82,7 @@ teardown() {
 @test "asdf update should not remove plugin versions" {
   run asdf install dummy 1.1.0
   [ "$status" -eq 0 ]
-  [ $(cat $ASDF_DIR/installs/dummy/1.1.0/version) = "1.1.0" ]
+  [ "$(cat "$ASDF_DIR/installs/dummy/1.1.0/version")" = "1.1.0" ]
   run asdf update
   [ "$status" -eq 0 ]
   [ -f $ASDF_DIR/installs/dummy/1.1.0/version ]

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -291,7 +291,7 @@ teardown() {
   mkdir -p $ASDF_DIR/plugins/foo
   run get_executable_path "foo" "system" "ls"
   [ "$status" -eq 0 ]
-  [ "$output" = $(which ls) ]
+  [ "$output" = "$(which ls)" ]
 }
 
 @test "get_executable_path for system version should not use asdf shims" {

--- a/test/version_commands.bats
+++ b/test/version_commands.bats
@@ -53,19 +53,19 @@ teardown() {
 @test "local should create a local .tool-versions file if it doesn't exist" {
   run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.1.0" ]
 }
 
 @test "[local - dummy_plugin] with latest should use the latest installed version" {
   run asdf local "dummy" "latest"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 2.0.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 2.0.0" ]
 }
 
 @test "[local - dummy_plugin] with latest:version should use the latest valid installed version" {
   run asdf local "dummy" "latest:1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.0.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.0.0" ]
 }
 
 @test "[local - dummy_plugin] with latest:version should return an error for invalid versions" {
@@ -77,13 +77,13 @@ teardown() {
 @test "[local - dummy_legacy_plugin] with latest should use the latest installed version" {
   run asdf local "legacy-dummy" "latest"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "legacy-dummy 5.1.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "legacy-dummy 5.1.0" ]
 }
 
 @test "[local - dummy_legacy_plugin] with latest:version should use the latest valid installed version" {
   run asdf local "legacy-dummy" "latest:1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "legacy-dummy 1.0.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "legacy-dummy 1.0.0" ]
 }
 
 @test "[local - dummy_legacy_plugin] with latest:version should return an error for invalid versions" {
@@ -95,7 +95,7 @@ teardown() {
 @test "local should allow multiple versions" {
   run asdf local "dummy" "1.1.0" "1.0.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0 1.0.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.1.0 1.0.0" ]
 }
 
 @test "local should create a local .tool-versions file if it doesn't exist when the directory name contains whitespace" {
@@ -123,7 +123,7 @@ teardown() {
 
   run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.1.0" ]
 }
 
 @test "local should append trailing newline before appending new version when missing" {
@@ -131,7 +131,7 @@ teardown() {
 
   run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = $'foobar 1.0.0\ndummy 1.1.0' ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = $'foobar 1.0.0\ndummy 1.1.0' ]
 }
 
 @test "local should not append trailing newline before appending new version when one present" {
@@ -139,7 +139,7 @@ teardown() {
 
   run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = $'foobar 1.0.0\ndummy 1.1.0' ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = $'foobar 1.0.0\ndummy 1.1.0' ]
 }
 
 @test "local should fail to set a path:dir if dir does not exists " {
@@ -152,7 +152,7 @@ teardown() {
   mkdir -p $PROJECT_DIR/local
   run asdf local "dummy" "path:$PROJECT_DIR/local"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy path:$PROJECT_DIR/local" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy path:$PROJECT_DIR/local" ]
 }
 
 @test "local -p/--parent should set should emit an error when called with incorrect arity" {
@@ -178,7 +178,7 @@ teardown() {
   touch $PROJECT_DIR/.tool-versions
   run asdf local -p "dummy" "1.1.0" "1.0.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0 1.0.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.1.0 1.0.0" ]
 }
 
 @test "local -p/--parent should overwrite the existing version if it's set" {
@@ -186,7 +186,7 @@ teardown() {
   echo 'dummy 1.0.0' >>$PROJECT_DIR/.tool-versions
   run asdf local -p "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.1.0" ]
 }
 
 @test "local -p/--parent should set the version if it's unset" {
@@ -194,25 +194,25 @@ teardown() {
   touch $PROJECT_DIR/.tool-versions
   run asdf local -p "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.1.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.1.0" ]
 }
 
 @test "global should create a global .tool-versions file if it doesn't exist" {
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "dummy 1.1.0" ]
+  [ "$(cat "$HOME/.tool-versions")" = "dummy 1.1.0" ]
 }
 
 @test "[global - dummy_plugin] with latest should use the latest installed version" {
   run asdf global "dummy" "latest"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "dummy 2.0.0" ]
+  [ "$(cat "$HOME/.tool-versions")" = "dummy 2.0.0" ]
 }
 
 @test "[global - dummy_plugin] with latest:version should use the latest valid installed version" {
   run asdf global "dummy" "latest:1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "dummy 1.0.0" ]
+  [ "$(cat "$HOME/.tool-versions")" = "dummy 1.0.0" ]
 }
 
 @test "[global - dummy_plugin] with latest:version should return an error for invalid versions" {
@@ -224,13 +224,13 @@ teardown() {
 @test "[global - dummy_legacy_plugin] with latest should use the latest installed version" {
   run asdf global "legacy-dummy" "latest"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "legacy-dummy 5.1.0" ]
+  [ "$(cat "$HOME/.tool-versions")" = "legacy-dummy 5.1.0" ]
 }
 
 @test "[global - dummy_legacy_plugin] with latest:version should use the latest valid installed version" {
   run asdf global "legacy-dummy" "latest:1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "legacy-dummy 1.0.0" ]
+  [ "$(cat "$HOME/.tool-versions")" = "legacy-dummy 1.0.0" ]
 }
 
 @test "[global - dummy_legacy_plugin] with latest:version should return an error for invalid versions" {
@@ -242,14 +242,14 @@ teardown() {
 @test "global should accept multiple versions" {
   run asdf global "dummy" "1.1.0" "1.0.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "dummy 1.1.0 1.0.0" ]
+  [ "$(cat "$HOME/.tool-versions")" = "dummy 1.1.0 1.0.0" ]
 }
 
 @test "global should overwrite the existing version if it's set" {
   echo 'dummy 1.0.0' >>$HOME/.tool-versions
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "dummy 1.1.0" ]
+  [ "$(cat "$HOME/.tool-versions")" = "dummy 1.1.0" ]
 }
 
 @test "global should append trailing newline before appending new version when missing" {
@@ -257,7 +257,7 @@ teardown() {
 
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = $'foobar 1.0.0\ndummy 1.1.0' ]
+  [ "$(cat "$HOME/.tool-versions")" = $'foobar 1.0.0\ndummy 1.1.0' ]
 }
 
 @test "global should not append trailing newline before appending new version when one present" {
@@ -265,7 +265,7 @@ teardown() {
 
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = $'foobar 1.0.0\ndummy 1.1.0' ]
+  [ "$(cat "$HOME/.tool-versions")" = $'foobar 1.0.0\ndummy 1.1.0' ]
 }
 
 @test "global should fail to set a path:dir if dir does not exists " {
@@ -278,15 +278,15 @@ teardown() {
   mkdir -p $PROJECT_DIR/local
   run asdf global "dummy" "path:$PROJECT_DIR/local"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "dummy path:$PROJECT_DIR/local" ]
+  [ "$(cat "$HOME/.tool-versions")" = "dummy path:$PROJECT_DIR/local" ]
 }
 
 @test "local should write to ASDF_DEFAULT_TOOL_VERSIONS_FILENAME" {
   export ASDF_DEFAULT_TOOL_VERSIONS_FILENAME="local-tool-versions"
   run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $ASDF_DEFAULT_TOOL_VERSIONS_FILENAME)" = "dummy 1.1.0" ]
-  [ "$(cat .tool-versions)" = "" ]
+  [ "$(cat "$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME")" = "dummy 1.1.0" ]
+  [ -z "$(cat .tool-versions)" ]
   unset ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
 }
 
@@ -295,8 +295,8 @@ teardown() {
   echo 'dummy 1.0.0' >>"$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME"
   run asdf local "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $ASDF_DEFAULT_TOOL_VERSIONS_FILENAME)" = "dummy 1.1.0" ]
-  [ "$(cat .tool-versions)" = "" ]
+  [ "$(cat "$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME")" = "dummy 1.1.0" ]
+  [ -z "$(cat .tool-versions)" ]
   unset ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
 }
 
@@ -304,8 +304,8 @@ teardown() {
   export ASDF_DEFAULT_TOOL_VERSIONS_FILENAME="global-tool-versions"
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME)" = "dummy 1.1.0" ]
-  [ "$(cat $HOME/.tool-versions)" = "" ]
+  [ "$(cat "$HOME/$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME")" = "dummy 1.1.0" ]
+  [ -z "$(cat "$HOME/.tool-versions")" ]
   unset ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
 }
 
@@ -314,8 +314,8 @@ teardown() {
   echo 'dummy 1.0.0' >>"$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME"
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME)" = "dummy 1.1.0" ]
-  [ "$(cat $HOME/.tool-versions)" = "" ]
+  [ "$(cat "$HOME/$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME")" = "dummy 1.1.0" ]
+  [ -z "$(cat "$HOME/.tool-versions")" ]
   unset ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
 }
 
@@ -347,8 +347,8 @@ teardown() {
 
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ -L $HOME/.tool-versions ]
-  [ "$(cat $HOME/other-dir/.tool-versions)" = "dummy 1.1.0" ]
+  [ -L "$HOME/.tool-versions" ]
+  [ "$(cat "$HOME/other-dir/.tool-versions")" = "dummy 1.1.0" ]
 }
 
 @test "global should preserve symlinks when updating versions" {
@@ -359,28 +359,28 @@ teardown() {
   run asdf global "dummy" "1.1.0"
   run asdf global "dummy" "1.1.0"
   [ "$status" -eq 0 ]
-  [ -L $HOME/.tool-versions ]
-  [ "$(cat $HOME/other-dir/.tool-versions)" = "dummy 1.1.0" ]
+  [ -L "$HOME/.tool-versions" ]
+  [ "$(cat "$HOME/other-dir/.tool-versions")" = "dummy 1.1.0" ]
 }
 
 @test "shell wrapper function should export ENV var" {
-  . $(dirname "$BATS_TEST_DIRNAME")/asdf.sh
+  . "$(dirname "$BATS_TEST_DIRNAME")/asdf.sh"
   asdf shell "dummy" "1.1.0"
-  [ $(echo $ASDF_DUMMY_VERSION) = "1.1.0" ]
+  [ "$(echo "$ASDF_DUMMY_VERSION")" = "1.1.0" ]
   unset ASDF_DUMMY_VERSION
 }
 
 @test "shell wrapper function with --unset should unset ENV var" {
-  . $(dirname "$BATS_TEST_DIRNAME")/asdf.sh
+  . "$(dirname "$BATS_TEST_DIRNAME")/asdf.sh"
   asdf shell "dummy" "1.1.0"
-  [ $(echo $ASDF_DUMMY_VERSION) = "1.1.0" ]
+  [ "$(echo "$ASDF_DUMMY_VERSION")" = "1.1.0" ]
   asdf shell "dummy" --unset
-  [ -z "$(echo $ASDF_DUMMY_VERSION)" ]
+  [ -z "$(echo "$ASDF_DUMMY_VERSION")" ]
   unset ASDF_DUMMY_VERSION
 }
 
 @test "shell wrapper function should return an error for missing plugins" {
-  . $(dirname "$BATS_TEST_DIRNAME")/asdf.sh
+  . "$(dirname "$BATS_TEST_DIRNAME")/asdf.sh"
   expected="No such plugin: nonexistent
 version 1.0.0 is not installed for nonexistent"
 
@@ -451,16 +451,16 @@ false"
 }
 
 @test "[shell - dummy_plugin] wrapper function should support latest" {
-  . $(dirname "$BATS_TEST_DIRNAME")/asdf.sh
+  . "$(dirname "$BATS_TEST_DIRNAME")/asdf.sh"
   asdf shell "dummy" "latest"
-  [ $(echo $ASDF_DUMMY_VERSION) = "2.0.0" ]
+  [ "$(echo "$ASDF_DUMMY_VERSION")" = "2.0.0" ]
   unset ASDF_DUMMY_VERSION
 }
 
 @test "[shell - dummy_legacy_plugin] wrapper function should support latest" {
-  . $(dirname "$BATS_TEST_DIRNAME")/asdf.sh
+  . "$(dirname "$BATS_TEST_DIRNAME")/asdf.sh"
   asdf shell "legacy-dummy" "latest"
-  [ $(echo $ASDF_LEGACY_DUMMY_VERSION) = "5.1.0" ]
+  [ "$(echo "$ASDF_LEGACY_DUMMY_VERSION")" = "5.1.0" ]
   unset ASDF_LEGACY_DUMMY_VERSION
 }
 
@@ -468,26 +468,26 @@ false"
   echo 'dummy 1.0.0' >>$HOME/.tool-versions
   run asdf global "dummy" "1.0.0" "latest"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "dummy 1.0.0 2.0.0" ]
+  [ "$(cat "$HOME/.tool-versions")" = "dummy 1.0.0 2.0.0" ]
 }
 
 @test "[global - dummy_legacy_plugin] should support latest" {
   echo 'legacy-dummy 1.0.0' >>$HOME/.tool-versions
   run asdf global "legacy-dummy" "1.0.0" "latest"
   [ "$status" -eq 0 ]
-  [ "$(cat $HOME/.tool-versions)" = "legacy-dummy 1.0.0 5.1.0" ]
+  [ "$(cat "$HOME/.tool-versions")" = "legacy-dummy 1.0.0 5.1.0" ]
 }
 
 @test "[local - dummy_plugin] should support latest" {
   echo 'dummy 1.0.0' >>$PROJECT_DIR/.tool-versions
   run asdf local "dummy" "1.0.0" "latest"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "dummy 1.0.0 2.0.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.0.0 2.0.0" ]
 }
 
 @test "[local - dummy_legacy_plugin] should support latest" {
   echo 'legacy-dummy 1.0.0' >>$PROJECT_DIR/.tool-versions
   run asdf local "legacy-dummy" "1.0.0" "latest"
   [ "$status" -eq 0 ]
-  [ "$(cat $PROJECT_DIR/.tool-versions)" = "legacy-dummy 1.0.0 5.1.0" ]
+  [ "$(cat "$PROJECT_DIR/.tool-versions")" = "legacy-dummy 1.0.0 5.1.0" ]
 }


### PR DESCRIPTION
# Summary

This PR is the **second** of a multi-part series that fixes various issues with the tests. For more detailed information, see the [first](https://github.com/asdf-vm/asdf/pull/1433) PR.

Here is a description of each commit/part:

- ~~Parts 1 does a few miscellaneous fixes~~ (#1433)
- Parts 2-5 are quite trivial and fix up obvious mistakes like quoting.
- Part 6 has the first non-obvious changes that remove use of `$?` by using the `run` function provided by Bats 
- Part 7 fixes all errors and warnings shown by Bats. The significant code change is that some regex comparison were changed to glob comparisons.
- Part 8 enables ShellCheck for warnings and errors
- Part 9 (the last commit) Fixes all infos, and enables ShellCheck to lint infos as well

Partially addresses #1396
