### PR TITLE
chore: Fix ShellCheck errors in tests

### DIFF
--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -47,8 +47,8 @@ teardown() {
 @test "install_command set ASDF_CONCURRENCY" {
   run asdf install dummy 1.0.0
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/installs/dummy/1.0.0/env ]
-  run grep ASDF_CONCURRENCY $ASDF_DIR/installs/dummy/1.0.0/env
+  [ -f "$ASDF_DIR/installs/dummy/1.0.0/env" ]
+  run grep ASDF_CONCURRENCY "$ASDF_DIR/installs/dummy/1.0.0/env"
   [ "$status" -eq 0 ]
 }
 
@@ -67,16 +67,16 @@ teardown() {
 @test "install_command should create a shim with asdf-plugin metadata" {
   run asdf install dummy 1.0.0
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/installs/dummy/1.0.0/env ]
-  run grep "asdf-plugin: dummy 1.0.0" $ASDF_DIR/shims/dummy
+  [ -f "$ASDF_DIR/installs/dummy/1.0.0/env" ]
+  run grep "asdf-plugin: dummy 1.0.0" "$ASDF_DIR/shims/dummy"
   [ "$status" -eq 0 ]
 }
 
 @test "install_command should create a shim with asdf-plugin metadata for plugins without download script" {
   run asdf install legacy-dummy 1.0.0
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/installs/legacy-dummy/1.0.0/env ]
-  run grep "asdf-plugin: legacy-dummy 1.0.0" $ASDF_DIR/shims/dummy
+  [ -f "$ASDF_DIR/installs/legacy-dummy/1.0.0/env" ]
+  run grep "asdf-plugin: legacy-dummy 1.0.0" "$ASDF_DIR/shims/dummy"
   [ "$status" -eq 0 ]
 }
 
@@ -130,7 +130,7 @@ teardown() {
   run asdf install dummy
   [ "$status" -eq 1 ]
   [ "$output" = "No versions specified for dummy in config files or environment" ]
-  [ ! -f $ASDF_DIR/installs/dummy/1.1.0/version ]
+  [ ! -f "$ASDF_DIR/installs/dummy/1.1.0/version" ]
 }
 
 @test "install_command fails if the plugin is not installed" {
@@ -156,7 +156,7 @@ teardown() {
   run asdf install other-dummy
   [ "$status" -eq 1 ]
   [ "$output" = "No versions specified for other-dummy in config files or environment" ]
-  [ ! -f $ASDF_DIR/installs/dummy/1.0.0/version ]
+  [ ! -f "$ASDF_DIR/installs/dummy/1.0.0/version" ]
 }
 
 @test "install_command fails when two tools are specified with no versions" {
@@ -164,8 +164,8 @@ teardown() {
   run asdf install dummy other-dummy
   [ "$status" -eq 1 ]
   [ "$output" = "Dummy couldn't install version: other-dummy (on purpose)" ]
-  [ ! -f $ASDF_DIR/installs/dummy/1.0.0/version ]
-  [ ! -f $ASDF_DIR/installs/other-dummy/2.0.0/version ]
+  [ ! -f "$ASDF_DIR/installs/dummy/1.0.0/version" ]
+  [ ! -f "$ASDF_DIR/installs/other-dummy/2.0.0/version" ]
 }
 
 @test "install_command without arguments uses a parent directory .tool-versions file if present" {
@@ -199,7 +199,7 @@ teardown() {
 @test "install_command doesn't install system version" {
   run asdf install dummy system
   [ "$status" -eq 0 ]
-  [ ! -f $ASDF_DIR/installs/dummy/system/version ]
+  [ ! -f "$ASDF_DIR/installs/dummy/system/version" ]
 }
 
 @test "install command executes configured pre plugin install hook" {
@@ -226,8 +226,8 @@ EOM
   cd $PROJECT_DIR
   run asdf install
   [ "$status" -eq 0 ]
-  [ "$output" = "" ]
-  [ -f $ASDF_DIR/installs/dummy/1.2.0/version ]
+  [ -z "$output" ]
+  [ -f "$ASDF_DIR/installs/dummy/1.2.0/version" ]
 }
 
 @test "install command without arguments installs versions from legacy files in parent directories" {
@@ -239,8 +239,8 @@ EOM
 
   run asdf install
   [ "$status" -eq 0 ]
-  [ "$output" = "" ]
-  [ -f $ASDF_DIR/installs/dummy/1.2.0/version ]
+  [ -z "$output" ]
+  [ -f "$ASDF_DIR/installs/dummy/1.2.0/version" ]
 }
 
 @test "install_command latest installs latest stable version" {
@@ -282,7 +282,7 @@ EOM
   run asdf install dummy-broken 1.0.0
   echo $output
   [ "$status" -eq 1 ]
-  [ ! -d $ASDF_DIR/downloads/dummy-broken/1.1.0 ]
-  [ ! -d $ASDF_DIR/installs/dummy-broken/1.1.0 ]
+  [ ! -d "$ASDF_DIR/downloads/dummy-broken/1.1.0" ]
+  [ ! -d "$ASDF_DIR/installs/dummy-broken/1.1.0" ]
   [ "$output" = "Download failed!" ]
 }

--- a/test/plugin_update_command.bats
+++ b/test/plugin_update_command.bats
@@ -86,31 +86,31 @@ teardown() {
   [ "$(cat "$ASDF_DIR/installs/dummy/1.1/version")" = "1.1" ]
   run asdf plugin-update dummy
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/installs/dummy/1.1/version ]
+  [ -f "$ASDF_DIR/installs/dummy/1.1/version" ]
   run asdf plugin-update --all
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/installs/dummy/1.1/version ]
+  [ -f "$ASDF_DIR/installs/dummy/1.1/version" ]
 }
 
 @test "asdf plugin-update should not remove plugins" {
   # dummy plugin is already installed
   run asdf plugin-update dummy
   [ "$status" -eq 0 ]
-  [ -d $ASDF_DIR/plugins/dummy ]
+  [ -d "$ASDF_DIR/plugins/dummy" ]
   run asdf plugin-update --all
   [ "$status" -eq 0 ]
-  [ -d $ASDF_DIR/plugins/dummy ]
+  [ -d "$ASDF_DIR/plugins/dummy" ]
 }
 
 @test "asdf plugin-update should not remove shims" {
   run asdf install dummy 1.1
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
   run asdf plugin-update dummy
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
   run asdf plugin-update --all
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
 }
 
 @test "asdf plugin-update done for all plugins" {

--- a/test/remove_command.bats
+++ b/test/remove_command.bats
@@ -34,22 +34,22 @@ teardown() {
   install_dummy_plugin
   run asdf install dummy 1.0
   [ "$status" -eq 0 ]
-  [ -d $ASDF_DIR/installs/dummy ]
+  [ -d "$ASDF_DIR/installs/dummy" ]
 
   run asdf plugin-remove dummy
   [ "$status" -eq 0 ]
-  [ ! -d $ASDF_DIR/installs/dummy ]
+  [ ! -d "$ASDF_DIR/installs/dummy" ]
 }
 
 @test "plugin_remove_command should also remove shims for that plugin" {
   install_dummy_plugin
   run asdf install dummy 1.0
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
 
   run asdf plugin-remove dummy
   [ "$status" -eq 0 ]
-  [ ! -f $ASDF_DIR/shims/dummy ]
+  [ ! -f "$ASDF_DIR/shims/dummy" ]
 }
 
 @test "plugin_remove_command should not remove unrelated shims" {
@@ -63,7 +63,7 @@ teardown() {
   [ "$status" -eq 0 ]
 
   # unrelated shim should exist
-  [ -f $ASDF_DIR/shims/gummy ]
+  [ -f "$ASDF_DIR/shims/gummy" ]
 }
 
 @test "plugin_remove_command executes pre-plugin-remove script" {

--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -60,8 +60,8 @@ teardown() {
   echo "dummy 1.0" >$PROJECT_DIR/.tool-versions
   run asdf install
 
-  echo "tr [:lower:] [:upper:]" >$ASDF_DIR/installs/dummy/1.0/bin/upper
-  chmod +x $ASDF_DIR/installs/dummy/1.0/bin/upper
+  echo "tr [:lower:] [:upper:]" >"$ASDF_DIR/installs/dummy/1.0/bin/upper"
+  chmod +x "$ASDF_DIR/installs/dummy/1.0/bin/upper"
 
   run asdf reshim dummy 1.0
 

--- a/test/uninstall_command.bats
+++ b/test/uninstall_command.bats
@@ -25,7 +25,7 @@ teardown() {
   [ "$status" -eq 0 ]
   [ "$(cat "$ASDF_DIR/installs/dummy/1.1.0/version")" = "1.1.0" ]
   run asdf uninstall dummy 1.1.0
-  [ ! -f $ASDF_DIR/installs/dummy/1.1.0/version ]
+  [ ! -f "$ASDF_DIR/installs/dummy/1.1.0/version" ]
 }
 
 @test "uninstall_command should invoke the plugin bin/uninstall if available" {
@@ -41,29 +41,29 @@ teardown() {
 
 @test "uninstall_command should remove the plugin shims if no other version is installed" {
   run asdf install dummy 1.1.0
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
   run asdf uninstall dummy 1.1.0
-  [ ! -f $ASDF_DIR/shims/dummy ]
+  [ ! -f "$ASDF_DIR/shims/dummy" ]
 }
 
 @test "uninstall_command should leave the plugin shims if other version is installed" {
   run asdf install dummy 1.0.0
-  [ -f $ASDF_DIR/installs/dummy/1.0.0/bin/dummy ]
+  [ -f "$ASDF_DIR/installs/dummy/1.0.0/bin/dummy" ]
 
   run asdf install dummy 1.1.0
-  [ -f $ASDF_DIR/installs/dummy/1.1.0/bin/dummy ]
+  [ -f "$ASDF_DIR/installs/dummy/1.1.0/bin/dummy" ]
 
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
   run asdf uninstall dummy 1.0.0
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
 }
 
 @test "uninstall_command should remove relevant asdf-plugin metadata" {
   run asdf install dummy 1.0.0
-  [ -f $ASDF_DIR/installs/dummy/1.0.0/bin/dummy ]
+  [ -f "$ASDF_DIR/installs/dummy/1.0.0/bin/dummy" ]
 
   run asdf install dummy 1.1.0
-  [ -f $ASDF_DIR/installs/dummy/1.1.0/bin/dummy ]
+  [ -f "$ASDF_DIR/installs/dummy/1.1.0/bin/dummy" ]
 
   run asdf uninstall dummy 1.0.0
   run grep "asdf-plugin: dummy 1.1.0" $ASDF_DIR/shims/dummy
@@ -74,13 +74,13 @@ teardown() {
 
 @test "uninstall_command should not remove other unrelated shims" {
   run asdf install dummy 1.0.0
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
 
-  touch $ASDF_DIR/shims/gummy
-  [ -f $ASDF_DIR/shims/gummy ]
+  touch "$ASDF_DIR/shims/gummy"
+  [ -f "$ASDF_DIR/shims/gummy" ]
 
   run asdf uninstall dummy 1.0.0
-  [ -f $ASDF_DIR/shims/gummy ]
+  [ -f "$ASDF_DIR/shims/gummy" ]
 }
 
 @test "uninstall command executes configured pre hook" {

--- a/test/update_command.bats
+++ b/test/update_command.bats
@@ -39,8 +39,8 @@ teardown() {
   if [ -n "$tag" ]; then
     run asdf update
     [ "$status" -eq 0 ]
-    cd $ASDF_DIR
-    git tag | grep $tag
+    cd "$ASDF_DIR"
+    git tag | grep "$tag"
     [ "$?" -eq 0 ]
   fi
 }
@@ -53,8 +53,8 @@ teardown() {
     echo "use_release_candidates = yes" >$ASDF_CONFIG_DEFAULT_FILE
     run asdf update
     [ "$status" -eq 0 ]
-    cd $ASDF_DIR
-    git tag | grep $tag
+    cd "$ASDF_DIR"
+    git tag | grep "$tag"
     [ "$?" -eq 0 ]
   fi
 }
@@ -85,29 +85,29 @@ teardown() {
   [ "$(cat "$ASDF_DIR/installs/dummy/1.1.0/version")" = "1.1.0" ]
   run asdf update
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/installs/dummy/1.1.0/version ]
+  [ -f "$ASDF_DIR/installs/dummy/1.1.0/version" ]
   run asdf update --head
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/installs/dummy/1.1.0/version ]
+  [ -f "$ASDF_DIR/installs/dummy/1.1.0/version" ]
 }
 
 @test "asdf update should not remove plugins" {
   # dummy plugin is already installed
   run asdf update
   [ "$status" -eq 0 ]
-  [ -d $ASDF_DIR/plugins/dummy ]
+  [ -d "$ASDF_DIR/plugins/dummy" ]
   run asdf update --head
   [ "$status" -eq 0 ]
-  [ -d $ASDF_DIR/plugins/dummy ]
+  [ -d "$ASDF_DIR/plugins/dummy" ]
 }
 
 @test "asdf update should not remove shims" {
   run asdf install dummy 1.1.0
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
   run asdf update
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
   run asdf update --head
   [ "$status" -eq 0 ]
-  [ -f $ASDF_DIR/shims/dummy ]
+  [ -f "$ASDF_DIR/shims/dummy" ]
 }

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -370,7 +370,7 @@ teardown() {
 
   run resolve_symlink bar
   [ "$status" -eq 0 ]
-  [ "$output" = $PWD/foo ]
+  [ "$output" = "$PWD/foo" ]
   rm -f foo bar
 }
 
@@ -380,7 +380,7 @@ teardown() {
 
   run resolve_symlink baz/bar
   [ "$status" -eq 0 ]
-  [ "$output" = $PWD/baz/../foo ]
+  [ "$output" = "$PWD/baz/../foo" ]
   rm -f foo bar
 }
 
@@ -390,7 +390,7 @@ teardown() {
 
   run resolve_symlink bar
   [ "$status" -eq 0 ]
-  [ "$output" = $PWD/foo ]
+  [ "$output" = "$PWD/foo" ]
   rm -f foo bar
 }
 


### PR DESCRIPTION
# Summary

This PR is the **third** of a multi-part series that fixes various issues with the tests. For more detailed information, see the [first](https://github.com/asdf-vm/asdf/pull/1433) PR.

Here is a description of each commit/part:

- ~~Parts 1 does a few miscellaneous fixes~~ (#1433)
- Parts 2-5 are quite trivial and fix up obvious mistakes like quoting. (#1443)
- Part 6 has the first non-obvious changes that remove use of `$?` by using the `run` function provided by Bats 
- Part 7 fixes all errors and warnings shown by Bats. The significant code change is that some regex comparison were changed to glob comparisons.
- Part 8 enables ShellCheck for warnings and errors
- Part 9 (the last commit) Fixes all infos, and enables ShellCheck to lint infos as well

Partially addresses #1396
