### PR TITLE
test: Improve isolation of Git

### DIFF
--- a/test/test_helpers.bash
+++ b/test/test_helpers.bash
@@ -4,6 +4,10 @@
 # tests fail when it is set to something other than the temp dir.
 unset ASDF_DIR
 
+# Set an agnostic Git configuration directory to prevent personal
+# configuration from interfering with the tests
+export GIT_CONFIG_GLOBAL=/dev/null
+
 # shellcheck source=lib/utils.bash
 . "$(dirname "$BATS_TEST_DIRNAME")"/lib/utils.bash
 


### PR DESCRIPTION
I've been getting errors like:

```txt
✗ plugin_add command with URL specified adds a plugin using repo
   (from function `install_mock_plugin_repo' in file test/test_helpers.bash, line 55,
    in test file test/plugin_add_command.bats, line 89)
     `install_mock_plugin_repo "dummy"' failed with status 128
   22:39:22.937158 git.c:455               trace: built-in: git commit -q -m 'asdf dummy plugin'
   22:39:22.938939 run-command.c:668       trace: run_command: gpg --status-fd=2 -bsau 0xA1E60C1F1A423B08
   error: gpg failed to sign the data
   fatal: failed to write commit object
```

I'm not sure why, because I can commit things properly normally, but this change fixes my problem, and prevents others like it for other people.