### PR TITLE
chore: Fix ShellCheck errors in tests

### DIFF
--- a/scripts/shellcheck.bash
+++ b/scripts/shellcheck.bash
@@ -23,4 +23,4 @@ shellcheck --shell bash --external-sources \
   test/fixtures/dummy_plugin/bin/*
 
 shellcheck --shell bats --external-source \
-  --severity warning test/*.bats
+  test/*.bats

--- a/test/asdf_elvish.bats
+++ b/test/asdf_elvish.bats
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+# shellcheck disable=SC2030,SC2031
 
 load test_helpers
 

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -98,7 +98,7 @@ teardown() {
   run grep "# asdf-plugin: dummy 1.0.0"$'\n'"# asdf-plugin: dummy 1.1.0" "$ASDF_DIR/shims/dummy"
   [ "$status" -eq 0 ]
 
-  lines_count=$(grep "asdf-plugin: dummy 1.1.0" "$ASDF_DIR/shims/dummy" | wc -l)
+  lines_count=$(grep -c "asdf-plugin: dummy 1.1.0" "$ASDF_DIR/shims/dummy")
   [ "$lines_count" -eq "1" ]
 }
 

--- a/test/latest_command.bats
+++ b/test/latest_command.bats
@@ -17,19 +17,19 @@ teardown() {
 ####################################################
 @test "[latest_command - dummy_plugin] shows latest stable version" {
   run asdf latest dummy
-  [ "$(echo "2.0.0")" = "$output" ]
+  [ "2.0.0" = "$output" ]
   [ "$status" -eq 0 ]
 }
 
 @test "[latest_command - dummy_plugin] shows latest stable version that matches the given string" {
   run asdf latest dummy 1
-  [ "$(echo "1.1.0")" = "$output" ]
+  [ "1.1.0" = "$output" ]
   [ "$status" -eq 0 ]
 }
 
 @test "[latest_command - dummy_plugin] an invalid version should return an error" {
   run asdf latest dummy 3
-  [ "$(echo "No compatible versions available (dummy 3)")" = "$output" ]
+  [ "No compatible versions available (dummy 3)" = "$output" ]
   [ "$status" -eq 1 ]
 }
 
@@ -40,7 +40,7 @@ teardown() {
   run asdf latest legacy-dummy
   echo "status: $status"
   echo "output: $output"
-  [ "$(echo "5.1.0")" = "$output" ]
+  [ "5.1.0" = "$output" ]
   [ "$status" -eq 0 ]
 }
 
@@ -48,7 +48,7 @@ teardown() {
   run asdf latest legacy-dummy 1
   echo "status: $status"
   echo "output: $output"
-  [ "$(echo "1.1.0")" = "$output" ]
+  [ "1.1.0" = "$output" ]
   [ "$status" -eq 0 ]
 }
 
@@ -64,7 +64,7 @@ teardown() {
   run asdf latest legacy-dummy 4
   echo "status: $status"
   echo "output: $output"
-  [ "$(echo "4.0.0")" = "$output" ]
+  [ "4.0.0" = "$output" ]
   [ "$status" -eq 0 ]
 }
 
@@ -72,7 +72,7 @@ teardown() {
   run asdf latest legacy-dummy 5
   echo "status: $status"
   echo "output: $output"
-  [ "$(echo "5.1.0")" = "$output" ]
+  [ "5.1.0" = "$output" ]
   [ "$status" -eq 0 ]
 }
 
@@ -80,7 +80,7 @@ teardown() {
   run asdf latest legacy-dummy 6
   echo "status: $status"
   echo "output: $output"
-  [ "$(echo "No compatible versions available (legacy-dummy 6)")" = "$output" ]
+  [ "No compatible versions available (legacy-dummy 6)" = "$output" ]
   [ "$status" -eq 1 ]
 }
 

--- a/test/list_command.bats
+++ b/test/list_command.bats
@@ -71,7 +71,7 @@ teardown() {
   run asdf install dummy 1.0
   run asdf install dummy 1.1
   run asdf list dummy 2
-  [ "$(echo "No compatible versions installed (dummy 2)")" = "$output" ]
+  [ "No compatible versions installed (dummy 2)" = "$output" ]
   [ "$status" -eq 1 ]
 }
 
@@ -89,7 +89,7 @@ teardown() {
 
 @test "list_all_command with an invalid version should return an error" {
   run asdf list-all dummy 3
-  [ "$(echo "No compatible versions available (dummy 3)")" = "$output" ]
+  [ "No compatible versions available (dummy 3)" = "$output" ]
   [ "$status" -eq 1 ]
 }
 

--- a/test/plugin_add_command.bats
+++ b/test/plugin_add_command.bats
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+# shellcheck disable=SC2030,SC2031
 
 load test_helpers
 

--- a/test/plugin_extension_command.bats
+++ b/test/plugin_extension_command.bats
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+# shellcheck disable=SC2016
 
 load test_helpers
 
@@ -23,7 +24,7 @@ teardown() {
   run asdf help
   [ "$status" -eq 0 ]
   echo "$output" | grep "PLUGIN dummy" # should present plugin section
-  listed_cmds=$(echo "$output" | grep "asdf dummy" | wc -l)
+  listed_cmds=$(echo "$output" | grep -c "asdf dummy")
   [ "$listed_cmds" -eq 3 ]
   echo "$output" | grep "asdf dummy foo bar" # should present commands without hyphens
 }
@@ -43,7 +44,6 @@ teardown() {
   run asdf help
   [ "$status" -eq 0 ]
   [[ "$output" == *"PLUGIN $plugin_name"* ]]
-  # shellcheck disable=SC2154
   listed_cmds=$(grep -c "asdf $plugin_name" <<<"${output}")
   [[ $listed_cmds -eq 3 ]]
   [[ "$output" == *"asdf $plugin_name foo"* ]]

--- a/test/plugin_list_all_command.bats
+++ b/test/plugin_list_all_command.bats
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+# shellcheck disable=SC2030,SC2031
 
 load test_helpers
 

--- a/test/reshim_command.bats
+++ b/test/reshim_command.bats
@@ -1,4 +1,5 @@
 #!/usr/bin/env bats
+# shellcheck disable=SC2012
 
 load test_helpers
 

--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
-# shellcheck disable=SC2164
+# shellcheck disable=SC2016,SC2164
 
 load test_helpers
 
@@ -39,11 +39,11 @@ teardown() {
   run asdf install
 
   path=$(echo "$PATH" | sed -e "s|$(asdf_data_dir)/shims||g; s|::|:|g")
-  run env PATH=$path which dummy
+  run env PATH="$path" which dummy
   [ "$output" = "" ]
   [ "$status" -eq 1 ]
 
-  run env PATH=$path asdf exec dummy world hello
+  run env PATH="$path" asdf exec dummy world hello
   [ "$output" = "This is Dummy 1.0! hello world" ]
   [ "$status" -eq 0 ]
 }
@@ -394,7 +394,6 @@ teardown() {
   run asdf install dummy 1.0
 
   exec_path="$ASDF_DIR/plugins/dummy/bin/exec-path"
-
   echo 'echo $3 # always same path' >"$exec_path"
   chmod +x "$exec_path"
 

--- a/test/update_command.bats
+++ b/test/update_command.bats
@@ -41,7 +41,6 @@ teardown() {
     [ "$status" -eq 0 ]
     cd "$ASDF_DIR"
     git tag | grep "$tag"
-    [ "$?" -eq 0 ]
   fi
 }
 
@@ -55,7 +54,6 @@ teardown() {
     [ "$status" -eq 0 ]
     cd "$ASDF_DIR"
     git tag | grep "$tag"
-    [ "$?" -eq 0 ]
   fi
 }
 

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
-# shellcheck disable=SC2164
+# shellcheck disable=SC2030,SC2031,SC2164
 
 load test_helpers
 
@@ -22,14 +22,14 @@ teardown() {
 @test "get_install_path should output version path when version is provided" {
   run get_install_path foo version "1.0.0"
   [ "$status" -eq 0 ]
-  install_path=${output#$HOME/}
+  install_path=${output#"$HOME/"}
   [ "$install_path" = ".asdf/installs/foo/1.0.0" ]
 }
 
 @test "get_install_path should output custom path when custom install type is provided" {
   run get_install_path foo custom "1.0.0"
   [ "$status" -eq 0 ]
-  install_path=${output#$HOME/}
+  install_path=${output#"$HOME/"}
   [ "$install_path" = ".asdf/installs/foo/custom-1.0.0" ]
 }
 
@@ -42,7 +42,7 @@ teardown() {
 @test "get_download_path should output version path when version is provided" {
   run get_download_path foo version "1.0.0"
   [ "$status" -eq 0 ]
-  download_path=${output#$HOME/}
+  download_path=${output#"$HOME/"}
   echo "$download_path"
   [ "$download_path" = ".asdf/downloads/foo/1.0.0" ]
 }
@@ -50,7 +50,7 @@ teardown() {
 @test "get_download_path should output custom path when custom download type is provided" {
   run get_download_path foo custom "1.0.0"
   [ "$status" -eq 0 ]
-  download_path=${output#$HOME/}
+  download_path=${output#"$HOME/"}
   [ "$download_path" = ".asdf/downloads/foo/custom-1.0.0" ]
 }
 

--- a/test/version_commands.bats
+++ b/test/version_commands.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
-# shellcheck disable=SC2164
+# shellcheck disable=SC2012,SC2030,SC2031,SC2164
 
 load test_helpers
 
@@ -72,7 +72,7 @@ teardown() {
 @test "[local - dummy_plugin] with latest:version should return an error for invalid versions" {
   run asdf local "dummy" "latest:99"
   [ "$status" -eq 1 ]
-  [ "$output" = "$(echo "No compatible versions available (dummy 99)")" ]
+  [ "$output" = "No compatible versions available (dummy 99)" ]
 }
 
 @test "[local - dummy_legacy_plugin] with latest should use the latest installed version" {
@@ -90,7 +90,7 @@ teardown() {
 @test "[local - dummy_legacy_plugin] with latest:version should return an error for invalid versions" {
   run asdf local "legacy-dummy" "latest:99"
   [ "$status" -eq 1 ]
-  [ "$output" = "$(echo "No compatible versions available (legacy-dummy 99)")" ]
+  [ "$output" = "No compatible versions available (legacy-dummy 99)" ]
 }
 
 @test "local should allow multiple versions" {
@@ -219,7 +219,7 @@ teardown() {
 @test "[global - dummy_plugin] with latest:version should return an error for invalid versions" {
   run asdf global "dummy" "latest:99"
   [ "$status" -eq 1 ]
-  [ "$output" = "$(echo "No compatible versions available (dummy 99)")" ]
+  [ "$output" = "No compatible versions available (dummy 99)" ]
 }
 
 @test "[global - dummy_legacy_plugin] with latest should use the latest installed version" {
@@ -237,7 +237,7 @@ teardown() {
 @test "[global - dummy_legacy_plugin] with latest:version should return an error for invalid versions" {
   run asdf global "legacy-dummy" "latest:99"
   [ "$status" -eq 1 ]
-  [ "$output" = "$(echo "No compatible versions available (legacy-dummy 99)")" ]
+  [ "$output" = "No compatible versions available (legacy-dummy 99)" ]
 }
 
 @test "global should accept multiple versions" {
@@ -367,16 +367,16 @@ teardown() {
 @test "shell wrapper function should export ENV var" {
   . "$(dirname "$BATS_TEST_DIRNAME")/asdf.sh"
   asdf shell "dummy" "1.1.0"
-  [ "$(echo "$ASDF_DUMMY_VERSION")" = "1.1.0" ]
+  [ "$ASDF_DUMMY_VERSION" = "1.1.0" ]
   unset ASDF_DUMMY_VERSION
 }
 
 @test "shell wrapper function with --unset should unset ENV var" {
   . "$(dirname "$BATS_TEST_DIRNAME")/asdf.sh"
   asdf shell "dummy" "1.1.0"
-  [ "$(echo "$ASDF_DUMMY_VERSION")" = "1.1.0" ]
+  [ "$ASDF_DUMMY_VERSION" = "1.1.0" ]
   asdf shell "dummy" --unset
-  [ -z "$(echo "$ASDF_DUMMY_VERSION")" ]
+  [ -z "$ASDF_DUMMY_VERSION" ]
   unset ASDF_DUMMY_VERSION
 }
 
@@ -454,14 +454,14 @@ false"
 @test "[shell - dummy_plugin] wrapper function should support latest" {
   . "$(dirname "$BATS_TEST_DIRNAME")/asdf.sh"
   asdf shell "dummy" "latest"
-  [ "$(echo "$ASDF_DUMMY_VERSION")" = "2.0.0" ]
+  [ "$ASDF_DUMMY_VERSION" = "2.0.0" ]
   unset ASDF_DUMMY_VERSION
 }
 
 @test "[shell - dummy_legacy_plugin] wrapper function should support latest" {
   . "$(dirname "$BATS_TEST_DIRNAME")/asdf.sh"
   asdf shell "legacy-dummy" "latest"
-  [ "$(echo "$ASDF_LEGACY_DUMMY_VERSION")" = "5.1.0" ]
+  [ "$ASDF_LEGACY_DUMMY_VERSION" = "5.1.0" ]
   unset ASDF_LEGACY_DUMMY_VERSION
 }
 


### PR DESCRIPTION
# Summary

This PR is the **eigth** of a multi-part series that fixes various issues with the tests. For more detailed information, see the [first](https://github.com/asdf-vm/asdf/pull/1433) PR.

I disabled SC2164 in places because it was not relevant since Bats automatically applies -e mode, and ShellCheck doesn't know that - I will update this PR to add a comment for each rule I ignore so it's more clear

I disabled `SC2030` and `SC2031` in places because it was not relevant since the tests are self contained (each test is within a subshell, and tests don't access variables from other tests)

I disabled [`SC2012`](https://www.shellcheck.net/wiki/SC2012) to keep the test behavior exactly the same. For each directory, only alphanumeric filenames were used so this warning doesn't really matter as much.

Closes #1396
