### PR TITLE
test: vaidate Bats minimum required version in tests

### DIFF
--- a/test/test_helpers.bash
+++ b/test/test_helpers.bash
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+bats_require_minimum_version 1.7.0
+
 # shellcheck source=lib/utils.bash
 . "$(dirname "$BATS_TEST_DIRNAME")"/lib/utils.bash
 


### PR DESCRIPTION
# Summary

[According to Bats](https://github.com/bats-core/bats-core/releases/tag/v1.7.0), the just-merged usage of `setup_suite.bash` was added in Bats 1.7. Conveniently, a `bats_require_minimum_version` was also added to assert the minimum Bats version.

This uses that, partially addressing #1435  

The assertion must be in `test_helpers.bash`, because versions under 1.7 won't even automatically source `setup_suite.bash`, making the assertion useless