### PR TITLE
test: Skip Fish test if not installed

### DIFF
--- a/test/asdf_fish.bats
+++ b/test/asdf_fish.bats
@@ -5,6 +5,10 @@ load test_helpers
 
 setup() {
   cd "$(dirname "$BATS_TEST_DIRNAME")"
+
+  if ! command -v fish; then
+    skip "Fish is not installed"
+  fi
 }
 
 cleaned_path() {


### PR DESCRIPTION
# Summary

In the same style as #1423 and #1422, this only runs Fish tests if Fish is installed

Partially addresses #465 (part of the WSL errors are Fish not installed errors, even if the error isn't WSL-specific)

