### PR TITLE
fix: enforce & use consistent function definitions

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -776,7 +776,7 @@ with_shim_executable() {
 
     # This function does get invoked, but shellcheck sees it as unused code
     # shellcheck disable=SC2317
-    function run_within_env() {
+    run_within_env() {
       local path
       path=$(remove_path_from_path "$PATH" "$(asdf_data_dir)/shims")
 

--- a/scripts/checkstyle.py
+++ b/scripts/checkstyle.py
@@ -3,7 +3,7 @@ import re
 import os
 import argparse
 from pathlib import Path
-from typing import List, Dict, Any # compat
+from typing import Callable, List, Dict, Any # compat
 
 # This file checks Bash and Shell scripts for violations not found with
 # shellcheck or existing methods. You can use it in several ways:
@@ -33,6 +33,7 @@ class c:
     RESET = '\033[0m'
     BOLD = '\033[1m'
     UNDERLINE = '\033[4m'
+    LINK: Callable[[str, str], str] = lambda href, text: f'\033]8;;{href}\a{text}\033]8;;\a'
 
 def utilGetStrs(line, m):
     return (
@@ -160,7 +161,7 @@ def main():
         {
             'name': 'no-function-keyword',
             'regex': '^[ \\t]*(?P<match>function .*?(?:\\([ \\t]*\\))?[ \\t]*){',
-            'reason': 'Only allow functions declared like `fn_name() { :; }` for consistency',
+            'reason': 'Only allow functions declared like `fn_name() {{ :; }}` for consistency (see ' + c.LINK('https://www.shellcheck.net/wiki/SC2113', 'ShellCheck SC2113') + ')',
             'fixerFn': noFunctionKeywordFixer,
             'testPositiveMatches': [
                 'function fn() { :; }',

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -453,7 +453,7 @@ EOF
 
   message="callback invoked"
 
-  function callback() {
+  callback() {
     echo "$message"
   }
 

--- a/test/where_command.bats
+++ b/test/where_command.bats
@@ -2,7 +2,7 @@
 
 load test_helpers
 
-function setup() {
+setup() {
   setup_asdf_dir
   install_dummy_plugin
   install_dummy_version 1.0
@@ -10,7 +10,7 @@ function setup() {
   install_dummy_version ref-master
 }
 
-function teardown() {
+teardown() {
   clean_asdf_dir
 }
 


### PR DESCRIPTION
# Summary

In Bash, there are there ways to declare a function:

```sh
fn() { :; }
function fn { :; }
function fn() { :; }
```

This PR ensures that only the first form is used.