### PR TITLE
fix: nushell PATH conversion to list before filter

### DIFF
--- a/asdf.nu
+++ b/asdf.nu
@@ -1,14 +1,14 @@
 def-env configure-asdf [] {
 
     let-env ASDF_DIR = ( if ( $env | get --ignore-errors ASDF_DIR | is-empty ) { $env.ASDF_NU_DIR } else { $env.ASDF_DIR } )
-        
+
     let shims_dir = ( if ( $env | get --ignore-errors ASDF_DATA_DIR | is-empty ) { $env.HOME | path join '.asdf' } else { $env.ASDF_DIR } | path join 'shims' )
 
     let asdf_bin_dir = ( $env.ASDF_DIR | path join 'bin' )
 
 
-    let-env PATH = ( $env.PATH | where { |p| $p != $shims_dir } | append $shims_dir )
-    let-env PATH = ( $env.PATH | where { |p| $p != $asdf_bin_dir } | append $asdf_bin_dir )
+    let-env PATH = ( $env.PATH | split row (char esep) | where { |p| $p != $shims_dir } | append $shims_dir )
+    let-env PATH = ( $env.PATH | split row (char esep) | where { |p| $p != $asdf_bin_dir } | append $asdf_bin_dir )
 
 }
 


### PR DESCRIPTION
# Summary

Nushell, at least in recent versions (I did not check ancient versions) needs to have the `$PATH` variable split on the separator character (`;` for Windows, otherwise `:`). Currently, asdf is broken with Nushell as a result.

Fixes: #1458 

## Other Information

None
