### PR TITLE
fix: bash completion for latest command

### DIFF
--- a/completions/asdf.bash
+++ b/completions/asdf.bash
@@ -77,7 +77,7 @@ _asdf() {
     ;;
   plugin-list | plugin-list-all | info) ;;
   *)
-    local cmds='current global help install list list-all local plugin-add plugin-list plugin-list-all plugin-remove plugin-update reshim shell uninstall update where which info'
+    local cmds='current global help install latest list list-all local plugin-add plugin-list plugin-list-all plugin-remove plugin-update reshim shell uninstall update where which info'
     # shellcheck disable=SC2207
     COMPREPLY=($(compgen -W "$cmds" -- "$cur"))
     ;;


### PR DESCRIPTION
# Summary

Adds _latest_ to the list of commands available for bash tab completion.

Fixes: #1440 

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->
N/A
