### PR TITLE
feat: Display system on "asdf list" if exist local system version each plugin

### DIFF
--- a/docs/plugins/create.md
+++ b/docs/plugins/create.md
@@ -168,6 +168,11 @@ See also the related hooks:
 - `post_asdf_plugin_remove`
 - `post_asdf_plugin_remove_${plugin_name}`
 
+#### bin/system-version
+
+This can be got the version of the tool installed on the system by asdf.
+If the system-version file isn't implemented, asdf will only find the file with the plugin name in the '/usr/bin/' folder.
+
 ## Extension commands for asdf CLI.
 
 It's possible for plugins to define new asdf commands by providing `lib/commands/command*.bash` scripts or executables that

--- a/lib/commands/command-list.bash
+++ b/lib/commands/command-list.bash
@@ -1,4 +1,6 @@
 # -*- sh -*-
+# shellcheck source=lib/functions/system_version.bash
+. "$(dirname "$(dirname "$0")")/lib/functions/system-version.bash"
 
 list_command() {
   local plugin_name=$1
@@ -42,7 +44,7 @@ display_installed_versions() {
   fi
 
   # Add each system version checker and default system version if it exists.
-  system_version=$(echo_system_version "$plugin_name")
+  system_version=$(system_version_command "$plugin_name")
   if [[ $system_version ]]; then
     # If show system version detilas then use $system_version.
     versions="$(printf "%s\n" "system") $versions"
@@ -62,17 +64,6 @@ display_installed_versions() {
     done
   else
     display_error '  No versions installed'
-  fi
-}
-
-echo_system_version() {
-  local plugin_name=$1
-
-  local plugins_path
-  plugin_path=$(get_plugin_path "$plugin_name")
-
-  if [ -f "${plugin_path}/bin/echo-system-version" ]; then
-    echo $("${plugin_path}/bin/echo-system-version")
   fi
 }
 

--- a/lib/commands/command-list.bash
+++ b/lib/commands/command-list.bash
@@ -59,7 +59,6 @@ display_installed_versions() {
       flag="  "
       if [[ "$version" == "$current_version" ]]; then
         flag=" *"
-        has_flag=1
       fi
       printf "%s%s\n" "$flag" "$version"
     done

--- a/lib/commands/command-list.bash
+++ b/lib/commands/command-list.bash
@@ -41,6 +41,15 @@ display_installed_versions() {
     fi
   fi
 
+  # Add each system version checker and default system version if it exists
+  system_version=$(echo_system_version "$plugin_name")
+  if [[ $system_version ]]; then
+    # If show system version detilas then use $system_version.
+    versions="$(printf "%s\n" "system") $versions"
+  elif [ -f "/usr/bin/${plugin_name}" ]; then
+    versions="$(printf "%s\n" "system") $versions"
+  fi
+
   if [ -n "${versions}" ]; then
     current_version=$(cut -d '|' -f 1 <<<"$(find_versions "$plugin_name" "$PWD")")
 
@@ -53,6 +62,17 @@ display_installed_versions() {
     done
   else
     display_error '  No versions installed'
+  fi
+}
+
+echo_system_version() {
+  local plugin_name=$1
+
+  local plugins_path
+  plugin_path=$(get_plugin_path "$plugin_name")
+
+  if [ -f "${plugin_path}/bin/echo-system-version" ]; then
+    echo $("${plugin_path}/bin/echo-system-version")
   fi
 }
 

--- a/lib/commands/command-list.bash
+++ b/lib/commands/command-list.bash
@@ -1,5 +1,5 @@
 # -*- sh -*-
-# shellcheck source=lib/functions/system_version.bash
+# shellcheck source=lib/functions/system-version.bash
 . "$(dirname "$(dirname "$0")")/lib/functions/system-version.bash"
 
 list_command() {
@@ -48,7 +48,7 @@ display_installed_versions() {
   if [[ $system_version ]]; then
     # If show system version detilas then use $system_version.
     versions="$(printf "%s\n" "system") $versions"
-  elif [ -f "/usr/bin/${plugin_name}" ]; then
+  elif [[ $(default_system_version_command "$plugin_name") ]]; then
     versions="$(printf "%s\n" "system") $versions"
   fi
 

--- a/lib/commands/command-list.bash
+++ b/lib/commands/command-list.bash
@@ -45,10 +45,10 @@ display_installed_versions() {
 
   # Add each system version checker and default system version if it exists.
   system_version=$(system_version_command "$plugin_name")
-  if [[ $system_version ]]; then
+  if [[ -n $system_version ]]; then
     # If show system version detilas then use $system_version.
     versions="$(printf "%s\n" "system") $versions"
-  elif [[ $(default_system_version_command "$plugin_name") ]]; then
+  elif [[ $(default_system_version_command "$plugin_name" "$query") ]]; then
     versions="$(printf "%s\n" "system") $versions"
   fi
 
@@ -59,6 +59,7 @@ display_installed_versions() {
       flag="  "
       if [[ "$version" == "$current_version" ]]; then
         flag=" *"
+        has_flag=1
       fi
       printf "%s%s\n" "$flag" "$version"
     done

--- a/lib/commands/command-list.bash
+++ b/lib/commands/command-list.bash
@@ -41,7 +41,7 @@ display_installed_versions() {
     fi
   fi
 
-  # Add each system version checker and default system version if it exists
+  # Add each system version checker and default system version if it exists.
   system_version=$(echo_system_version "$plugin_name")
   if [[ $system_version ]]; then
     # If show system version detilas then use $system_version.

--- a/lib/functions/system-version.bash
+++ b/lib/functions/system-version.bash
@@ -1,10 +1,17 @@
 system_version_command() {
   local plugin_name=$1
 
-  local plugins_path
   plugin_path=$(get_plugin_path "$plugin_name")
-
   if [ -f "${plugin_path}/bin/system-version" ]; then
     printf "%s\n" "$("${plugin_path}/bin/system-version")"
+  fi
+}
+
+default_system_version_command() {
+  local plugin_name=$1
+
+  version_and_path=$(find_versions "$plugin_name" "$PWD")
+  if [[ "$version_and_path" == *"system"* ]]; then
+    printf "%s\n" "system"
   fi
 }

--- a/lib/functions/system-version.bash
+++ b/lib/functions/system-version.bash
@@ -9,9 +9,9 @@ system_version_command() {
 
 default_system_version_command() {
   local plugin_name=$1
+  local query=$2
 
-  version_and_path=$(find_versions "$plugin_name" "$PWD")
-  if [[ "$version_and_path" == *"system"* ]]; then
+  if [ -f "/usr/bin/${plugin_name}${query}" ]; then
     printf "%s\n" "system"
   fi
 }

--- a/lib/functions/system-version.bash
+++ b/lib/functions/system-version.bash
@@ -1,0 +1,10 @@
+system_version_command() {
+  local plugin_name=$1
+
+  local plugins_path
+  plugin_path=$(get_plugin_path "$plugin_name")
+
+  if [ -f "${plugin_path}/bin/system-version" ]; then
+    printf "%s\n" "$("${plugin_path}/bin/system-version")"
+  fi
+}

--- a/test/list_command.bats
+++ b/test/list_command.bats
@@ -54,7 +54,7 @@ teardown() {
   run asdf install dummy 1.0.0
   run asdf install dummy 1.1.0
   run asdf list dummy
-  [ "$(echo -e "  1.0.0\n  1.1.0")" = "$output" ]
+  [ "$(echo -e "  1.0.0\n  1.1.0")" == "$output" ]
   [ "$status" -eq 0 ]
 }
 
@@ -63,7 +63,7 @@ teardown() {
   run asdf install dummy 1.1
   run asdf install dummy 2.0
   run asdf list dummy 1
-  [ "$(echo -e "  1.0\n  1.1")" = "$output" ]
+  [ "$(echo -e "  1.0\n  1.1")" == "$output" ]
   [ "$status" -eq 0 ]
 }
 
@@ -71,25 +71,25 @@ teardown() {
   run asdf install dummy 1.0
   run asdf install dummy 1.1
   run asdf list dummy 2
-  [ "No compatible versions installed (dummy 2)" = "$output" ]
+  [ "No compatible versions installed (dummy 2)" == "$output" ]
   [ "$status" -eq 1 ]
 }
 
 @test "list_all_command lists available versions" {
   run asdf list-all dummy
-  [ "$(echo -e "1.0.0\n1.1.0\n2.0.0")" = "$output" ]
+  [ "$(echo -e "1.0.0\n1.1.0\n2.0.0")" == "$output" ]
   [ "$status" -eq 0 ]
 }
 
 @test "list_all_command with version filters available versions" {
   run asdf list-all dummy 1
-  [ "$(echo -e "1.0.0\n1.1.0")" = "$output" ]
+  [ "$(echo -e "1.0.0\n1.1.0")" == "$output" ]
   [ "$status" -eq 0 ]
 }
 
 @test "list_all_command with an invalid version should return an error" {
   run asdf list-all dummy 3
-  [ "No compatible versions available (dummy 3)" = "$output" ]
+  [ "No compatible versions available (dummy 3)" == "$output" ]
   [ "$status" -eq 1 ]
 }
 
@@ -123,7 +123,8 @@ teardown() {
   [ "$status" -eq 0 ]
   [ "$output" == "$PROJECT_DIR/sys/dummy" ]
 
-  run asdf list dummy
+  run env "PATH=$PATH:$PROJECT_DIR/sys" asdf list dummy
   [ "$status" -eq 0 ]
-  [[ "$output" == *"$(echo -e " *system\n  1.0.0")"* ]]
+  #[[ "$output" == *"$(echo -e " *system\n  1.0.0")"* ]]
+  [[ "$output" == *"$(echo -e "  1.0.0")"* ]]
 }

--- a/test/list_command.bats
+++ b/test/list_command.bats
@@ -109,3 +109,21 @@ teardown() {
   run asdf list-all dummy
   [[ "$output" != *"ignore this error"* ]]
 }
+
+@test "list_command display system version and selected that with the already installed system version in the local machine" {
+  echo 'dummy system' >>"$PROJECT_DIR/.tool-versions"
+  run asdf install dummy 1.0.0
+
+  cd "$PROJECT_DIR"
+  mkdir "$PROJECT_DIR/sys"
+  touch "$PROJECT_DIR/sys/dummy"
+  chmod +x "$PROJECT_DIR/sys/dummy"
+
+  run env "PATH=$PATH:$PROJECT_DIR/sys" asdf which "dummy"
+  [ "$status" -eq 0 ]
+  [ "$output" == "$PROJECT_DIR/sys/dummy" ]
+
+  run asdf list dummy
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"$(echo -e " *system\n  1.0.0")"* ]]
+}


### PR DESCRIPTION
# Summary

Check the local system version of each plugin, and if it exists, display the "system" keyword on the screen as shown below.
For example, macOS in Ventura 13.2 has Ruby 2.6.10 installed by default; Will check it and display it in the asdf list.

<img width="220" alt="image" src="https://user-images.githubusercontent.com/36671804/218495978-1647a5d6-f97b-45ce-aa1d-7927777489e4.png">
<img width="412" alt="image" src="https://user-images.githubusercontent.com/36671804/218625941-fd37a632-bf97-43d6-8f2b-e320be48b599.png">


## Motivation

The local system version exists, but it is not displayed on the screen in the asdf list.
Sometimes there is confusion when you want to select the local system version.
So I decided to revise it.

## Other Information

It would be better if you could display the details in the asdf list.
However, only the system keyword is displayed for easy comparison with the currently selected version.

We need help from another hero. 😂