### PR TITLE
fix: prefix messages with 'asdf: '

### DIFF
--- a/bin/private/asdf-exec
+++ b/bin/private/asdf-exec
@@ -10,6 +10,6 @@ rm "$(asdf_data_dir)"/shims/*
 "$asdf_dir"/bin/asdf reshim
 shim_name=$(basename "$2")
 
-printf "asdf: now running %s\\n" "$shim_name"
+display "now running %s\\n" "$shim_name"
 
 exec "$shim_name" "${@:3}"

--- a/lib/commands/command-current.bash
+++ b/lib/commands/command-current.bash
@@ -30,15 +30,15 @@ plugin_current_command() {
 
   if [ -n "$version_not_installed" ]; then
     description="Not installed. Run \"asdf install $plugin $version\""
-    printf "$terminal_format" "$plugin" "$version" "$description" 1>&2
+    display "$terminal_format" "$plugin" "$version" "$description" 1>&2
     return 1
   elif [ -z "$full_version" ]; then
     description="No version is set. Run \"asdf <global|shell|local> $plugin <version>\""
-    printf "$terminal_format" "$plugin" "______" "$description" 1>&2
+    display "$terminal_format" "$plugin" "______" "$description" 1>&2
     return 126
   else
     description="$version_file_path"
-    printf "$terminal_format" "$plugin" "$full_version" "$description"
+    display "$terminal_format" "$plugin" "$full_version" "$description"
   fi
 }
 
@@ -75,8 +75,8 @@ check_for_deprecated_plugin() {
   local new_script="${plugin_path}/bin/list-legacy-filenames"
 
   if [ "$legacy_config" = "yes" ] && [ -f "$deprecated_script" ] && [ ! -f "$new_script" ]; then
-    printf "Heads up! It looks like your %s plugin is out of date. You can update it with:\n\n" "$plugin_name"
-    printf "  asdf plugin-update %s\n\n" "$plugin_name"
+    display "Heads up! It looks like your %s plugin is out of date. You can update it with:\n\n" "$plugin_name"
+    display "  asdf plugin-update %s\n\n" "$plugin_name"
   fi
 }
 

--- a/lib/commands/command-exec.bash
+++ b/lib/commands/command-exec.bash
@@ -16,7 +16,7 @@ shim_exec_command() {
     local executable_path="$3"
 
     if [ ! -x "$executable_path" ]; then
-      printf "No %s executable found for %s %s\n" "$shim_name" "$plugin_name" "$version" >&2
+      display "No %s executable found for %s %s\n" "$shim_name" "$plugin_name" "$version" >&2
       exit 2
     fi
 

--- a/lib/commands/command-exec.bash
+++ b/lib/commands/command-exec.bash
@@ -10,6 +10,9 @@ shim_exec_command() {
     exit 1
   fi
 
+  # shellcheck disable=SC2034
+  ASDF_INTERNAL_PREFIX_PRINTS=yes
+
   exec_shim() {
     local plugin_name="$1"
     local version="$2"

--- a/lib/commands/command-help.bash
+++ b/lib/commands/command-help.bash
@@ -78,11 +78,11 @@ help_command() {
           (print_plugin_help "$plugin_path")
         fi
       else
-        printf "No documentation for plugin %s\n" "$plugin_name" >&2
+        display "No documentation for plugin %s\n" "$plugin_name" >&2
         exit 1
       fi
     else
-      printf "No plugin named %s\n" "$plugin_name" >&2
+      display "No plugin named %s\n" "$plugin_name" >&2
       exit 1
     fi
   else

--- a/lib/commands/command-list.bash
+++ b/lib/commands/command-list.bash
@@ -15,7 +15,7 @@ list_command() {
         display_installed_versions "$plugin_name" "$query"
       done
     else
-      printf "%s\n" 'No plugins installed'
+      display "%s\n" 'No plugins installed'
     fi
   else
     check_if_plugin_exists "$plugin_name"

--- a/lib/commands/command-plugin-push.bash
+++ b/lib/commands/command-plugin-push.bash
@@ -4,14 +4,14 @@ plugin_push_command() {
   local plugin_name=$1
   if [ "$plugin_name" = "--all" ]; then
     for dir in "$(asdf_data_dir)"/plugins/*/; do
-      printf "Pushing %s...\n" "$(basename "$dir")"
+      display "Pushing %s...\n" "$(basename "$dir")"
       (cd "$dir" && git push)
     done
   else
     local plugin_path
     plugin_path=$(get_plugin_path "$plugin_name")
     check_if_plugin_exists "$plugin_name"
-    printf "Pushing %s...\n" "$plugin_name"
+    display "Pushing %s...\n" "$plugin_name"
     (cd "$plugin_path" && git push)
   fi
 }

--- a/lib/commands/command-plugin-test.bash
+++ b/lib/commands/command-plugin-test.bash
@@ -92,20 +92,21 @@ plugin_test_command() {
     local list_all="$plugin_path/bin/list-all"
     if grep api.github.com "$list_all" >/dev/null; then
       if ! grep Authorization "$list_all" >/dev/null; then
-        printf "\nLooks like %s/bin/list-all relies on GitHub releases\n" "$plugin_name"
-        printf "but it does not properly sets an Authorization header to prevent\n"
-        printf "GitHub API rate limiting.\n\n"
-        printf "See https://github.com/asdf-vm/asdf/blob/master/docs/creating-plugins.md#github-api-rate-limiting\n"
+        printf '\n'
+        display "Looks like %s/bin/list-all relies on GitHub releases\n" "$plugin_name"
+        display "but it does not properly sets an Authorization header to prevent\n"
+        display "GitHub API rate limiting.\n\n"
+        display "See https://github.com/asdf-vm/asdf/blob/master/docs/creating-plugins.md#github-api-rate-limiting\n"
 
         fail_test "$plugin_name/bin/list-all does not set GitHub Authorization token"
       fi
 
       # test for most common token names we have on plugins. If both are empty show this warning
       if [ -z "$OAUTH_TOKEN" ] && [ -z "$GITHUB_API_TOKEN" ]; then
-        printf "%s/bin/list-all is using GitHub API, just be sure you provide an API Authorization token\n" "$plugin_name"
-        printf "via your CI env GITHUB_API_TOKEN. This is the current rate_limit:\n\n"
+        display "%s/bin/list-all is using GitHub API, just be sure you provide an API Authorization token\n" "$plugin_name"
+        display "via your CI env GITHUB_API_TOKEN. This is the current rate_limit:\n\n"
         curl -s https://api.github.com/rate_limit
-        printf "\n"
+        display "\n"
       fi
     fi
 

--- a/lib/commands/command-update.bash
+++ b/lib/commands/command-update.bash
@@ -7,7 +7,7 @@ update_command() {
     cd "$(asdf_dir)" || exit 1
 
     if [ -f asdf_updates_disabled ] || ! git rev-parse --is-inside-work-tree &>/dev/null; then
-      printf "Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf.\n"
+      display "Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf.\n"
       exit 42
     else
       do_update "$update_to_head"
@@ -23,7 +23,7 @@ do_update() {
     git fetch origin master
     git checkout master
     git reset --hard origin/master
-    printf "Updated asdf to latest on the master branch\n"
+    display "Updated asdf to latest on the master branch\n"
   else
     # Update to latest release
     git fetch origin --tags || exit 1
@@ -38,7 +38,7 @@ do_update() {
 
     # Update
     git checkout "$tag" || exit 1
-    printf "Updated asdf to release %s\n" "$tag"
+    display "Updated asdf to release %s\n" "$tag"
   fi
 }
 

--- a/lib/commands/command-which.bash
+++ b/lib/commands/command-which.bash
@@ -15,7 +15,7 @@ which_command() {
     local executable_path="$3"
 
     if [ ! -x "$executable_path" ]; then
-      printf "No %s executable found for %s %s\n" "$shim_name" "$plugin_name" "$version" >&2
+      display "No %s executable found for %s %s\n" "$shim_name" "$plugin_name" "$version" >&2
       exit 1
     fi
 

--- a/lib/functions/installs.bash
+++ b/lib/functions/installs.bash
@@ -6,7 +6,8 @@ handle_failure() {
 
 handle_cancel() {
   local install_path="$1"
-  printf "\nreceived sigint, cleaning up"
+  printf '\n'
+  display '%s' "received sigint, cleaning up"
   handle_failure "$install_path"
 }
 
@@ -55,7 +56,7 @@ install_one_local_tool() {
       install_tool_version "$plugin_name" "$plugin_version"
     done
   else
-    printf "No versions specified for %s in config files or environment\n" "$plugin_name"
+    display "No versions specified for %s in config files or environment\n" "$plugin_name"
     exit 1
   fi
 }
@@ -85,7 +86,7 @@ install_local_tool_versions() {
   fi
 
   if [ -z "$plugins_installed" ]; then
-    printf "Install plugins first to be able to install tools\n"
+    display "Install plugins first to be able to install tools\n"
     exit 1
   fi
 
@@ -95,7 +96,7 @@ install_local_tool_versions() {
     tools_file=$(strip_tool_version_comments "$tool_versions_path" | cut -d ' ' -f 1)
     for plugin_name in $tools_file; do
       if ! printf '%s\n' "${plugins_installed[@]}" | grep -q "^$plugin_name\$"; then
-        printf "%s plugin is not installed\n" "$plugin_name"
+        display "%s plugin is not installed\n" "$plugin_name"
         some_plugin_not_installed='yes'
       fi
     done
@@ -122,9 +123,9 @@ install_local_tool_versions() {
   fi
 
   if [ -z "$some_tools_installed" ]; then
-    printf "Either specify a tool & version in the command\n"
-    printf "OR add .tool-versions file in this directory\n"
-    printf "or in a parent directory\n"
+    display "Either specify a tool & version in the command\n"
+    display "OR add .tool-versions file in this directory\n"
+    display "or in a parent directory\n"
     exit 1
   fi
 }
@@ -180,7 +181,7 @@ install_tool_version() {
   trap 'handle_cancel $install_path' INT
 
   if [ -d "$install_path" ]; then
-    printf "%s %s is already installed\n" "$plugin_name" "$full_version"
+    display "%s %s is already installed\n" "$plugin_name" "$full_version"
   else
 
     if [ -f "${plugin_path}/bin/download" ]; then

--- a/lib/functions/plugins.bash
+++ b/lib/functions/plugins.bash
@@ -145,7 +145,7 @@ update_plugin() {
     asdf_run_hook "pre_asdf_plugin_update" "$plugin_name"
     asdf_run_hook "pre_asdf_plugin_update_${plugin_name}"
 
-    printf "Updating %s to %s\n" "$plugin_name" "$gitref"
+    display "Updating %s to %s\n" "$plugin_name" "$gitref"
 
     git "${common_git_options[@]}" fetch --prune --update-head-ok origin "$gitref:$gitref"
     prev_ref=$(git "${common_git_options[@]}" rev-parse --short HEAD)

--- a/lib/functions/versions.bash
+++ b/lib/functions/versions.bash
@@ -92,7 +92,7 @@ list_all_command() {
 
   if [[ $return_code -ne 0 ]]; then
     # Printing all output to allow plugin to handle error formatting
-    printf "Plugin %s's list-all callback script failed with output:\n" "${plugin_name}" >&2
+    display "Plugin %s's list-all callback script failed with output:\n" "${plugin_name}" >&2
     printf "%s\n" "$(cat "$std_err_file")" >&2
     printf "%s\n" "$(cat "$std_out_file")" >&2
     rm "$std_out_file" "$std_err_file"
@@ -144,7 +144,7 @@ latest_command() {
     versions=$("${plugin_path}"/bin/latest-stable "$query")
     if [ -z "${versions}" ]; then
       # this branch requires this print to mimic the error from the list-all branch
-      printf "No compatible versions available (%s %s)\n" "$plugin_name" "$query" >&2
+      display "No compatible versions available (%s %s)\n" "$plugin_name" "$query" >&2
       exit 1
     fi
   else
@@ -201,7 +201,7 @@ latest_all() {
       printf "%s\t%s\t%s\n" "$plugin_name" "$version" "$installed_status"
     done
   else
-    printf "%s\n" 'No plugins installed'
+    display "%s\n" 'No plugins installed'
   fi
   exit 0
 }

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -153,7 +153,9 @@ display_error() {
 }
 
 display() {
-  printf 'asdf: '
+  if [ "$ASDF_INTERNAL_PREFIX_PRINTS" = 'yes' ]; then
+    printf 'asdf: '
+  fi
 
   # shellcheck disable=SC2059
   printf "$@"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -137,7 +137,7 @@ version_not_installed_text() {
   local plugin_name=$1
   local version=$2
 
-  printf "version %s is not installed for %s\n" "$version" "$plugin_name"
+  display "version %s is not installed for %s\n" "$version" "$plugin_name"
 }
 
 get_plugin_path() {
@@ -150,6 +150,13 @@ get_plugin_path() {
 
 display_error() {
   printf "%s\n" "$1" >&2
+}
+
+display() {
+  printf 'asdf: '
+
+  # shellcheck disable=SC2059
+  printf "$@"
 }
 
 get_version_in_dir() {
@@ -231,7 +238,7 @@ find_versions() {
 
 display_no_version_set() {
   local plugin_name=$1
-  printf "No version is set for %s; please run \`asdf <global | shell | local> %s <version>\`\n" "$plugin_name" "$plugin_name"
+  display "No version is set for %s; please run \`asdf <global | shell | local> %s <version>\`\n" "$plugin_name" "$plugin_name"
 }
 
 get_version_from_env() {
@@ -423,7 +430,7 @@ initialize_or_update_repository() {
 
   disable_plugin_short_name_repo="$(get_asdf_config_value "disable_plugin_short_name_repository")"
   if [ "yes" = "$disable_plugin_short_name_repo" ]; then
-    printf "Short-name plugin repository is disabled\n" >&2
+    display "Short-name plugin repository is disabled\n" >&2
     exit 1
   fi
 
@@ -431,10 +438,10 @@ initialize_or_update_repository() {
   repository_path=$(asdf_data_dir)/repository
 
   if [ ! -d "$repository_path" ]; then
-    printf "initializing plugin repository..."
+    display "initializing plugin repository..."
     git clone "$repository_url" "$repository_path"
   elif repository_needs_update; then
-    printf "updating plugin repository..."
+    display "updating plugin repository..."
     (cd "$repository_path" && git fetch && git reset --hard origin/master)
   fi
 
@@ -640,7 +647,7 @@ shim_plugin_versions() {
   if [ -x "$shim_path" ]; then
     grep "# asdf-plugin: " "$shim_path" 2>/dev/null | sed -e "s/# asdf-plugin: //" | uniq
   else
-    printf "asdf: unknown shim %s\n" "$executable_name"
+    display "unknown shim %s\n" "$executable_name"
     return 1
   fi
 }
@@ -653,7 +660,7 @@ shim_plugins() {
   if [ -x "$shim_path" ]; then
     grep "# asdf-plugin: " "$shim_path" 2>/dev/null | sed -e "s/# asdf-plugin: //" | cut -d' ' -f 1 | uniq
   else
-    printf "asdf: unknown shim %s\n" "$executable_name"
+    display "unknown shim %s\n" "$executable_name"
     return 1
   fi
 }
@@ -814,15 +821,16 @@ with_shim_executable() {
     done
 
     if [ -n "${preset_plugin_versions[*]}" ]; then
-      printf "%s %s\n" "No preset version installed for command" "$shim_name"
-      printf "%s\n\n" "Please install a version by running one of the following:"
+      display "%s %s\n" "No preset version installed for command" "$shim_name"
+      display "%s\n\n" "Please install a version by running one of the following:"
       for preset_plugin_version in "${preset_plugin_versions[@]}"; do
-        printf "%s %s\n" "asdf install" "$preset_plugin_version"
+        display "%s %s\n" "asdf install" "$preset_plugin_version"
       done
-      printf "\n%s %s\n" "or add one of the following versions in your config file at" "$closest_tool_version"
+      printf '\n'
+      display "%s %s\n" "or add one of the following versions in your config file at" "$closest_tool_version"
     else
-      printf "%s %s\n" "No version is set for command" "$shim_name"
-      printf "%s %s\n" "Consider adding one of the following versions in your config file at" "$closest_tool_version"
+      display "%s %s\n" "No version is set for command" "$shim_name"
+      display "%s %s\n" "Consider adding one of the following versions in your config file at" "$closest_tool_version"
     fi
     shim_plugin_versions "${shim_name}"
   ) >&2


### PR DESCRIPTION
# Summary

Sometimes asdf prints messages, and it's not obvious that the message is coming from asdf. This fixes that.

It does so by prepending `asdf: ` to every single user-read console message, but only on the `asdf exec` subcommand codepath.

Fixes: #1467
