### PR TITLE
fix: Better handling with paths that include spaces

### DIFF
--- a/bin/asdf
+++ b/bin/asdf
@@ -49,7 +49,10 @@ find_asdf_cmd() {
 find_plugin_cmd() {
   local ASDF_CMD_FILE args_offset
   if [ -d "$(get_plugin_path "$1")/bin" ]; then
-    IFS=' ' read -r ASDF_CMD_FILE args_offset <<<"$(find_cmd "$(get_plugin_path "$1")/lib/commands" "${@:2}")"
+    local result=
+    result="$(find_cmd "$(get_plugin_path "$1")/lib/commands" "${@:2}")"
+    ASDF_CMD_FILE=${result% *}
+    args_offset=${result##* }
     if [ -n "$ASDF_CMD_FILE" ]; then
       args_offset=$((args_offset + 1)) # since the first argument is the plugin name
       printf "%s %s\\n" "$ASDF_CMD_FILE" "$args_offset"
@@ -65,9 +68,14 @@ asdf_cmd() {
     exit 1
   fi
 
-  IFS=' ' read -r ASDF_CMD_FILE args_offset <<<"$(find_asdf_cmd "$@")"
+  local result=
+  result="$(find_asdf_cmd "$@")"
+  ASDF_CMD_FILE=${result% *}
+  args_offset=${result##* }
   if [ -z "$ASDF_CMD_FILE" ]; then
-    IFS=' ' read -r ASDF_CMD_FILE args_offset <<<"$(find_plugin_cmd "$@")"
+    result="$(find_plugin_cmd "$@")"
+    ASDF_CMD_FILE=${result% *}
+    args_offset=${result##* }
   fi
 
   if [ -x "$ASDF_CMD_FILE" ]; then

--- a/lib/commands/command-plugin-remove.bash
+++ b/lib/commands/command-plugin-remove.bash
@@ -21,7 +21,16 @@ plugin_remove_command() {
   rm -rf "$(asdf_data_dir)/installs/${plugin_name}"
   rm -rf "$(asdf_data_dir)/downloads/${plugin_name}"
 
-  grep -l --null "asdf-plugin: ${plugin_name}" "$(asdf_data_dir)"/shims/* 2>/dev/null | xargs -0 rm -f
+  local is_nullglob_disabled=
+  shopt -q nullglob || is_nullglob_disabled=yes
+  shopt -s nullglob
+  for f in "$(asdf_data_dir)"/shims/*; do
+    if grep -q "asdf-plugin: ${plugin_name}" "$f"; then
+      rm -f "$f"
+    fi
+  done
+  [ "$is_nullglob_disabled" = 'yes' ] && shopt -u nullglob
+  unset -v is_nullglob_disabled
 
   asdf_run_hook "post_asdf_plugin_remove" "$plugin_name"
   asdf_run_hook "post_asdf_plugin_remove_${plugin_name}"

--- a/lib/commands/command-plugin-remove.bash
+++ b/lib/commands/command-plugin-remove.bash
@@ -21,7 +21,7 @@ plugin_remove_command() {
   rm -rf "$(asdf_data_dir)/installs/${plugin_name}"
   rm -rf "$(asdf_data_dir)/downloads/${plugin_name}"
 
-  grep -l "asdf-plugin: ${plugin_name}" "$(asdf_data_dir)"/shims/* 2>/dev/null | xargs rm -f
+  grep -l --null "asdf-plugin: ${plugin_name}" "$(asdf_data_dir)"/shims/* 2>/dev/null | xargs -0 rm -f
 
   asdf_run_hook "post_asdf_plugin_remove" "$plugin_name"
   asdf_run_hook "post_asdf_plugin_remove_${plugin_name}"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -206,7 +206,7 @@ find_versions() {
   local legacy_filenames=""
 
   if [ "$legacy_config" = "yes" ] && [ -f "$legacy_list_filenames_script" ]; then
-    legacy_filenames=$($legacy_list_filenames_script)
+    legacy_filenames=$("$legacy_list_filenames_script")
   fi
 
   while [ "$search_path" != "/" ]; do

--- a/test/reshim_command.bats
+++ b/test/reshim_command.bats
@@ -4,7 +4,7 @@
 load test_helpers
 
 setup() {
-  ASDF_BATS_SPACE_IN_PATH=true setup_asdf_dir
+  setup_asdf_dir
   install_dummy_plugin
 
   PROJECT_DIR="$HOME/project"

--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -206,6 +206,8 @@ teardown() {
   [ "$output" = "System" ]
 }
 
+# NOTE: The name of this test is linked to a condition in `test_helpers.bash. See
+# the 'setup_asdf_dir' function for details.
 @test "shim exec should use path executable when specified version path:<path>" {
   run asdf install dummy 1.0
 

--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -206,12 +206,9 @@ teardown() {
   [ "$output" = "System" ]
 }
 
+# NOTE: The name of this test is linked to a condition in `test_helpers.bash. See
+# the 'setup_asdf_dir' function for details.
 @test "shim exec should use path executable when specified version path:<path>" {
-  # Currently, the .tool_versions parser is not setup to handle specifying a path with spaces:
-  # `dummy path:/path/with space/bin path:/path2/with space/bin`
-  # So, make sure `BASE_DIR` has no spaces, so that the test can pass.
-  BASE_DIR="$(mktemp -dt "asdf_with_no_spaces.XXXX")"
-
   run asdf install dummy 1.0
 
   CUSTOM_DUMMY_PATH="$PROJECT_DIR/foo"

--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -206,9 +206,12 @@ teardown() {
   [ "$output" = "System" ]
 }
 
-# NOTE: The name of this test is linked to a condition in `test_helpers.bash. See
-# the 'setup_asdf_dir' function for details.
 @test "shim exec should use path executable when specified version path:<path>" {
+  # Currently, the .tool_versions parser is not setup to handle specifying a path with spaces:
+  # `dummy path:/path/with space/bin path:/path2/with space/bin`
+  # So, make sure `BASE_DIR` has no spaces, so that the test can pass.
+  BASE_DIR="$(mktemp -dt "asdf_with_no_spaces.XXXX")"
+
   run asdf install dummy 1.0
 
   CUSTOM_DUMMY_PATH="$PROJECT_DIR/foo"

--- a/test/test_helpers.bash
+++ b/test/test_helpers.bash
@@ -6,11 +6,12 @@ bats_require_minimum_version 1.7.0
 . "$(dirname "$BATS_TEST_DIRNAME")"/lib/utils.bash
 
 setup_asdf_dir() {
-  if [ -n "${ASDF_BATS_SPACE_IN_PATH:-}" ]; then
-    BASE_DIR="$(mktemp -dt "asdf with spaces.XXXX")"
+  if [ "$BATS_TEST_NAME" = 'test_shim_exec_should_use_path_executable_when_specified_version_path-3a-3cpath-3e' ]; then
+    BASE_DIR="$(mktemp -dt "asdf_with_no_spaces.XXXX")"
   else
-    BASE_DIR="$(mktemp -dt asdf.XXXX)"
+    BASE_DIR="$(mktemp -dt "asdf with spaces.XXXX")"
   fi
+
   HOME="$BASE_DIR/home"
   ASDF_DIR="$HOME/.asdf"
   mkdir -p "$ASDF_DIR/plugins"

--- a/test/test_helpers.bash
+++ b/test/test_helpers.bash
@@ -6,7 +6,12 @@ bats_require_minimum_version 1.7.0
 . "$(dirname "$BATS_TEST_DIRNAME")"/lib/utils.bash
 
 setup_asdf_dir() {
-  BASE_DIR="$(mktemp -dt "asdf with spaces.XXXX")"
+  if [ "$BATS_TEST_NAME" = 'test_shim_exec_should_use_path_executable_when_specified_version_path-3a-3cpath-3e' ]; then
+    BASE_DIR="$(mktemp -dt "asdf_with_no_spaces.XXXX")"
+  else
+    BASE_DIR="$(mktemp -dt "asdf with spaces.XXXX")"
+  fi
+
   HOME="$BASE_DIR/home"
   ASDF_DIR="$HOME/.asdf"
   mkdir -p "$ASDF_DIR/plugins"

--- a/test/test_helpers.bash
+++ b/test/test_helpers.bash
@@ -6,12 +6,7 @@ bats_require_minimum_version 1.7.0
 . "$(dirname "$BATS_TEST_DIRNAME")"/lib/utils.bash
 
 setup_asdf_dir() {
-  if [ "$BATS_TEST_NAME" = 'test_shim_exec_should_use_path_executable_when_specified_version_path-3a-3cpath-3e' ]; then
-    BASE_DIR="$(mktemp -dt "asdf_with_no_spaces.XXXX")"
-  else
-    BASE_DIR="$(mktemp -dt "asdf with spaces.XXXX")"
-  fi
-
+  BASE_DIR="$(mktemp -dt "asdf with spaces.XXXX")"
   HOME="$BASE_DIR/home"
   ASDF_DIR="$HOME/.asdf"
   mkdir -p "$ASDF_DIR/plugins"


### PR DESCRIPTION
# Summary

I saw that there was a `ASDF_BATS_SPACE_IN_PATH` variable, which seemed to be part of a gradual transition to make the tests work better with whitespace stuff. Probably with help from #1433, it was somewhat trivial to make the proper fixes and remove this variable entirely.

One test was left out because it seems that change requires a fix in the `.tool-versions` parser (related to the `path:~/src/elixir` feature)
 
