### PR TITLE
docs: list asdf-nodejs deps for enterprise linux in guide

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -312,10 +312,11 @@ For demonstration purposes we will install & set [Node.js](https://nodejs.org/) 
 
 Each plugin has dependencies so we need to check the plugin repo where they should be listed. For `asdf-nodejs` they are:
 
-| OS             | Dependency Installation                 |
-| -------------- | --------------------------------------- |
-| Linux (Debian) | `apt-get install dirmngr gpg curl gawk` |
-| macOS          | `brew install gpg gawk`                 |
+| OS                             | Dependency Installation                 |
+| ------------------------------ | --------------------------------------- |
+| Debian                         | `apt-get install dirmngr gpg curl gawk` |
+| CentOS/ Rocky Linux/ AlmaLinux | `yum install gnupg2 curl gawk`          |
+| macOS                          | `brew install gpg gawk`                 |
 
 We should install dependencies first as some Plugins have post-install hooks.
 


### PR DESCRIPTION
# Summary

I saw that there was no "Dependency Installation" for Enterprise Linux.
