### PR TITLE
fix: Prepend asdf directories to the PATH in Nushell

### DIFF
--- a/asdf.nu
+++ b/asdf.nu
@@ -7,8 +7,8 @@ def-env configure-asdf [] {
     let asdf_bin_dir = ( $env.ASDF_DIR | path join 'bin' )
 
 
-    let-env PATH = ( $env.PATH | split row (char esep) | where { |p| $p != $shims_dir } | append $shims_dir )
-    let-env PATH = ( $env.PATH | split row (char esep) | where { |p| $p != $asdf_bin_dir } | append $asdf_bin_dir )
+    let-env PATH = ( $env.PATH | split row (char esep) | where { |p| $p != $shims_dir } | prepend $shims_dir )
+    let-env PATH = ( $env.PATH | split row (char esep) | where { |p| $p != $asdf_bin_dir } | prepend $asdf_bin_dir )
 
 }
 


### PR DESCRIPTION
# Summary

In the Nushell setup script, I change the paths to asdf shims and bin to be prepended in front of the existing `$PATH` instead of being appended at the end. This change makes asdf plugins have priority over the existing commands in the search path as well as other shells' setup.