### PR TITLE
ci: bump nushell & elvish versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,8 +7,8 @@ on:
   pull_request:
 
 env:
-  ELVISH_VERSION: v0.18.0
-  NUSHELL_VERSION: 0.73.0
+  ELVISH_VERSION: v0.19.2
+  NUSHELL_VERSION: 0.77.0
 
 jobs:
   detect-changes:


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

- Elvish versions listed here: https://dl.elv.sh/linux-amd64/
- Nushell versions listed here: https://github.com/nushell/nushell/releases

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->

Since these are both pre `1.0.0` release we should try to keep up to date with testing against the latest.