### PR TITLE
fix: Nushell plugin list --urls

### DIFF
--- a/asdf.nu
+++ b/asdf.nu
@@ -79,8 +79,10 @@ module asdf {
     ] {
 
         let params = [
-            {name: 'urls', enabled: $urls, template: '\s+?(?P<repository>git@.+\.git)', flag: '--urls'}
-            {name: 'refs', enabled: $refs, template: '\s+?(?P<branch>\w+)\s+(?P<ref>\w+)', flag: '--refs'}
+            {name: 'urls', enabled: $urls, flag: '--urls',
+             template: '\s+?(?P<repository>(?:http[s]?|git).+\.git|/.+)'}
+            {name: 'refs', enabled: $refs, flag: '--refs',
+             template: '\s+?(?P<branch>\w+)\s+(?P<ref>\w+)'}
         ]
 
         let template = '(?P<name>.+)' + (
@@ -91,10 +93,9 @@ module asdf {
                             str trim
                         )
 
-        let parsed_urls_flag = ($params | where enabled and name == 'urls'  | get --ignore-errors flag | default '' )
-        let parsed_refs_flag = ($params | where enabled and name == 'refs'  | get --ignore-errors flag | default '' )
+        let flags = ($params | where enabled | get --ignore-errors flag | default '' )
 
-        ^asdf plugin list $parsed_urls_flag $parsed_refs_flag | lines | parse -r $template | str trim
+        ^asdf plugin list $flags | lines | parse -r $template | str trim
     }
 
     # list all available plugins

--- a/lib/functions/plugins.bash
+++ b/lib/functions/plugins.bash
@@ -28,15 +28,13 @@ plugin_list_command() {
         printf "%s" "$plugin_name"
 
         if [ -n "$show_repo" ]; then
-          printf "\t%s" "$(git --git-dir "$plugin_path/.git" remote get-url origin 2>/dev/null)"
+          printf "\t%s" "$(get_plugin_remote_url "$plugin_name")"
         fi
 
         if [ -n "$show_ref" ]; then
-          local branch
-          local gitref
-          branch=$(git --git-dir "$plugin_path/.git" rev-parse --abbrev-ref HEAD 2>/dev/null)
-          gitref=$(git --git-dir "$plugin_path/.git" rev-parse --short HEAD 2>/dev/null)
-          printf "\t%s\t%s" "$branch" "$gitref"
+          printf "\t%s\t%s" \
+            "$(get_plugin_remote_branch "$plugin_name")" \
+            "$(get_plugin_remote_gitref "$plugin_name")"
         fi
 
         printf "\n"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -860,3 +860,24 @@ util_resolve_user_path() {
     util_resolve_user_path_reply="$path"
   fi
 }
+
+get_plugin_remote_url() {
+  local plugin_name="$1"
+  local plugin_path
+  plugin_path="$(get_plugin_path "$plugin_name")"
+  git --git-dir "$plugin_path/.git" remote get-url origin 2>/dev/null
+}
+
+get_plugin_remote_branch() {
+  local plugin_name="$1"
+  local plugin_path
+  plugin_path="$(get_plugin_path "$plugin_name")"
+  git --git-dir "$plugin_path/.git" rev-parse --abbrev-ref HEAD 2>/dev/null
+}
+
+get_plugin_remote_gitref() {
+  local plugin_name="$1"
+  local plugin_path
+  plugin_path="$(get_plugin_path "$plugin_name")"
+  git --git-dir "$plugin_path/.git" rev-parse --short HEAD 2>/dev/null
+}

--- a/test/asdf_nu.bats
+++ b/test/asdf_nu.bats
@@ -11,8 +11,6 @@ setup() {
   fi
 
   setup_asdf_dir
-  setup_repo
-  install_dummy_plugin
 }
 
 teardown() {
@@ -23,7 +21,7 @@ cleaned_path() {
   echo "$PATH" | tr ':' '\n' | grep -v "asdf" | tr '\n' ':'
 }
 
-@test "exports ASDF_DIR" {
+run_nushell() {
   run nu -c "
     hide-env -i asdf
     hide-env -i ASDF_DIR
@@ -31,8 +29,11 @@ cleaned_path() {
     let-env ASDF_NU_DIR = '$PWD'
 
     source asdf.nu
+    $1"
+}
 
-    echo \$env.ASDF_DIR"
+@test "exports ASDF_DIR" {
+  run_nushell "echo \$env.ASDF_DIR"
 
   [ "$status" -eq 0 ]
   result=$(echo "$output" | grep "asdf")
@@ -40,16 +41,7 @@ cleaned_path() {
 }
 
 @test "adds asdf dirs to PATH" {
-  run nu -c "
-    hide-env -i asdf
-    hide-env -i ASDF_DIR
-    let-env PATH = ( '$(cleaned_path)' | split row ':' )
-    let-env ASDF_NU_DIR = '$PWD'
-
-    source asdf.nu
-
-
-    \$env.PATH | to text"
+  run_nushell "\$env.PATH | to text"
 
   [ "$status" -eq 0 ]
 
@@ -58,15 +50,8 @@ cleaned_path() {
 }
 
 @test "does not add paths to PATH more than once" {
-  run nu -c "
-    hide-env -i asdf
-    hide-env -i ASDF_DIR
-    let-env PATH = ( '$(cleaned_path)' | split row ':' )
-    let-env ASDF_NU_DIR = '$PWD'
-
+  run_nushell "
     source asdf.nu
-    source asdf.nu
-
     echo \$env.PATH"
 
   [ "$status" -eq 0 ]
@@ -91,27 +76,13 @@ cleaned_path() {
 }
 
 @test "defines the asdf or main function" {
-  run nu -c "
-    hide-env -i asdf
-    hide-env -i ASDF_DIR
-    let-env PATH = ( '$(cleaned_path)' | split row ':' )
-    let-env ASDF_NU_DIR = '$PWD'
-
-    source asdf.nu
-    which asdf | get path | to text"
+  run_nushell "which asdf | get path | to text"
 
   [ "$status" -eq 0 ]
 }
 
 @test "function calls asdf command" {
-  run nu -c "
-    hide-env -i asdf
-    hide-env -i ASDF_DIR
-    let-env PATH = ( '$(cleaned_path)' | split row ':' )
-    let-env ASDF_NU_DIR = '$PWD'
-
-    source asdf.nu
-    asdf info"
+  run_nushell "asdf info"
 
   [ "$status" -eq 0 ]
 
@@ -119,15 +90,67 @@ cleaned_path() {
   [ "$result" != "" ]
 }
 
-@test "parses the output of asdf plugin list all" {
-  run nu -c "
-    hide-env -i asdf
-    hide-env -i ASDF_DIR
-    let-env PATH = ( '$(cleaned_path)' | split row ':' )
-    let-env ASDF_NU_DIR = '$PWD'
+@test "parses the output of asdf plugin list" {
+  setup_repo
+  install_dummy_plugin
+  run_nushell "asdf plugin list | to csv -n"
 
-    source asdf.nu
-    asdf plugin list all | to csv -n"
+  [ "$status" -eq 0 ]
+  [ "$output" = "dummy" ]
+}
+
+@test "parses the output of asdf plugin list --urls" {
+  setup_repo
+  install_mock_plugin_repo "dummy"
+  asdf plugin add "dummy" "${BASE_DIR}/repo-dummy"
+
+  run_nushell "asdf plugin list --urls | to csv -n"
+
+  [ "$status" -eq 0 ]
+
+  local repo_url
+  repo_url=$(get_plugin_remote_url "dummy")
+
+  [ "$output" = "dummy,$repo_url" ]
+}
+
+@test "parses the output of asdf plugin list --refs" {
+  setup_repo
+  install_mock_plugin_repo "dummy"
+  asdf plugin add "dummy" "${BASE_DIR}/repo-dummy"
+
+  run_nushell "asdf plugin list --refs | to csv -n"
+
+  [ "$status" -eq 0 ]
+
+  local branch gitref
+  branch=$(get_plugin_remote_branch "dummy")
+  gitref=$(get_plugin_remote_gitref "dummy")
+
+  [ "$output" = "dummy,$branch,$gitref" ]
+}
+
+@test "parses the output of asdf plugin list --urls --refs" {
+  setup_repo
+  install_mock_plugin_repo "dummy"
+  asdf plugin add "dummy" "${BASE_DIR}/repo-dummy"
+
+  run_nushell "asdf plugin list --urls --refs | to csv -n"
+
+  [ "$status" -eq 0 ]
+
+  local repo_url branch gitref
+  repo_url=$(get_plugin_remote_url "dummy")
+  branch=$(get_plugin_remote_branch "dummy")
+  gitref=$(get_plugin_remote_gitref "dummy")
+
+  [ "$output" = "dummy,$repo_url,$branch,$gitref" ]
+}
+
+@test "parses the output of asdf plugin list all" {
+  setup_repo
+  install_dummy_plugin
+  run_nushell "asdf plugin list all | to csv -n"
 
   [ "$status" -eq 0 ]
   [ "$output" = "\


### PR DESCRIPTION
# Summary

Fixes: #1503.

## Other Information

Also adds tests for the `--refs`flag and its combination with `--urls`.

Note that installed plugins can have a "remote" URL of two forms:
- a remote git URL (i.e. starting with `http[s]|git` and terminating with `.git`)
- an absolute path to a local folder

**N.B.**: At the moment this PR is only testing for plugins added from a local folder (second case above). To test plugins that have been cloned from an *actually remote* repository (first case above) there have to be testing fixtures that clone them first.