### PR TITLE
fix: `asdf info` show BASH_VERSION & all asdf envs

### DIFF
--- a/lib/commands/command-info.bash
+++ b/lib/commands/command-info.bash
@@ -4,9 +4,14 @@
 
 info_command() {
   printf "%s:\n%s\n\n" "OS" "$(uname -a)"
-  printf "%s:\n%s\n\n" "SHELL" "$($SHELL --version)"
+  printf "%s:\n%s\n\n" "SHELL" "$("$SHELL" --version)"
+  printf "%s:\n%s\n\n" "BASH VERSION" "$BASH_VERSION"
   printf "%s:\n%s\n\n" "ASDF VERSION" "$(asdf_version)"
-  printf "%s:\n%s\n\n" "ASDF ENVIRONMENT VARIABLES" "$(env | grep -E "ASDF_DIR|ASDF_DATA_DIR|ASDF_CONFIG_FILE|ASDF_DEFAULT_TOOL_VERSIONS_FILENAME")"
+  printf '%s\n' 'ASDF INTERNAL VARIABLES:'
+  printf 'ASDF_DEFAULT_TOOL_VERSIONS_FILENAME=%s\n' "${ASDF_DEFAULT_TOOL_VERSIONS_FILENAME}"
+  printf 'ASDF_DATA_DIR=%s\n' "${ASDF_DATA_DIR}"
+  printf 'ASDF_DIR=%s\n' "${ASDF_DIR}"
+  printf 'ASDF_CONFIG_FILE=%s\n\n' "${ASDF_CONFIG_FILE}"
   printf "%s:\n%s\n\n" "ASDF INSTALLED PLUGINS" "$(plugin_list_command --urls --refs)"
 }
 

--- a/test/info_command.bats
+++ b/test/info_command.bats
@@ -25,8 +25,9 @@ teardown() {
   [ "$status" -eq 0 ]
   [[ $output == *$'OS:\n'* ]]
   [[ $output == *$'SHELL:\n'* ]]
+  [[ $output == *$'BASH VERSION:\n'* ]]
   [[ $output == *$'ASDF VERSION:\n'* ]]
-  [[ $output == *$'ASDF ENVIRONMENT VARIABLES:\n'* ]]
+  [[ $output == *$'ASDF INTERNAL VARIABLES:\n'* ]]
   [[ $output == *$'ASDF INSTALLED PLUGINS:\n'* ]]
 
 }


### PR DESCRIPTION
These changes make two fixes with the `info` subcommand:

- Use `$BASH_VERSION` for info about the current version of Bash because:
  - `$SHELL --version` is too verbose
  - `$SHELL` breaks when Bash is installed in a location that contains spaces (ShellCheck misses this because it seems it hard-codes `SHELL` as an exception)
  - `$SHELL` breaks when a login shell other than Bash is used

- Change printing of environment variables so that
  - All variables that asdf uses are printed, even if they are not set
  - Remove exec/subshell



<details>

<summary>Sample Output</summary>

```
$ asdf info
OS:
Linux nullptr 5.15.0-67-generic #74-Ubuntu SMP Wed Feb 22 14:14:39 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux

SHELL:
Bash 5.1.16(1)-release

ASDF VERSION:
v0.11.3-f5f391c

ASDF ENVIRONMENT VARIABLES:
ASDF_DEFAULT_TOOL_VERSIONS_FILENAME=(not set)
ASDF_DATA_DIR=/home/edwin/.asdf
ASDF_DIR=/storage/ur/storage_home/Docs/Programming/Repositories/git/asdf
ASDF_CONFIG_FILE=/home/edwin/.config/asdf/asdfrc

ASDF INSTALLED PLUGINS:
elixir                       master 1693b35
nodejs                       master c9e5df4
python                       master 8505457

```

</details>