### PR TITLE
test: skip tests for uninstalled shells when run locally

### DIFF
--- a/test/asdf_elvish.bats
+++ b/test/asdf_elvish.bats
@@ -8,12 +8,16 @@ setup() {
   export XDG_DATA_HOME=
   export XDG_DATA_DIRS=
 
+  if ! command -v elvish &>/dev/null && [ -z "$GITHUB_ACTIONS" ]; then
+    skip 'Elvish not installed'
+  fi
+
   local ver_major=
   local ver_minor=
   local ver_patch=
   IFS='.' read -r ver_major ver_minor ver_patch <<<"$(elvish -version)"
 
-  if ((ver_major == 0 && ver_minor < 18)); then
+  if ((ver_major == 0 && ver_minor < 18)) && [ -z "$GITHUB_ACTIONS" ]; then
     skip "Elvish version is not at least 0.18. Found ${ver_major}.${ver_minor}.${ver_patch}"
   fi
 }

--- a/test/asdf_fish.bats
+++ b/test/asdf_fish.bats
@@ -6,7 +6,7 @@ load test_helpers
 setup() {
   cd "$(dirname "$BATS_TEST_DIRNAME")"
 
-  if ! command -v fish; then
+  if ! command -v fish &>/dev/null && [ -z "$GITHUB_ACTIONS" ]; then
     skip "Fish is not installed"
   fi
 }

--- a/test/asdf_nu.bats
+++ b/test/asdf_nu.bats
@@ -6,7 +6,7 @@ load test_helpers
 setup() {
   cd "$(dirname "$BATS_TEST_DIRNAME")"
 
-  if ! command -v nu; then
+  if ! command -v nu &>/dev/null && [ -z "$GITHUB_ACTIONS" ]; then
     skip "Nu is not installed"
   fi
 


### PR DESCRIPTION
# Summary

Before:
```sh
 - exports ASDF_DIR (skipped: Elvish version is not at least 0.18. Found ..)
```

After:
```sh
 - exports ASDF_DIR (skipped: Elvish not installed)
```

## Other Information

This also makes sure that CI fails if a particular shell isn't installed.
