### PR TITLE
fix!: do not remove items from PATH in POSIX entrypoint

### DIFF
--- a/asdf.sh
+++ b/asdf.sh
@@ -47,7 +47,7 @@ if [ -z "$ASDF_DIR" ]; then
 fi
 
 if [ -z "$ASDF_DIR" ]; then
-  printf "%s\n" "asdf: Error: Source directory could not be calculated. Please set it manually before sourcing this file." >&2
+  printf "%s\n" "asdf: Error: Source directory could not be calculated. Please set \$ASDF_DIR manually before sourcing this file." >&2
   return 1
 fi
 
@@ -56,22 +56,20 @@ if [ ! -d "$ASDF_DIR" ]; then
   return 1
 fi
 
-_asdf_bin="${ASDF_DIR}/bin"
+_asdf_bin="$ASDF_DIR/bin"
 _asdf_shims="${ASDF_DATA_DIR:-$HOME/.asdf}/shims"
 
-# shellcheck disable=SC3060
-if [ -n "$BASH_VERSION" ] || [ -n "$ZSH_VERSION" ]; then
-  case ":$PATH:" in
-    *":${_asdf_bin}:"*) PATH="${PATH//$_asdf_bin:/}" ;;
-  esac
-  case ":$PATH:" in
-    *":${_asdf_shims}:"*) PATH="${PATH//$_asdf_shims:/}" ;;
-  esac
-fi
+case ":$PATH:" in
+  *":$_asdf_bin:"*) : ;;
+  *) PATH="$_asdf_bin:$PATH" ;;
+esac
+case ":$PATH:" in
+  *":$_asdf_shims:"*) : ;;
+  *) PATH="$_asdf_shims:$PATH" ;;
+esac
 
-PATH="${_asdf_bin}:${_asdf_shims}:$PATH"
 unset -v _asdf_bin _asdf_shims
 
 # shellcheck source=lib/asdf.sh
-. "${ASDF_DIR}/lib/asdf.sh"
+. "$ASDF_DIR/lib/asdf.sh"
 


### PR DESCRIPTION
# Summary

The PATH issue was briefly mentioned in the original [POSIX entrypoint PR](https://github.com/asdf-vm/asdf/pull/1480#issue-1590511816), but it was not fixed there.

The issue is that previously `asdf` modified the PATH variable, and removed the asdf bin or asdf shims directory (from PATH) if they existed. Besides not being good practice (in my opinion), this had issues since this behavior would only run under Bash and ZSH (POSIX doesn't support substitution in parameter expansion and I intentionally didn't add this behavior to KSH for simplicity). Since the same script could change PATH differently (when ran under different shells), this can be confusing behavior. Also, neither the Elvish, or Nushell scripts remove items from the PATH, this also could be confusing.

These changes make it so the POSIX entrypoint match the Elvish, Fish, and Nushell behavior by only adding the bin and shims directory if they aren't already in the path.

Tested with Zsh, Bash, Dash, Ksh, Mksh