### PR TITLE
feat: Add search subcommand

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -60,6 +60,8 @@ asdf shim-versions <command>            List the plugins and versions that
 asdf update                             Update asdf to the latest stable release
 asdf update --head                      Update asdf to the latest on the master branch
 
+asdf search <name>                      Searches if the command exists. Not fuzzy find.
+
 RESOURCES
 GitHub: https://github.com/asdf-vm/asdf
 Docs:   https://asdf-vm.com

--- a/lib/commands/command-search.bash
+++ b/lib/commands/command-search.bash
@@ -1,0 +1,8 @@
+# -*- sh -*-
+
+search_command() {
+  local target="$1"
+  curl -s https://api.github.com/repos/asdf-vm/asdf-plugins/contents/plugins | jq -r ".[]|.name" | grep -i $target
+ }
+ 
+ search_command $@


### PR DESCRIPTION
# Summary

I have added a search subcommand. 
which searches if the plugin exists from asdf-vm/asdf-plugins repository.


eg:
```
$ asdf search vim
neovim
vim
```
command-search.sh is a very simple shell script.

Also, I have added help that denotes the search subcommand.

