### PR TITLE
Salmon

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,6 @@ insert_final_newline = true
 
 [*.py]
 indent_size = 4
+
+[*.fish]
+indent_size = 4

--- a/asdf.fish
+++ b/asdf.fish
@@ -1,17 +1,17 @@
 if not set -q ASDF_DIR
-  set -x ASDF_DIR (dirname (status -f))
+    set -x ASDF_DIR (dirname (status -f))
 end
 
 # Add asdf to PATH
 # fish_add_path was added in fish 3.2, so we need a fallback for older version
 if type -q fish_add_path
-  if test -n "$ASDF_DATA_DIR"
-    fish_add_path --global --move "$ASDF_DATA_DIR/shims" "$ASDF_DIR/bin"
-  else
-    fish_add_path --global --move "$HOME/.asdf/shims" "$ASDF_DIR/bin"
-  end
+    if test -n "$ASDF_DATA_DIR"
+        fish_add_path --global --move "$ASDF_DATA_DIR/shims" "$ASDF_DIR/bin"
+    else
+        fish_add_path --global --move "$HOME/.asdf/shims" "$ASDF_DIR/bin"
+    end
 else
-  set -l asdf_user_shims (
+    set -l asdf_user_shims (
     if test -n "$ASDF_DATA_DIR"
       printf "%s\n" "$ASDF_DATA_DIR/shims"
     else
@@ -19,19 +19,19 @@ else
     end
   )
 
-  set -l asdf_bin_dirs $ASDF_DIR/bin $asdf_user_shims
+    set -l asdf_bin_dirs $ASDF_DIR/bin $asdf_user_shims
 
-  for x in $asdf_bin_dirs
-    if test -d $x
-      for i in (seq 1 (count $PATH))
-        if test $PATH[$i] = $x
-          set -e PATH[$i]
-          break
+    for x in $asdf_bin_dirs
+        if test -d $x
+            for i in (seq 1 (count $PATH))
+                if test $PATH[$i] = $x
+                    set -e PATH[$i]
+                    break
+                end
+            end
         end
-      end
+        set PATH $x $PATH
     end
-    set PATH $x $PATH
-  end
 end
 
 # Load the asdf wrapper function

--- a/asdf.fish
+++ b/asdf.fish
@@ -1,38 +1,24 @@
-if not set -q ASDF_DIR
-    set -x ASDF_DIR (dirname (status -f))
+if test -z $ASDF_DIR
+    set ASDF_DIR (realpath (dirname (status filename)))
 end
+set --export ASDF_DIR $ASDF_DIR
 
-# Add asdf to PATH
-# fish_add_path was added in fish 3.2, so we need a fallback for older version
-if type -q fish_add_path
-    if test -n "$ASDF_DATA_DIR"
-        fish_add_path --global --move "$ASDF_DATA_DIR/shims" "$ASDF_DIR/bin"
-    else
-        fish_add_path --global --move "$HOME/.asdf/shims" "$ASDF_DIR/bin"
-    end
+set -l _asdf_bin "$ASDF_DIR/bin"
+if test -z $ASDF_DATA_DIR
+    set _asdf_shims "$HOME/.asdf/shims"
 else
-    set -l asdf_user_shims (
-    if test -n "$ASDF_DATA_DIR"
-      printf "%s\n" "$ASDF_DATA_DIR/shims"
-    else
-      printf "%s\n" "$HOME/.asdf/shims"
-    end
-  )
-
-    set -l asdf_bin_dirs $ASDF_DIR/bin $asdf_user_shims
-
-    for x in $asdf_bin_dirs
-        if test -d $x
-            for i in (seq 1 (count $PATH))
-                if test $PATH[$i] = $x
-                    set -e PATH[$i]
-                    break
-                end
-            end
-        end
-        set PATH $x $PATH
-    end
+    set _asdf_shims "$ASDF_DATA_DIR/shims"
 end
+
+# Do not use fish_add_path (added in Fish 3.2) because it
+# potentially changes the order of items in fish_user_paths
+if not contains $_asdf_bin $fish_user_paths
+    set --global --prepend fish_user_paths $_asdf_bin
+end
+if not contains $_asdf_shims $fish_user_paths
+    set --global --prepend fish_user_paths $_asdf_shims
+end
+set --erase _asdf_bin _asdf_shims
 
 # Load the asdf wrapper function
 . $ASDF_DIR/lib/asdf.fish

--- a/completions/asdf.fish
+++ b/completions/asdf.fish
@@ -31,19 +31,19 @@ function __fish_asdf_arg_at -a number
 end
 
 function __fish_asdf_list_versions -a plugin
-    asdf list $plugin 2> /dev/null | sed -e 's/^[[:space:]]*//'
+    asdf list $plugin 2>/dev/null | sed -e 's/^[[:space:]]*//'
 end
 
 function __fish_asdf_list_all -a plugin
-    asdf list-all $plugin 2> /dev/null
+    asdf list-all $plugin 2>/dev/null
 end
 
 function __fish_asdf_plugin_list
-    asdf plugin-list 2> /dev/null
+    asdf plugin-list 2>/dev/null
 end
 
 function __fish_asdf_plugin_list_all
-    asdf plugin-list-all 2> /dev/null
+    asdf plugin-list-all 2>/dev/null
 end
 
 function __fish_asdf_list_shims
@@ -51,87 +51,87 @@ function __fish_asdf_list_shims
 end
 
 # update
-complete -f -c asdf -n '__fish_asdf_needs_command' -a update -d "Update asdf"
-complete -f -c asdf -n '__fish_asdf_using_command update; and __fish_asdf_arg_number 2' -l "head" -d "Updates to master HEAD"
+complete -f -c asdf -n __fish_asdf_needs_command -a update -d "Update asdf"
+complete -f -c asdf -n '__fish_asdf_using_command update; and __fish_asdf_arg_number 2' -l head -d "Updates to master HEAD"
 
 # plugin-add completion
-complete -f -c asdf -n '__fish_asdf_needs_command' -a plugin-add -d "Add git repo as plugin"
+complete -f -c asdf -n __fish_asdf_needs_command -a plugin-add -d "Add git repo as plugin"
 complete -f -c asdf -n '__fish_asdf_using_command plugin-add; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list_all | grep -v \'*\' | awk \'{ print $1 }\')'
 complete -f -c asdf -n '__fish_asdf_using_command plugin-add; and __fish_asdf_arg_number 3' -a '(__fish_asdf_plugin_list_all | grep (__fish_asdf_arg_at 3) | awk \'{ print $2 }\')'
 complete -f -c asdf -n '__fish_asdf_using_command plugin-add; and __fish_asdf_arg_number 4'
 
 # plugin-list completion
-complete -f -c asdf -n '__fish_asdf_needs_command' -a plugin-list -d "List installed plugins"
+complete -f -c asdf -n __fish_asdf_needs_command -a plugin-list -d "List installed plugins"
 
 # plugin-list-all completion
-complete -f -c asdf -n '__fish_asdf_needs_command' -a plugin-list-all -d "List all existing plugins"
+complete -f -c asdf -n __fish_asdf_needs_command -a plugin-list-all -d "List all existing plugins"
 
 # plugin-remove completion
-complete -f -c asdf -n '__fish_asdf_needs_command' -a plugin-remove -d "Remove plugin and package versions"
+complete -f -c asdf -n __fish_asdf_needs_command -a plugin-remove -d "Remove plugin and package versions"
 complete -f -c asdf -n '__fish_asdf_using_command plugin-remove; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
 
 # plugin-update completion
-complete -f -c asdf -n '__fish_asdf_needs_command' -a plugin-update -d "Update plugin"
+complete -f -c asdf -n __fish_asdf_needs_command -a plugin-update -d "Update plugin"
 complete -f -c asdf -n '__fish_asdf_using_command plugin-update; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
 complete -f -c asdf -n '__fish_asdf_using_command plugin-update; and __fish_asdf_arg_number 2' -a --all
 
 # install completion
-complete -f -c asdf -n '__fish_asdf_needs_command' -a install -d "Install a specific version of a package"
+complete -f -c asdf -n __fish_asdf_needs_command -a install -d "Install a specific version of a package"
 complete -f -c asdf -n '__fish_asdf_using_command install; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
 complete -f -c asdf -n '__fish_asdf_using_command install; and __fish_asdf_arg_number 3' -a '(__fish_asdf_list_all (__fish_asdf_arg_at 3))'
 
 # uninstall completion
-complete -f -c asdf -n '__fish_asdf_needs_command' -a uninstall -d "Remove a specific version of a package"
+complete -f -c asdf -n __fish_asdf_needs_command -a uninstall -d "Remove a specific version of a package"
 complete -f -c asdf -n '__fish_asdf_using_command uninstall; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
 complete -f -c asdf -n '__fish_asdf_using_command uninstall; and __fish_asdf_arg_number 3' -a '(__fish_asdf_list_versions (__fish_asdf_arg_at 3))'
 
 # current completion
-complete -f -c asdf -n '__fish_asdf_needs_command' -a current -d "Display version set or being used for package"
+complete -f -c asdf -n __fish_asdf_needs_command -a current -d "Display version set or being used for package"
 complete -f -c asdf -n '__fish_asdf_using_command current; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
 
 # where completion
-complete -f -c asdf -n '__fish_asdf_needs_command' -a where -d "Display install path for an installed version"
+complete -f -c asdf -n __fish_asdf_needs_command -a where -d "Display install path for an installed version"
 complete -f -c asdf -n '__fish_asdf_using_command where; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
 complete -f -c asdf -n '__fish_asdf_using_command where; and __fish_asdf_arg_number 3' -a '(__fish_asdf_list_versions (__fish_asdf_arg_at 3))'
 
 # which completion
-complete -f -c asdf -n '__fish_asdf_needs_command' -a which -d "Display executable path for a command"
+complete -f -c asdf -n __fish_asdf_needs_command -a which -d "Display executable path for a command"
 complete -f -c asdf -n '__fish_asdf_using_command which; and __fish_asdf_arg_number 2' -a '(__fish_asdf_list_shims)'
 
 # latest completion
-complete -f -c asdf -n '__fish_asdf_needs_command' -a latest -d "Show latest stable version of a package"
+complete -f -c asdf -n __fish_asdf_needs_command -a latest -d "Show latest stable version of a package"
 complete -f -c asdf -n '__fish_asdf_using_command latest; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
 complete -f -c asdf -n '__fish_asdf_using_command latest; and __fish_asdf_arg_number 2' -a --all
 
 # list completion
-complete -f -c asdf -n '__fish_asdf_needs_command' -a list -d "List installed versions of a package"
+complete -f -c asdf -n __fish_asdf_needs_command -a list -d "List installed versions of a package"
 complete -f -c asdf -n '__fish_asdf_using_command list; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
 
 # list-all completion
-complete -f -c asdf -n '__fish_asdf_needs_command' -a list-all -d "List all versions of a package"
+complete -f -c asdf -n __fish_asdf_needs_command -a list-all -d "List all versions of a package"
 complete -f -c asdf -n '__fish_asdf_using_command list-all; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
 
 # reshim completion
-complete -f -c asdf -n '__fish_asdf_needs_command' -a reshim -d "Recreate shims for version of a package"
+complete -f -c asdf -n __fish_asdf_needs_command -a reshim -d "Recreate shims for version of a package"
 complete -f -c asdf -n '__fish_asdf_using_command reshim; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
 complete -f -c asdf -n '__fish_asdf_using_command reshim; and __fish_asdf_arg_number 3' -a '(__fish_asdf_list_versions (__fish_asdf_arg_at 3))'
 
 # local completion
-complete -f -c asdf -n '__fish_asdf_needs_command' -a local -d "Set local version for a plugin"
+complete -f -c asdf -n __fish_asdf_needs_command -a local -d "Set local version for a plugin"
 complete -f -c asdf -n '__fish_asdf_using_command local; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
 complete -f -c asdf -n '__fish_asdf_using_command local; and test (count (commandline -opc)) -gt 2' -a '(__fish_asdf_list_versions (__fish_asdf_arg_at 3)) system'
 
 # global completion
-complete -f -c asdf -n '__fish_asdf_needs_command' -a global -d "Set global version for a plugin"
+complete -f -c asdf -n __fish_asdf_needs_command -a global -d "Set global version for a plugin"
 complete -f -c asdf -n '__fish_asdf_using_command global; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
 complete -f -c asdf -n '__fish_asdf_using_command global; and test (count (commandline -opc)) -gt 2' -a '(__fish_asdf_list_versions (__fish_asdf_arg_at 3)) system'
 
 # shell completion
-complete -f -c asdf -n '__fish_asdf_needs_command' -a shell -d "Set version for a plugin in current shell session"
+complete -f -c asdf -n __fish_asdf_needs_command -a shell -d "Set version for a plugin in current shell session"
 complete -f -c asdf -n '__fish_asdf_using_command shell; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
 complete -f -c asdf -n '__fish_asdf_using_command shell; and test (count (commandline -opc)) -gt 2' -a '(__fish_asdf_list_versions (__fish_asdf_arg_at 3)) system'
 
 # misc
-complete -f -c asdf -n '__fish_asdf_needs_command' -l "help" -d "Displays help"
-complete -f -c asdf -n '__fish_asdf_needs_command' -a "info" -d "Print OS, Shell and ASDF debug information"
-complete -f -c asdf -n '__fish_asdf_needs_command' -l "version" -d "Displays asdf version"
+complete -f -c asdf -n __fish_asdf_needs_command -l help -d "Displays help"
+complete -f -c asdf -n __fish_asdf_needs_command -a info -d "Print OS, Shell and ASDF debug information"
+complete -f -c asdf -n __fish_asdf_needs_command -l version -d "Displays asdf version"

--- a/lib/asdf.fish
+++ b/lib/asdf.fish
@@ -5,7 +5,7 @@ function asdf
     set -e argv[1]
 
     switch "$command"
-        case "shell"
+        case shell
             # source commands that need to export variables
             command asdf export-shell-version fish $argv | source # asdf_allow: source
         case '*'

--- a/lib/asdf.fish
+++ b/lib/asdf.fish
@@ -1,15 +1,14 @@
-
-# Add function wrapper so we can export variables
+# The asdf function is a wrapper so we can export variables
 function asdf
     set command $argv[1]
     set -e argv[1]
 
     switch "$command"
         case shell
-            # source commands that need to export variables
+            # Source commands that need to export variables.
             command asdf export-shell-version fish $argv | source # asdf_allow: source
         case '*'
-            # forward other commands to asdf script
+            # Forward other commands to asdf script.
             command asdf "$command" $argv
     end
 end

--- a/scripts/format.bash
+++ b/scripts/format.bash
@@ -23,3 +23,6 @@ shfmt --language-dialect bash --indent 2 --write \
 # check .bats files
 shfmt --language-dialect bats --indent 2 --write \
   test/*.bats
+
+# check .fish files
+fish_indent --write ./**/*.fish

--- a/scripts/shfmt.bash
+++ b/scripts/shfmt.bash
@@ -23,3 +23,6 @@ shfmt --language-dialect bash --indent 2 --diff \
 # check .bats files
 shfmt --language-dialect bats --indent 2 --diff \
   test/*.bats
+
+# check .fish files
+fish_indent --check ./**/*.fish


### PR DESCRIPTION
# Summary

As per [this comment](https://github.com/asdf-vm/asdf/pull/1521#issuecomment-1486619699), this matches the behavior of Fish with Bash, Nushell, and all the other shells. Along with a few other things

There were some bugs with the previous Fish implementation that are now fixed:

- If `ASDF_DIR` was set to an empty string, the value is used (unlike in Bash/Zsh, Elvish, Nushell, which replaces it with a correct one)
- `ASDF_DIR` is now always an absolute path to the asdf directory (previously it could have been a `.`). (Since it's an absolute path, we now export it so that asdf can use it instead of recalculating)
- Depending on version, either `PATH` or `fish_user_paths` (through `fish_add_path`) would be modified. Now, only the latter is potentially modified

It seems that `fish_add_path` potentially modifies the placement of an entry in `$fish_user_paths`, even if `--move` is not specified, so I opted to prepend to `$fish_user_paths` manually, so the behavior is consistent with all the other shells.

Now we also use `fish_indent` to make sure Fish scripts are formatted nicely (even if we have relatively few of them)
