### PR TITLE
docs: fix `ASDF_${LANG}_VERSION` usage

### DIFF
--- a/docs/manage/versions.md
+++ b/docs/manage/versions.md
@@ -80,7 +80,7 @@ asdf local <name> latest[:<version>]
 
 `global` writes the version to `$HOME/.tool-versions`.
 
-`shell` set the version to an environment variable named `ASDF_${LANG}_VERSION`, for the current shell session only.
+`shell` set the version to an environment variable named `ASDF_${TOOL}_VERSION`, for the current shell session only.
 
 `local` writes the version to `$PWD/.tool-versions`, creating it if needed.
 


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

Changing `ASDF_${LANG}_VERSION` to `ASDF_${TOOL}_VERSION` for consistency.

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->

`ASDF_${TOOL}_VERSION` is used pretty consistently in this page, and I initially thought `ASDF_${LANG}_VERSION` was something different. Updating for consistency.