### PR TITLE
chore: bump nushell version in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   ELVISH_VERSION: v0.19.2
-  NUSHELL_VERSION: 0.77.0
+  NUSHELL_VERSION: 0.78.0
 
 jobs:
   detect-changes:


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

```diff
-  NUSHELL_VERSION: 0.77.0
+  NUSHELL_VERSION: 0.78.0
```

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->
