### PR TITLE
ci: pin all shell versions for Ubuntu test environment

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           curl -fsSLo- https://packages.microsoft.com/keys/microsoft.asc | sudo tee >/dev/null /etc/apt/trusted.gpg.d/microsoft.asc
           sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-bullseye-prod bullseye main" > /etc/apt/sources.list.d/microsoft.list'
-          sudo add-apt-repository -y ppa:fish-shell/nightly-master
+          sudo add-apt-repository -y ppa:fish-shell/release-3
           sudo apt-get update
           echo "FISH VERSIONS"
           sudo apt-cache show fish | grep Version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,9 +8,9 @@ on:
 
 env:
   ELVISH_VERSION: v0.19.2
-  FISH_VERSION: 3.5.1
+  FISH_VERSION: 3.6.1-1~jammy
   NUSHELL_VERSION: 0.78.0
-  POWERSHELL_VERSION: 7.3.3
+  POWERSHELL_VERSION: 7.3.3-1.deb
 
 jobs:
   detect-changes:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,8 +65,8 @@ jobs:
           sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-bullseye-prod bullseye main" > /etc/apt/sources.list.d/microsoft.list'
           sudo add-apt-repository -y ppa:fish-shell/nightly-master
           sudo apt-get update
-          sudo aptitude versions fish
-          sudo aptitude versions powershell
+          sudo apt-show-versions fish
+          sudo apt-show-versions powershell
           sudo apt-get -y install curl parallel \
             fish=${{ env.FISH_VERSION }} \
             powershell=${{ env.POWERSHELL_VERSION }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,8 +65,8 @@ jobs:
           sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-bullseye-prod bullseye main" > /etc/apt/sources.list.d/microsoft.list'
           sudo add-apt-repository -y ppa:fish-shell/nightly-master
           sudo apt-get update
-          sudo apt-show-versions fish
-          sudo apt-show-versions powershell
+          sudo apt-cache show fish | grep Version
+          sudo apt-cache show powershell | grep Version
           sudo apt-get -y install curl parallel \
             fish=${{ env.FISH_VERSION }} \
             powershell=${{ env.POWERSHELL_VERSION }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,9 +8,9 @@ on:
 
 env:
   ELVISH_VERSION: v0.19.2
-  FISH_VERSION: 3.6.1-1~jammy
+  FISH_VERSION: 3.6.1
   NUSHELL_VERSION: 0.78.0
-  POWERSHELL_VERSION: 7.3.3-1.deb
+  POWERSHELL_VERSION: 7.3.3
 
 jobs:
   detect-changes:
@@ -66,8 +66,8 @@ jobs:
           sudo add-apt-repository -y ppa:fish-shell/release-3
           sudo apt-get update
           sudo apt-get -y install curl parallel \
-            fish=${{ env.FISH_VERSION }} \
-            powershell=${{ env.POWERSHELL_VERSION }}
+            fish="${{ env.FISH_VERSION }}-1~jammy" \
+            powershell="${{ env.POWERSHELL_VERSION }}-1.deb"
 
           # Create $HOME/bin
           mkdir -p "$HOME/bin"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,10 +65,6 @@ jobs:
           sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-bullseye-prod bullseye main" > /etc/apt/sources.list.d/microsoft.list'
           sudo add-apt-repository -y ppa:fish-shell/release-3
           sudo apt-get update
-          echo "FISH VERSIONS"
-          sudo apt-cache show fish | grep Version
-          echo "POWERSHELL VERSIONS"
-          sudo apt-cache show powershell | grep Version
           sudo apt-get -y install curl parallel \
             fish=${{ env.FISH_VERSION }} \
             powershell=${{ env.POWERSHELL_VERSION }}
@@ -116,10 +112,10 @@ jobs:
       - name: Install test dependencies
         run: |
           brew install coreutils parallel \
-            elvish@${{ env.ELVISH_VERSION }} \
-            fish@${{ env.FISH_VERSION }} \
-            nushell@${{ env.NUSHELL_VERSION }} \
-            powershell@${{ env.POWERSHELL_VERSION }}
+            elvish \
+            fish \
+            nushell \
+            powershell
 
       - name: Install bats
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,6 +65,8 @@ jobs:
           sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-bullseye-prod bullseye main" > /etc/apt/sources.list.d/microsoft.list'
           sudo add-apt-repository -y ppa:fish-shell/nightly-master
           sudo apt-get update
+          sudo apt-get versions fish
+          sudo apt-get versions powershell
           sudo apt-get -y install curl parallel \
             fish=${{ env.FISH_VERSION }} \
             powershell=${{ env.POWERSHELL_VERSION }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,9 @@ on:
 
 env:
   ELVISH_VERSION: v0.19.2
+  FISH_VERSION: 3.5.1
   NUSHELL_VERSION: 0.78.0
+  POWERSHELL_VERSION: 7.3.3
 
 jobs:
   detect-changes:
@@ -63,7 +65,9 @@ jobs:
           sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-bullseye-prod bullseye main" > /etc/apt/sources.list.d/microsoft.list'
           sudo add-apt-repository -y ppa:fish-shell/nightly-master
           sudo apt-get update
-          sudo apt-get -y install fish curl parallel powershell
+          sudo apt-get -y install curl parallel \
+            fish=${{ env.FISH_VERSION }} \
+            powershell=${{ env.POWERSHELL_VERSION }}
 
           # Create $HOME/bin
           mkdir -p "$HOME/bin"
@@ -106,7 +110,12 @@ jobs:
           fetch-depth: 0
 
       - name: Install test dependencies
-        run: brew install coreutils parallel fish elvish nushell
+        run: |
+          brew install coreutils parallel \
+            elvish@${{ env.ELVISH_VERSION }} \
+            fish@${{ env.FISH_VERSION }} \
+            nushell@${{ env.NUSHELL_VERSION }} \
+            powershell@${{ env.POWERSHELL_VERSION }}
 
       - name: Install bats
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,9 @@ jobs:
           sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-bullseye-prod bullseye main" > /etc/apt/sources.list.d/microsoft.list'
           sudo add-apt-repository -y ppa:fish-shell/nightly-master
           sudo apt-get update
+          echo "FISH VERSIONS"
           sudo apt-cache show fish | grep Version
+          echo "POWERSHELL VERSIONS"
           sudo apt-cache show powershell | grep Version
           sudo apt-get -y install curl parallel \
             fish=${{ env.FISH_VERSION }} \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,8 +65,8 @@ jobs:
           sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-bullseye-prod bullseye main" > /etc/apt/sources.list.d/microsoft.list'
           sudo add-apt-repository -y ppa:fish-shell/nightly-master
           sudo apt-get update
-          sudo apt-get versions fish
-          sudo apt-get versions powershell
+          sudo aptitude versions fish
+          sudo aptitude versions powershell
           sudo apt-get -y install curl parallel \
             fish=${{ env.FISH_VERSION }} \
             powershell=${{ env.POWERSHELL_VERSION }}


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

Currently we pin Shell versions for Elvish & Nushell. We do not for Fish or Powershell.

We should be consistent. So this PR introduces pinning to Fish & Powershell.

Homebrew installation on the macOS runner wasn't using any pinned versions. We will leave this as is for now.

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->
