### PR TITLE
feat: Support configurable `ASDF_CONCURRENCY`

### DIFF
--- a/defaults
+++ b/defaults
@@ -5,3 +5,4 @@ use_release_candidates = no
 always_keep_download = no
 plugin_repository_last_check_duration = 60
 disable_plugin_short_name_repository = no
+concurrency = auto

--- a/docs/manage/configuration.md
+++ b/docs/manage/configuration.md
@@ -134,6 +134,16 @@ Disabling the plugin short-name repository does not remove plugins previously in
 
 :::
 
+### `concurrency`
+
+The default concurrency to use.
+
+| Options                                                                                                 | Description                                                  |
+| :------------------------------------------------------------------------------------------------------ | :----------------------------------------------------------- |
+| integer | Number of cores to use when compiling the source code |
+
+Note that if the environment variable `ASDF_CONCURRENCY` is set, that takes precedence.
+
 ## Environment Variables
 
 Setting environment variables varies depending on your system and Shell. Default locations depend upon your installation location and method (Git clone, Homebrew, AUR).
@@ -172,6 +182,11 @@ The location where `asdf` will install plugins, shims and tool versions. Can be 
 
 - Default: `$HOME/.asdf`
 - Usage: `export ASDF_DATA_DIR=/home/john_doe/.asdf`
+
+### `ASDF_CONCURRENCY`
+
+- Default: Output of `nproc`
+- Usage: `export ASDF_CONCURRENCY=32`
 
 ## Internal Configuration
 

--- a/docs/manage/configuration.md
+++ b/docs/manage/configuration.md
@@ -151,45 +151,67 @@ Setting environment variables varies depending on your system and Shell. Default
 
 Environment variables should generally be set before sourcing `asdf.sh`/`asdf.fish` etc. For Elvish set above `use asdf`.
 
-The following examples assume:
-
-- an installation to `$HOME/.asdf`
-- a Bash Shell
+The following describe usage with a Bash Shell.
 
 ### `ASDF_CONFIG_FILE`
 
 Path to the `.asdfrc` configuration file. Can be set to any location. Must be an absolute path.
 
-- Default: `$HOME/.asdfrc`
+- If Unset: `$HOME/.asdfrc` will be used.
 - Usage: `export ASDF_CONFIG_FILE=/home/john_doe/.config/asdf/.asdfrc`
 
 ### `ASDF_DEFAULT_TOOL_VERSIONS_FILENAME`
 
 The filename of the file storing the tool names and versions. Can be any valid filename. Typically, you should not set this value unless you want to ignore `.tool-versions` files.
 
-- Default: `.tool-versions`
+- If Unset: `.tool-versions` will be used.
 - Usage: `export ASDF_DEFAULT_TOOL_VERSIONS_FILENAME=tool_versions`
 
 ### `ASDF_DIR`
 
 The location of `asdf` core scripts. Can be set to any location. Must be an absolute path.
 
-- Default: `$HOME/.asdf` (always the parent directory of the `bin/asdf` executable)
+- If Unset: the parent directory of the `bin/asdf` executable is used.
 - Usage: `export ASDF_DIR=/home/john_doe/.config/asdf`
 
 ### `ASDF_DATA_DIR`
 
 The location where `asdf` will install plugins, shims and tool versions. Can be set to any location. Must be an absolute path.
 
-- Default: `$HOME/.asdf`
+- If Unset: `$HOME/.asdf` if it exists, or else the value of `ASDF_DIR`
 - Usage: `export ASDF_DATA_DIR=/home/john_doe/.asdf`
 
 ### `ASDF_CONCURRENCY`
 
-Number of cores to use when compiling the source code. If unset, the asdf config `concurrency` value is used. If set, this environment variable takes precedence over the asdf config `concurrency` value. 
+Number of cores to use when compiling the source code. If set, this value takes precedence over the asdf config `concurrency` value. 
 
-- Default: unset environment variable
+- If Unset: the asdf config `concurrency` value is used.
 - Usage: `export ASDF_CONCURRENCY=32`
+
+## Full Configuration Example
+
+Following a simple asdf setup with:
+
+- a Bash Shell
+- an installation location of `$HOME/.asdf`
+- installed via Git
+- NO environment variables set 
+- NO custom `.asdfrc` file
+
+would result in the following outcomes:
+
+| Configuration                         | Value            | Calculated by                                                                                                                                      |
+| :------------------------------------ | :--------------- | :------------------------------------------------------------------------------------------------------------------------------------------------- |
+| config file location                  | `$HOME/.asdfrc`  | `ASDF_CONFIG_FILE` is empty, so use `$HOME/.asdfrc`                                                                                                |
+| default tool versions filename        | `.tool-versions` | `ASDF_DEFAULT_TOOL_VERSIONS_FILENAME` is empty, so use `.tool-versions`                                                                            |
+| asdf dir                              | `$HOME/.asdf`    | `ASDF_DIR` is empty, so use parent dir of `bin/asdf`                                                                                               |
+| asdf data dir                         | `$HOME/.asdf`    | `ASDF_DATA_DIR` is empty so use `$HOME/.asdf` as `$HOME` exists.                                                                                   |
+| concurrency                           | `auto`           | `ASDF_CONCURRENCY` is empty, so rely on `concurrency` value from the [default configuration](https://github.com/asdf-vm/asdf/blob/master/defaults) |
+| legacy_version_file                   | `no`             | No custom `.asdfrc`, so use the [default configuration](https://github.com/asdf-vm/asdf/blob/master/defaults)                                      |
+| use_release_candidates                | `no`             | No custom `.asdfrc`, so use the [default configuration](https://github.com/asdf-vm/asdf/blob/master/defaults)                                      |
+| always_keep_download                  | `no`             | No custom `.asdfrc`, so use the [default configuration](https://github.com/asdf-vm/asdf/blob/master/defaults)                                      |
+| plugin_repository_last_check_duration | `60`             | No custom `.asdfrc`, so use the [default configuration](https://github.com/asdf-vm/asdf/blob/master/defaults)                                      |
+| disable_plugin_short_name_repository  | `no`             | No custom `.asdfrc`, so use the [default configuration](https://github.com/asdf-vm/asdf/blob/master/defaults)                                      |
 
 ## Internal Configuration
 

--- a/docs/manage/configuration.md
+++ b/docs/manage/configuration.md
@@ -136,14 +136,14 @@ Disabling the plugin short-name repository does not remove plugins previously in
 
 ### `concurrency`
 
-The default concurrency to use.
+The default number of cores to use during compilation.
 
-| Options | Description                                                                              |
-| :------ | :--------------------------------------------------------------------------------------- |
-| integer | Number of cores to use when compiling the source code                                    |
-| `auto`  | Calculate the number of cores using `nproc`, then `sysctl hw.ncpu`, then `/proc/cpuinfo` |
+| Options | Description                                                                                          |
+| :------ | :--------------------------------------------------------------------------------------------------- |
+| integer | Number of cores to use when compiling the source code                                                |
+| `auto`  | Calculate the number of cores using `nproc`, then `sysctl hw.ncpu`, then `/proc/cpuinfo` or else `1` |
 
-Note that if the environment variable `ASDF_CONCURRENCY` is set, that takes precedence.
+Note: the environment variable `ASDF_CONCURRENCY` take precedence if set.
 
 ## Environment Variables
 
@@ -186,7 +186,9 @@ The location where `asdf` will install plugins, shims and tool versions. Can be 
 
 ### `ASDF_CONCURRENCY`
 
-- Default: Output of `nproc`, then `sysctl hw.ncpu`, then `/proc/cpuinfo`
+Number of cores to use when compiling the source code. If unset, the asdf config `concurrency` value is used. If set, this environment variable takes precedence over the asdf config `concurrency` value. 
+
+- Default: unset environment variable
 - Usage: `export ASDF_CONCURRENCY=32`
 
 ## Internal Configuration

--- a/docs/manage/configuration.md
+++ b/docs/manage/configuration.md
@@ -138,9 +138,10 @@ Disabling the plugin short-name repository does not remove plugins previously in
 
 The default concurrency to use.
 
-| Options                                                                                                 | Description                                                  |
-| :------------------------------------------------------------------------------------------------------ | :----------------------------------------------------------- |
-| integer | Number of cores to use when compiling the source code |
+| Options | Description                                                                              |
+| :------ | :--------------------------------------------------------------------------------------- |
+| integer | Number of cores to use when compiling the source code                                    |
+| `auto`  | Calculate the number of cores using `nproc`, then `sysctl hw.ncpu`, then `/proc/cpuinfo` |
 
 Note that if the environment variable `ASDF_CONCURRENCY` is set, that takes precedence.
 
@@ -185,7 +186,7 @@ The location where `asdf` will install plugins, shims and tool versions. Can be 
 
 ### `ASDF_CONCURRENCY`
 
-- Default: Output of `nproc`
+- Default: Output of `nproc`, then `sysctl hw.ncpu`, then `/proc/cpuinfo`
 - Usage: `export ASDF_CONCURRENCY=32`
 
 ## Internal Configuration

--- a/lib/functions/installs.bash
+++ b/lib/functions/installs.bash
@@ -25,25 +25,27 @@ install_command() {
 }
 
 get_concurrency() {
-  if [ -n "$ASDF_CONCURRENCY" ]; then
-    printf "%s\n" "$ASDF_CONCURRENCY"
-    return
-  fi
-
   local asdf_concurrency=
-  asdf_concurrency=$(get_asdf_config_value 'concurrency')
-
-  if [ -n "$asdf_concurrency" ]; then
-    printf "%s\n" "$asdf_concurrency"
-  elif command -v nproc &>/dev/null; then
-    nproc
-  elif command -v sysctl &>/dev/null && sysctl hw.ncpu &>/dev/null; then
-    sysctl -n hw.ncpu
-  elif [ -f /proc/cpuinfo ]; then
-    grep -c processor /proc/cpuinfo
+  if [ -n "$ASDF_CONCURRENCY" ]; then
+    asdf_concurrency=$ASDF_CONCURRENCY
   else
-    printf "1\n"
+    asdf_concurrency=$(get_asdf_config_value 'concurrency')
   fi
+
+  if [ "$asdf_concurrency" = 'auto' ]; then
+    if command -v nproc &>/dev/null; then
+      nproc
+    elif command -v sysctl &>/dev/null && sysctl hw.ncpu &>/dev/null; then
+      sysctl -n hw.ncpu
+    elif [ -f /proc/cpuinfo ]; then
+      grep -c processor /proc/cpuinfo
+    else
+      printf '%s\n' '1'
+    fi
+  else
+    printf '%s\n' "$asdf_concurrency"
+  fi
+
 }
 
 install_one_local_tool() {

--- a/lib/functions/installs.bash
+++ b/lib/functions/installs.bash
@@ -25,7 +25,17 @@ install_command() {
 }
 
 get_concurrency() {
-  if command -v nproc &>/dev/null; then
+  if [ -n "$ASDF_CONCURRENCY" ]; then
+    printf "%s\n" "$ASDF_CONCURRENCY"
+    return
+  fi
+
+  local asdf_concurrency=
+  asdf_concurrency=$(get_asdf_config_value 'concurrency')
+
+  if [ -n "$asdf_concurrency" ]; then
+    printf "%s\n" "$asdf_concurrency"
+  elif command -v nproc &>/dev/null; then
     nproc
   elif command -v sysctl &>/dev/null && sysctl hw.ncpu &>/dev/null; then
     sysctl -n hw.ncpu

--- a/lib/functions/installs.bash
+++ b/lib/functions/installs.bash
@@ -26,26 +26,26 @@ install_command() {
 
 get_concurrency() {
   local asdf_concurrency=
+
   if [ -n "$ASDF_CONCURRENCY" ]; then
-    asdf_concurrency=$ASDF_CONCURRENCY
+    asdf_concurrency="$ASDF_CONCURRENCY"
   else
     asdf_concurrency=$(get_asdf_config_value 'concurrency')
   fi
 
   if [ "$asdf_concurrency" = 'auto' ]; then
     if command -v nproc &>/dev/null; then
-      nproc
+      asdf_concurrency=$(nproc)
     elif command -v sysctl &>/dev/null && sysctl hw.ncpu &>/dev/null; then
-      sysctl -n hw.ncpu
+      asdf_concurrency=$(sysctl -n hw.ncpu)
     elif [ -f /proc/cpuinfo ]; then
-      grep -c processor /proc/cpuinfo
+      asdf_concurrency=$(grep -c processor /proc/cpuinfo)
     else
-      printf '%s\n' '1'
+      asdf_concurrency="1"
     fi
-  else
-    printf '%s\n' "$asdf_concurrency"
   fi
 
+  printf "%s\n" "$asdf_concurrency"
 }
 
 install_one_local_tool() {

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -52,6 +52,25 @@ teardown() {
   [ "$status" -eq 0 ]
 }
 
+@test "install_command set ASDF_CONCURRENCY via env var" {
+  ASDF_CONCURRENCY=-1 run asdf install dummy 1.0.0
+  [ "$status" -eq 0 ]
+  [ -f "$ASDF_DIR/installs/dummy/1.0.0/env" ]
+  run grep ASDF_CONCURRENCY=-1 "$ASDF_DIR/installs/dummy/1.0.0/env"
+  [ "$status" -eq 0 ]
+}
+
+@test "install_command set ASDF_CONCURRENCY via asdfrc" {
+  cat >"$HOME/.asdfrc" <<-'EOM'
+  concurrency = -2
+EOM
+  run asdf install dummy 1.0.0
+  [ "$status" -eq 0 ]
+  [ -f "$ASDF_DIR/installs/dummy/1.0.0/env" ]
+  run grep ASDF_CONCURRENCY=-2 "$ASDF_DIR/installs/dummy/1.0.0/env"
+  [ "$status" -eq 0 ]
+}
+
 @test "install_command without arguments should work in directory containing whitespace" {
   WHITESPACE_DIR="$PROJECT_DIR/whitespace\ dir"
   mkdir -p "$WHITESPACE_DIR"


### PR DESCRIPTION
# Summary

Fixes #1097

## Other Information

Use by either setting:

- environment variable `ASDF_CURRENCY`
- config key `concurrency`
