### PR TITLE
Use Bats assertion libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ repository
 .vagrant
 keyrings
 /tmp
+/node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "asdf",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "asdf",
+      "devDependencies": {
+        "@hyperupcall/bats-all": "^5.1.1"
+      }
+    },
+    "node_modules/@hyperupcall/bats-all": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hyperupcall/bats-all/-/bats-all-5.1.1.tgz",
+      "integrity": "sha512-MJW6Ti5GbGvyP/DRDyO2Eg4ixMEO29t5QcUeNgcW7+sGA9bPBz4/pZhA+3zhKoNj6KH67n83LD89mId5PNY9Jw==",
+      "dev": true
+    }
+  },
+  "dependencies": {
+    "@hyperupcall/bats-all": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hyperupcall/bats-all/-/bats-all-5.1.1.tgz",
+      "integrity": "sha512-MJW6Ti5GbGvyP/DRDyO2Eg4ixMEO29t5QcUeNgcW7+sGA9bPBz4/pZhA+3zhKoNj6KH67n83LD89mId5PNY9Jw==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "asdf",
+  "private": true,
+  "devDependencies": {
+    "@hyperupcall/bats-all": "^5.1.1"
+  }
+}

--- a/test/asdf_elvish.bats
+++ b/test/asdf_elvish.bats
@@ -80,7 +80,7 @@ cleaned_path() {
     pprint \$_asdf:"
 
   assert_success
-  [[ "$output" =~ "<ns " ]]
+  assert_output -p "<ns "
 }
 
 @test "does not add paths to PATH more than once" {
@@ -106,7 +106,7 @@ cleaned_path() {
     pprint \$asdf~"
 
   assert_success
-  [[ "$output" =~ "<closure " ]]
+  assert_output -p "<closure "
 }
 
 @test "function calls asdf command" {

--- a/test/asdf_elvish.bats
+++ b/test/asdf_elvish.bats
@@ -34,7 +34,7 @@ cleaned_path() {
     echo \$E:ASDF_DIR"
 
   assert_success
-  [ "$output" = "$HOME/.asdf" ]
+  assert_output -- "$HOME/.asdf"
 }
 
 @test "retains ASDF_DIR" {
@@ -45,7 +45,7 @@ cleaned_path() {
     echo \$E:ASDF_DIR"
 
   assert_success
-  [ "$output" = "/path/to/asdf" ]
+  assert_output "/path/to/asdf"
 }
 
 @test "retains ASDF_DATA_DIR" {
@@ -56,7 +56,7 @@ cleaned_path() {
     echo \$E:ASDF_DATA_DIR"
 
   assert_success
-  [ "$output" = "/path/to/asdf-data" ]
+  assert_output "/path/to/asdf-data"
 }
 
 @test "adds asdf dirs to PATH" {

--- a/test/asdf_elvish.bats
+++ b/test/asdf_elvish.bats
@@ -33,7 +33,7 @@ cleaned_path() {
     use ./asdf _asdf; var asdf~ = \$_asdf:asdf~
     echo \$E:ASDF_DIR"
 
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$HOME/.asdf" ]
 }
 
@@ -44,7 +44,7 @@ cleaned_path() {
     use ./asdf _asdf; var asdf~ = \$_asdf:asdf~
     echo \$E:ASDF_DIR"
 
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "/path/to/asdf" ]
 }
 
@@ -55,7 +55,7 @@ cleaned_path() {
     use ./asdf _asdf; var asdf~ = \$_asdf:asdf~
     echo \$E:ASDF_DATA_DIR"
 
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "/path/to/asdf-data" ]
 }
 
@@ -66,7 +66,7 @@ cleaned_path() {
     use ./asdf _asdf; var asdf~ = \$_asdf:asdf~
     echo \$E:PATH"
 
-  [ "$status" -eq 0 ]
+  assert_success
 
   result=$(echo "$output" | grep "asdf")
   [ "$result" != "" ]
@@ -79,7 +79,7 @@ cleaned_path() {
     use ./asdf _asdf; var asdf~ = \$_asdf:asdf~
     pprint \$_asdf:"
 
-  [ "$status" -eq 0 ]
+  assert_success
   [[ "$output" =~ "<ns " ]]
 }
 
@@ -92,7 +92,7 @@ cleaned_path() {
     use ./asdf _asdf; var asdf~ = \$_asdf:asdf~
     echo \$E:PATH"
 
-  [ "$status" -eq 0 ]
+  assert_success
 
   result=$(echo "$result" | tr ':' '\n' | grep "asdf" | sort | uniq -d)
   [ "$result" = "" ]
@@ -105,7 +105,7 @@ cleaned_path() {
     use ./asdf _asdf; var asdf~ = \$_asdf:asdf~
     pprint \$asdf~"
 
-  [ "$status" -eq 0 ]
+  assert_success
   [[ "$output" =~ "<closure " ]]
 }
 
@@ -116,7 +116,7 @@ cleaned_path() {
     use ./asdf _asdf; var asdf~ = \$_asdf:asdf~
     asdf info"
 
-  [ "$status" -eq 0 ]
+  assert_success
 
   result=$(echo "$output" | grep "ASDF INSTALLED PLUGINS:")
   [ "$result" != "" ]

--- a/test/asdf_fish.bats
+++ b/test/asdf_fish.bats
@@ -25,7 +25,7 @@ cleaned_path() {
     . asdf.fish
     echo \$ASDF_DIR"
 
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" != "" ]
 }
 
@@ -39,7 +39,7 @@ cleaned_path() {
     . (pwd)/asdf.fish  # if the full path is not passed, status -f will return the relative path
     echo \$PATH"
 
-  [ "$status" -eq 0 ]
+  assert_success
 
   result=$(echo "$output" | grep "asdf")
   [ "$result" != "" ]
@@ -56,7 +56,7 @@ cleaned_path() {
     . asdf.fish
     echo \$PATH"
 
-  [ "$status" -eq 0 ]
+  assert_success
 
   result=$(echo "$output" | tr ' ' '\n' | grep "asdf" | sort | uniq -d)
   [ "$result" = "" ]
@@ -71,7 +71,7 @@ cleaned_path() {
     . asdf.fish
     type asdf"
 
-  [ "$status" -eq 0 ]
+  assert_success
   [[ "$output" =~ "is a function" ]]
 }
 
@@ -84,7 +84,7 @@ cleaned_path() {
     . asdf.fish
     asdf info"
 
-  [ "$status" -eq 0 ]
+  assert_success
 
   result=$(echo "$output" | grep "ASDF INSTALLED PLUGINS:")
   [ "$result" != "" ]

--- a/test/asdf_fish.bats
+++ b/test/asdf_fish.bats
@@ -26,7 +26,7 @@ cleaned_path() {
     echo \$ASDF_DIR"
 
   assert_success
-  [ "$output" != "" ]
+  refute_output ''
 }
 
 @test "adds asdf dirs to PATH" {

--- a/test/asdf_fish.bats
+++ b/test/asdf_fish.bats
@@ -72,7 +72,7 @@ cleaned_path() {
     type asdf"
 
   assert_success
-  [[ "$output" =~ "is a function" ]]
+  assert_line "asdf is a function with definition"
 }
 
 @test "function calls asdf command" {

--- a/test/asdf_nu.bats
+++ b/test/asdf_nu.bats
@@ -35,7 +35,7 @@ run_nushell() {
 @test "exports ASDF_DIR" {
   run_nushell "echo \$env.ASDF_DIR"
 
-  [ "$status" -eq 0 ]
+  assert_success
   result=$(echo "$output" | grep "asdf")
   [ "$result" = "$PWD" ]
 }
@@ -43,7 +43,7 @@ run_nushell() {
 @test "adds asdf dirs to PATH" {
   run_nushell "\$env.PATH | to text"
 
-  [ "$status" -eq 0 ]
+  assert_success
 
   [[ "$output" == *"$PWD/bin"* ]]
   [[ "$output" == *"$HOME/.asdf/shims"* ]]
@@ -54,7 +54,7 @@ run_nushell() {
     source asdf.nu
     echo \$env.PATH"
 
-  [ "$status" -eq 0 ]
+  assert_success
 
   result=$(echo "$output" | tr ' ' '\n' | grep "asdf" | sort | uniq -d)
   [ "$result" = "" ]
@@ -71,20 +71,20 @@ run_nushell() {
 
     echo \$env.ASDF_DIR"
 
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$PWD" ]
 }
 
 @test "defines the asdf or main function" {
   run_nushell "which asdf | get path | to text"
 
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "function calls asdf command" {
   run_nushell "asdf info"
 
-  [ "$status" -eq 0 ]
+  assert_success
 
   result=$(echo "$output" | grep "ASDF INSTALLED PLUGINS:")
   [ "$result" != "" ]
@@ -95,7 +95,7 @@ run_nushell() {
   install_dummy_plugin
   run_nushell "asdf plugin list | to csv -n"
 
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "dummy" ]
 }
 
@@ -106,7 +106,7 @@ run_nushell() {
 
   run_nushell "asdf plugin list --urls | to csv -n"
 
-  [ "$status" -eq 0 ]
+  assert_success
 
   local repo_url
   repo_url=$(get_plugin_remote_url "dummy")
@@ -121,7 +121,7 @@ run_nushell() {
 
   run_nushell "asdf plugin list --refs | to csv -n"
 
-  [ "$status" -eq 0 ]
+  assert_success
 
   local branch gitref
   branch=$(get_plugin_remote_branch "dummy")
@@ -137,7 +137,7 @@ run_nushell() {
 
   run_nushell "asdf plugin list --urls --refs | to csv -n"
 
-  [ "$status" -eq 0 ]
+  assert_success
 
   local repo_url branch gitref
   repo_url=$(get_plugin_remote_url "dummy")
@@ -152,7 +152,7 @@ run_nushell() {
   install_dummy_plugin
   run_nushell "asdf plugin list all | to csv -n"
 
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "\
 bar,false,http://example.com/bar
 dummy,true,http://example.com/dummy

--- a/test/asdf_nu.bats
+++ b/test/asdf_nu.bats
@@ -72,7 +72,7 @@ run_nushell() {
     echo \$env.ASDF_DIR"
 
   assert_success
-  [ "$output" = "$PWD" ]
+  assert_output -- "$PWD"
 }
 
 @test "defines the asdf or main function" {
@@ -96,7 +96,7 @@ run_nushell() {
   run_nushell "asdf plugin list | to csv -n"
 
   assert_success
-  [ "$output" = "dummy" ]
+  assert_output "dummy"
 }
 
 @test "parses the output of asdf plugin list --urls" {
@@ -111,7 +111,7 @@ run_nushell() {
   local repo_url
   repo_url=$(get_plugin_remote_url "dummy")
 
-  [ "$output" = "dummy,$repo_url" ]
+  assert_output "dummy,$repo_url"
 }
 
 @test "parses the output of asdf plugin list --refs" {
@@ -127,7 +127,7 @@ run_nushell() {
   branch=$(get_plugin_remote_branch "dummy")
   gitref=$(get_plugin_remote_gitref "dummy")
 
-  [ "$output" = "dummy,$branch,$gitref" ]
+  assert_output "dummy,$branch,$gitref"
 }
 
 @test "parses the output of asdf plugin list --urls --refs" {
@@ -144,7 +144,7 @@ run_nushell() {
   branch=$(get_plugin_remote_branch "dummy")
   gitref=$(get_plugin_remote_gitref "dummy")
 
-  [ "$output" = "dummy,$repo_url,$branch,$gitref" ]
+  assert_output "dummy,$repo_url,$branch,$gitref"
 }
 
 @test "parses the output of asdf plugin list all" {

--- a/test/asdf_nu.bats
+++ b/test/asdf_nu.bats
@@ -45,8 +45,8 @@ run_nushell() {
 
   assert_success
 
-  [[ "$output" == *"$PWD/bin"* ]]
-  [[ "$output" == *"$HOME/.asdf/shims"* ]]
+  assert_output -p "$PWD/bin"
+  assert_output -p "$HOME/.asdf/shims"
 }
 
 @test "does not add paths to PATH more than once" {

--- a/test/asdf_pwsh.bats
+++ b/test/asdf_pwsh.bats
@@ -27,7 +27,7 @@ cleaned_path() {
     Write-Output \"\$env:ASDF_DIR\""
 
   assert_success
-  [ "$output" != "" ]
+  refute_output ''
 }
 
 @test "adds asdf dirs to PATH" {

--- a/test/asdf_pwsh.bats
+++ b/test/asdf_pwsh.bats
@@ -26,7 +26,7 @@ cleaned_path() {
     . ./asdf.ps1
     Write-Output \"\$env:ASDF_DIR\""
 
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" != "" ]
 }
 
@@ -41,7 +41,7 @@ cleaned_path() {
     . ./asdf.ps1
     Write-Output \$Env:PATH"
 
-  [ "$status" -eq 0 ]
+  assert_success
   result=$(echo "$output" | grep "asdf")
   [ "$result" != "" ]
 }
@@ -58,7 +58,7 @@ cleaned_path() {
     . ./asdf.ps1
     Write-Output \$Env:PATH"
 
-  [ "$status" -eq 0 ]
+  assert_success
 
   result=$(echo "$output" | tr ' ' '\n' | grep "asdf" | sort | uniq -d)
   [ "$result" = "" ]
@@ -75,7 +75,7 @@ cleaned_path() {
     ./ asdf.ps1
     \$(Get-Command -CommandType asdf).Name"
 
-  [ "$status" -eq 0 ]
+  assert_success
   [[ "$output" =~ "asdf" ]]
 }
 
@@ -90,7 +90,7 @@ cleaned_path() {
     . ./asdf.ps1
     asdf info"
 
-  [ "$status" -eq 0 ]
+  assert_success
   result=$(echo "$output" | grep "ASDF INSTALLED PLUGINS:")
   [ "$result" != "" ]
 }

--- a/test/asdf_pwsh.bats
+++ b/test/asdf_pwsh.bats
@@ -76,7 +76,7 @@ cleaned_path() {
     \$(Get-Command -CommandType asdf).Name"
 
   assert_success
-  [[ "$output" =~ "asdf" ]]
+  assert_output -p "asdf"
 }
 
 @test "function calls asdf command" {

--- a/test/asdf_sh.bats
+++ b/test/asdf_sh.bats
@@ -70,7 +70,7 @@ cleaned_path() {
 }
 
 @test "defines the asdf function" {
-  output=$(
+  result=$(
     unset -f asdf
     unset ASDF_DIR
     PATH=$(cleaned_path)
@@ -79,7 +79,7 @@ cleaned_path() {
     type asdf
   )
 
-  [[ "$output" =~ "is a function" ]]
+  [[ "$result" == "asdf is a function"* ]]
 }
 
 @test "function calls asdf command" {

--- a/test/asdf_sh.bats
+++ b/test/asdf_sh.bats
@@ -93,5 +93,5 @@ cleaned_path() {
   )
 
   output=$(echo "$result" | grep "ASDF INSTALLED PLUGINS:")
-  [ "$output" != "" ]
+  refute_output ''
 }

--- a/test/banned_commands.bats
+++ b/test/banned_commands.bats
@@ -79,7 +79,7 @@ teardown() {
     fi
 
     [ "$status" -eq 1 ]
-    [ "" = "$output" ]
+    assert_output ''
   done
 
   for cmd in "${banned_commands_regex[@]}"; do
@@ -96,6 +96,6 @@ teardown() {
     fi
 
     [ "$status" -eq 1 ]
-    [ "" = "$output" ]
+    assert_output ''
   done
 }

--- a/test/current_command.bats
+++ b/test/current_command.bats
@@ -24,7 +24,7 @@ teardown() {
 
   run asdf current "dummy"
   assert_success
-  [ "$output" = "$expected" ]
+  assert_output -- "$expected"
 }
 
 @test "current should handle long version name" {
@@ -34,7 +34,7 @@ teardown() {
 
   run asdf current "dummy"
   assert_success
-  [ "$output" = "$expected" ]
+  assert_output -- "$expected"
 }
 
 @test "current should handle multiple versions" {
@@ -44,7 +44,7 @@ teardown() {
 
   run asdf current "dummy"
   assert_success
-  [ "$output" = "$expected" ]
+  assert_output -- "$expected"
 }
 
 @test "current should derive from the legacy file if enabled" {
@@ -55,7 +55,7 @@ teardown() {
 
   run asdf current "dummy"
   assert_success
-  [ "$output" = "$expected" ]
+  assert_output -- "$expected"
 }
 
 # TODO: Need to fix plugin error as well
@@ -64,7 +64,7 @@ teardown() {
 
   run asdf current "foobar"
   [ "$status" -eq 1 ]
-  [ "$output" = "$expected" ]
+  assert_output -- "$expected"
 }
 
 @test "current should error when no version is set" {
@@ -73,7 +73,7 @@ teardown() {
 
   run asdf current "dummy"
   [ "$status" -eq 126 ]
-  [ "$output" = "$expected" ]
+  assert_output -- "$expected"
 }
 
 @test "current should error when a version is set that isn't installed" {
@@ -83,7 +83,7 @@ teardown() {
 
   run asdf current "dummy"
   [ "$status" -eq 1 ]
-  [ "$output" = "$expected" ]
+  assert_output -- "$expected"
 }
 
 @test "should output all plugins when no plugin passed" {
@@ -130,7 +130,7 @@ foobar          1.0.0           $PROJECT_DIR/.tool-versions"
 
   run asdf current
   assert_success
-  [ "$output" = "$expected" ]
+  assert_output -- "$expected"
 }
 
 @test "current should handle comments" {
@@ -140,5 +140,5 @@ foobar          1.0.0           $PROJECT_DIR/.tool-versions"
 
   run asdf current "dummy"
   assert_success
-  [ "$output" = "$expected" ]
+  assert_output -- "$expected"
 }

--- a/test/current_command.bats
+++ b/test/current_command.bats
@@ -105,7 +105,7 @@ teardown() {
 dummy           1.1.0           $PROJECT_DIR/.tool-versions
 foobar          1.0.0           $PROJECT_DIR/.tool-versions"
 
-  assert_output "$expected"
+  assert_output -- "$expected"
 }
 
 @test "should always match the tool name exactly" {

--- a/test/current_command.bats
+++ b/test/current_command.bats
@@ -105,7 +105,7 @@ teardown() {
 dummy           1.1.0           $PROJECT_DIR/.tool-versions
 foobar          1.0.0           $PROJECT_DIR/.tool-versions"
 
-  [ "$expected" = "$output" ]
+  assert_output "$expected"
 }
 
 @test "should always match the tool name exactly" {

--- a/test/current_command.bats
+++ b/test/current_command.bats
@@ -23,7 +23,7 @@ teardown() {
   expected="dummy           1.1.0           $PROJECT_DIR/.tool-versions"
 
   run asdf current "dummy"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$expected" ]
 }
 
@@ -33,7 +33,7 @@ teardown() {
   expected="dummy           nightly-2000-01-01 $PROJECT_DIR/.tool-versions"
 
   run asdf current "dummy"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$expected" ]
 }
 
@@ -43,7 +43,7 @@ teardown() {
   expected="dummy           1.2.0 1.1.0     $PROJECT_DIR/.tool-versions"
 
   run asdf current "dummy"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$expected" ]
 }
 
@@ -54,7 +54,7 @@ teardown() {
   expected="dummy           1.2.0           $PROJECT_DIR/.dummy-version"
 
   run asdf current "dummy"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$expected" ]
 }
 
@@ -120,7 +120,7 @@ foobar          1.0.0           $PROJECT_DIR/.tool-versions"
   echo 'y 2.1.0' >>"$PROJECT_DIR/.tool-versions"
 
   run asdf current "y"
-  [ "$status" -eq 0 ]
+  assert_success
   [[ "$output" == *'2.1.0'* ]]
 }
 
@@ -129,7 +129,7 @@ foobar          1.0.0           $PROJECT_DIR/.tool-versions"
   expected="No plugins installed"
 
   run asdf current
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$expected" ]
 }
 
@@ -139,6 +139,6 @@ foobar          1.0.0           $PROJECT_DIR/.tool-versions"
   expected="dummy           1.2.0           $PROJECT_DIR/.tool-versions"
 
   run asdf current "dummy"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$expected" ]
 }

--- a/test/help_command.bats
+++ b/test/help_command.bats
@@ -30,7 +30,7 @@ Dummy plugin is a plugin only used for unit tests
 EOF
   )"
   assert_success
-  [ "$output" = "$expected_output" ]
+  assert_output -- "$expected_output"
 }
 
 @test "help should show dummy plugin help specific to version when version is present" {
@@ -48,7 +48,7 @@ Details specific for version 1.2.3
 EOF
   )"
   assert_success
-  [ "$output" = "$expected_output" ]
+  assert_output -- "$expected_output"
 }
 
 @test "help should fail for unknown plugins" {
@@ -56,7 +56,7 @@ EOF
 
   run asdf help "sunny"
   [ "$status" -eq 1 ]
-  [ "$output" = "No plugin named sunny" ]
+  assert_output "No plugin named sunny"
 }
 
 @test "help should fail when plugin doesn't have documentation callback" {
@@ -64,7 +64,7 @@ EOF
 
   run asdf help "legacy-dummy"
   [ "$status" -eq 1 ]
-  [ "$output" = "No documentation for plugin legacy-dummy" ]
+  assert_output "No documentation for plugin legacy-dummy"
 }
 
 @test "help should show asdf help when no plugin name is provided" {

--- a/test/help_command.bats
+++ b/test/help_command.bats
@@ -29,7 +29,7 @@ Dummy plugin documentation
 Dummy plugin is a plugin only used for unit tests
 EOF
   )"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$expected_output" ]
 }
 
@@ -47,7 +47,7 @@ Dummy plugin is a plugin only used for unit tests
 Details specific for version 1.2.3
 EOF
   )"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$expected_output" ]
 }
 
@@ -72,7 +72,7 @@ EOF
 
   run asdf help
 
-  [ "$status" -eq 0 ]
+  assert_success
   [[ $output == 'version: v'* ]]
   [[ $output == *$'MANAGE PLUGINS\n'* ]]
   [[ $output == *$'MANAGE PACKAGES\n'* ]]

--- a/test/info_command.bats
+++ b/test/info_command.bats
@@ -22,7 +22,7 @@ teardown() {
 
   run asdf info
 
-  [ "$status" -eq 0 ]
+  assert_success
   [[ $output == *$'OS:\n'* ]]
   [[ $output == *$'SHELL:\n'* ]]
   [[ $output == *$'BASH VERSION:\n'* ]]

--- a/test/info_command.bats
+++ b/test/info_command.bats
@@ -23,11 +23,10 @@ teardown() {
   run asdf info
 
   assert_success
-  [[ $output == *$'OS:\n'* ]]
-  [[ $output == *$'SHELL:\n'* ]]
-  [[ $output == *$'BASH VERSION:\n'* ]]
-  [[ $output == *$'ASDF VERSION:\n'* ]]
-  [[ $output == *$'ASDF INTERNAL VARIABLES:\n'* ]]
-  [[ $output == *$'ASDF INSTALLED PLUGINS:\n'* ]]
-
+  assert_line -p $'OS:'
+  assert_line -p $'SHELL:'
+  assert_line -p $'BASH VERSION:'
+  assert_line -p $'ASDF VERSION:'
+  assert_line -p $'ASDF INTERNAL VARIABLES:'
+  assert_line -p $'ASDF INSTALLED PLUGINS:'
 }

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -18,13 +18,13 @@ teardown() {
 
 @test "install_command installs the correct version" {
   run asdf install dummy 1.1.0
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$ASDF_DIR/installs/dummy/1.1.0/version")" = "1.1.0" ]
 }
 
 @test "install_command installs the correct version for plugins without download script" {
   run asdf install legacy-dummy 1.1.0
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$ASDF_DIR/installs/legacy-dummy/1.1.0/version")" = "1.1.0" ]
 }
 
@@ -32,7 +32,7 @@ teardown() {
   cd "$PROJECT_DIR"
   echo -n 'dummy 1.2.0' >".tool-versions"
   run asdf install
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$ASDF_DIR/installs/dummy/1.2.0/version")" = "1.2.0" ]
 }
 
@@ -40,16 +40,16 @@ teardown() {
   cd "$PROJECT_DIR"
   echo -n 'dummy 1.2.0' >".tool-versions"
   run asdf install dummy
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$ASDF_DIR/installs/dummy/1.2.0/version")" = "1.2.0" ]
 }
 
 @test "install_command set ASDF_CONCURRENCY" {
   run asdf install dummy 1.0.0
-  [ "$status" -eq 0 ]
+  assert_success
   [ -f "$ASDF_DIR/installs/dummy/1.0.0/env" ]
   run grep ASDF_CONCURRENCY "$ASDF_DIR/installs/dummy/1.0.0/env"
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "install_command without arguments should work in directory containing whitespace" {
@@ -60,43 +60,43 @@ teardown() {
 
   run asdf install
 
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$ASDF_DIR/installs/dummy/1.2.0/version")" = "1.2.0" ]
 }
 
 @test "install_command should create a shim with asdf-plugin metadata" {
   run asdf install dummy 1.0.0
-  [ "$status" -eq 0 ]
+  assert_success
   [ -f "$ASDF_DIR/installs/dummy/1.0.0/env" ]
   run grep "asdf-plugin: dummy 1.0.0" "$ASDF_DIR/shims/dummy"
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "install_command should create a shim with asdf-plugin metadata for plugins without download script" {
   run asdf install legacy-dummy 1.0.0
-  [ "$status" -eq 0 ]
+  assert_success
   [ -f "$ASDF_DIR/installs/legacy-dummy/1.0.0/env" ]
   run grep "asdf-plugin: legacy-dummy 1.0.0" "$ASDF_DIR/shims/dummy"
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "install_command on two versions should create a shim with asdf-plugin metadata" {
   run asdf install dummy 1.1.0
-  [ "$status" -eq 0 ]
+  assert_success
 
   run grep "asdf-plugin: dummy 1.1.0" "$ASDF_DIR/shims/dummy"
-  [ "$status" -eq 0 ]
+  assert_success
 
   run grep "asdf-plugin: dummy 1.0.0" "$ASDF_DIR/shims/dummy"
   [ "$status" -eq 1 ]
 
   run asdf install dummy 1.0.0
-  [ "$status" -eq 0 ]
+  assert_success
   run grep "asdf-plugin: dummy 1.0.0" "$ASDF_DIR/shims/dummy"
-  [ "$status" -eq 0 ]
+  assert_success
 
   run grep "# asdf-plugin: dummy 1.0.0"$'\n'"# asdf-plugin: dummy 1.1.0" "$ASDF_DIR/shims/dummy"
-  [ "$status" -eq 0 ]
+  assert_success
 
   lines_count=$(grep -c "asdf-plugin: dummy 1.1.0" "$ASDF_DIR/shims/dummy")
   [ "$lines_count" -eq "1" ]
@@ -107,7 +107,7 @@ teardown() {
   echo 'dummy 1.0.0' >"$PROJECT_DIR/.tool-versions"
 
   run asdf install
-  [ "$status" -eq 0 ]
+  assert_success
   [ -f "$ASDF_DIR/shims/dummy" ]
   [ ! -f "$ASDF_DIR/shims/subdir" ]
 }
@@ -122,7 +122,7 @@ teardown() {
 
   # execute the generated shim
   run "$ASDF_DIR/shims/dummy" world hello
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "This is Dummy 1.0.0! hello world" ]
 }
 
@@ -181,7 +181,7 @@ teardown() {
 
   # execute the generated shim
   [ "$("$ASDF_DIR/shims/dummy" world hello)" = "This is Dummy 1.0.0! hello world" ]
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "install_command installs multiple tool versions when they are specified in a .tool-versions file" {
@@ -189,7 +189,7 @@ teardown() {
   cd "$PROJECT_DIR"
 
   run asdf install
-  [ "$status" -eq 0 ]
+  assert_success
 
   [ "$(cat "$ASDF_DIR/installs/dummy/1.0.0/version")" = "1.0.0" ]
   [ "$(cat "$ASDF_DIR/installs/dummy/1.2.0/version")" = "1.2.0" ]
@@ -197,7 +197,7 @@ teardown() {
 
 @test "install_command doesn't install system version" {
   run asdf install dummy system
-  [ "$status" -eq 0 ]
+  assert_success
   [ ! -f "$ASDF_DIR/installs/dummy/system/version" ]
 }
 
@@ -224,7 +224,7 @@ EOM
   echo '1.2.0' >>"$PROJECT_DIR/.dummy-version"
   cd "$PROJECT_DIR"
   run asdf install
-  [ "$status" -eq 0 ]
+  assert_success
   [ -z "$output" ]
   [ -f "$ASDF_DIR/installs/dummy/1.2.0/version" ]
 }
@@ -237,33 +237,33 @@ EOM
   cd "$PROJECT_DIR/child"
 
   run asdf install
-  [ "$status" -eq 0 ]
+  assert_success
   [ -z "$output" ]
   [ -f "$ASDF_DIR/installs/dummy/1.2.0/version" ]
 }
 
 @test "install_command latest installs latest stable version" {
   run asdf install dummy latest
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$ASDF_DIR/installs/dummy/2.0.0/version")" = "2.0.0" ]
 }
 
 @test "install_command latest:version installs latest stable version that matches the given string" {
   run asdf install dummy latest:1
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$ASDF_DIR/installs/dummy/1.1.0/version")" = "1.1.0" ]
 }
 
 @test "install_command deletes the download directory" {
   run asdf install dummy 1.1.0
-  [ "$status" -eq 0 ]
+  assert_success
   [ ! -d "$ASDF_DIR/downloads/dummy/1.1.0" ]
   [ "$(cat "$ASDF_DIR/installs/dummy/1.1.0/version")" = "1.1.0" ]
 }
 
 @test "install_command keeps the download directory when --keep-download flag is provided" {
   run asdf install dummy 1.1.0 --keep-download
-  [ "$status" -eq 0 ]
+  assert_success
   [ -d "$ASDF_DIR/downloads/dummy/1.1.0" ]
   [ "$(cat "$ASDF_DIR/installs/dummy/1.1.0/version")" = "1.1.0" ]
 }
@@ -271,7 +271,7 @@ EOM
 @test "install_command keeps the download directory when always_keep_download setting is true" {
   echo 'always_keep_download = yes' >"$HOME/.asdfrc"
   run asdf install dummy 1.1.0
-  [ "$status" -eq 0 ]
+  assert_success
   [ -d "$ASDF_DIR/downloads/dummy/1.1.0" ]
   [ "$(cat "$ASDF_DIR/installs/dummy/1.1.0/version")" = "1.1.0" ]
 }

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -225,7 +225,7 @@ EOM
   cd "$PROJECT_DIR"
   run asdf install
   assert_success
-  [ -z "$output" ]
+  assert_output ''
   [ -f "$ASDF_DIR/installs/dummy/1.2.0/version" ]
 }
 
@@ -238,7 +238,7 @@ EOM
 
   run asdf install
   assert_success
-  [ -z "$output" ]
+  assert_output ''
   [ -f "$ASDF_DIR/installs/dummy/1.2.0/version" ]
 }
 

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -123,13 +123,13 @@ teardown() {
   # execute the generated shim
   run "$ASDF_DIR/shims/dummy" world hello
   assert_success
-  [ "$output" = "This is Dummy 1.0.0! hello world" ]
+  assert_output "This is Dummy 1.0.0! hello world"
 }
 
 @test "install_command fails when tool is specified but no version of the tool is configured" {
   run asdf install dummy
   [ "$status" -eq 1 ]
-  [ "$output" = "No versions specified for dummy in config files or environment" ]
+  assert_output "No versions specified for dummy in config files or environment"
   [ ! -f "$ASDF_DIR/installs/dummy/1.1.0/version" ]
 }
 
@@ -139,7 +139,7 @@ teardown() {
 
   run asdf install
   [ "$status" -eq 1 ]
-  [ "$output" = "other_dummy plugin is not installed" ]
+  assert_output "other_dummy plugin is not installed"
 }
 
 @test "install_command fails if the plugin is not installed without collisions" {
@@ -148,14 +148,14 @@ teardown() {
 
   run asdf install
   [ "$status" -eq 1 ]
-  [ "$output" = "dum plugin is not installed" ]
+  assert_output "dum plugin is not installed"
 }
 
 @test "install_command fails when tool is specified but no version of the tool is configured in config file" {
   echo 'dummy 1.0.0' >"$PROJECT_DIR/.tool-versions"
   run asdf install other-dummy
   [ "$status" -eq 1 ]
-  [ "$output" = "No versions specified for other-dummy in config files or environment" ]
+  assert_output "No versions specified for other-dummy in config files or environment"
   [ ! -f "$ASDF_DIR/installs/dummy/1.0.0/version" ]
 }
 
@@ -163,7 +163,7 @@ teardown() {
   printf 'dummy 1.0.0\nother-dummy 2.0.0' >"$PROJECT_DIR/.tool-versions"
   run asdf install dummy other-dummy
   [ "$status" -eq 1 ]
-  [ "$output" = "Dummy couldn't install version: other-dummy (on purpose)" ]
+  assert_output "Dummy couldn't install version: other-dummy (on purpose)"
   [ ! -f "$ASDF_DIR/installs/dummy/1.0.0/version" ]
   [ ! -f "$ASDF_DIR/installs/other-dummy/2.0.0/version" ]
 }
@@ -207,7 +207,7 @@ pre_asdf_install_dummy = echo will install dummy $1
 EOM
 
   run asdf install dummy 1.0.0
-  [ "$output" = "will install dummy 1.0.0" ]
+  assert_output "will install dummy 1.0.0"
 }
 
 @test "install command executes configured post plugin install hook" {
@@ -216,7 +216,7 @@ post_asdf_install_dummy = echo HEY $version FROM $plugin_name
 EOM
 
   run asdf install dummy 1.0.0
-  [ "$output" = "HEY 1.0.0 FROM dummy" ]
+  assert_output "HEY 1.0.0 FROM dummy"
 }
 
 @test "install command without arguments installs versions from legacy files" {
@@ -281,5 +281,5 @@ EOM
   [ "$status" -eq 1 ]
   [ ! -d "$ASDF_DIR/downloads/dummy-broken/1.1.0" ]
   [ ! -d "$ASDF_DIR/installs/dummy-broken/1.1.0" ]
-  [ "$output" = "Download failed!" ]
+  assert_output "Download failed!"
 }

--- a/test/latest_command.bats
+++ b/test/latest_command.bats
@@ -17,19 +17,19 @@ teardown() {
 ####################################################
 @test "[latest_command - dummy_plugin] shows latest stable version" {
   run asdf latest dummy
-  [ "2.0.0" = "$output" ]
+  assert_output "2.0.0"
   assert_success
 }
 
 @test "[latest_command - dummy_plugin] shows latest stable version that matches the given string" {
   run asdf latest dummy 1
-  [ "1.1.0" = "$output" ]
+  assert_output "1.1.0"
   assert_success
 }
 
 @test "[latest_command - dummy_plugin] an invalid version should return an error" {
   run asdf latest dummy 3
-  [ "No compatible versions available (dummy 3)" = "$output" ]
+  assert_output "No compatible versions available (dummy 3)"
   [ "$status" -eq 1 ]
 }
 
@@ -40,7 +40,7 @@ teardown() {
   run asdf latest legacy-dummy
   echo "status: $status"
   echo "output: $output"
-  [ "5.1.0" = "$output" ]
+  assert_output "5.1.0"
   assert_success
 }
 
@@ -48,7 +48,7 @@ teardown() {
   run asdf latest legacy-dummy 1
   echo "status: $status"
   echo "output: $output"
-  [ "1.1.0" = "$output" ]
+  assert_output "1.1.0"
   assert_success
 }
 
@@ -56,7 +56,7 @@ teardown() {
   run asdf latest legacy-dummy 3
   echo "status: $status"
   echo "output: $output"
-  [ -z "$output" ]
+  assert_output ''
   [ "$status" -eq 1 ]
 }
 
@@ -64,7 +64,7 @@ teardown() {
   run asdf latest legacy-dummy 4
   echo "status: $status"
   echo "output: $output"
-  [ "4.0.0" = "$output" ]
+  assert_output "4.0.0"
   assert_success
 }
 
@@ -72,7 +72,7 @@ teardown() {
   run asdf latest legacy-dummy 5
   echo "status: $status"
   echo "output: $output"
-  [ "5.1.0" = "$output" ]
+  assert_output "5.1.0"
   assert_success
 }
 
@@ -80,7 +80,7 @@ teardown() {
   run asdf latest legacy-dummy 6
   echo "status: $status"
   echo "output: $output"
-  [ "No compatible versions available (legacy-dummy 6)" = "$output" ]
+  assert_output "No compatible versions available (legacy-dummy 6)"
   [ "$status" -eq 1 ]
 }
 
@@ -92,12 +92,12 @@ teardown() {
   run asdf install legacy-dummy 4.0.0
   run asdf latest --all
   echo "output $output"
-  [ "$(echo -e "dummy\t2.0.0\tinstalled\nlegacy-dummy\t5.1.0\tmissing\n")" = "$output" ]
+  [ "$output" = "$(echo -e "dummy\t2.0.0\tinstalled\nlegacy-dummy\t5.1.0\tmissing\n")" ]
   assert_success
 }
 
 @test "[latest_command - all plugins] not installed plugin should return missing" {
   run asdf latest --all
-  [ "$(echo -e "dummy\t2.0.0\tmissing\nlegacy-dummy\t5.1.0\tmissing\n")" = "$output" ]
+  [ "$output" = "$(echo -e "dummy\t2.0.0\tmissing\nlegacy-dummy\t5.1.0\tmissing\n")" ]
   assert_success
 }

--- a/test/latest_command.bats
+++ b/test/latest_command.bats
@@ -18,13 +18,13 @@ teardown() {
 @test "[latest_command - dummy_plugin] shows latest stable version" {
   run asdf latest dummy
   [ "2.0.0" = "$output" ]
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "[latest_command - dummy_plugin] shows latest stable version that matches the given string" {
   run asdf latest dummy 1
   [ "1.1.0" = "$output" ]
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "[latest_command - dummy_plugin] an invalid version should return an error" {
@@ -41,7 +41,7 @@ teardown() {
   echo "status: $status"
   echo "output: $output"
   [ "5.1.0" = "$output" ]
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "[latest_command - dummy_legacy_plugin] shows latest stable version that matches the given string" {
@@ -49,7 +49,7 @@ teardown() {
   echo "status: $status"
   echo "output: $output"
   [ "1.1.0" = "$output" ]
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "[latest_command - dummy_legacy_plugin] No stable version should return an error" {
@@ -65,7 +65,7 @@ teardown() {
   echo "status: $status"
   echo "output: $output"
   [ "4.0.0" = "$output" ]
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "[latest_command - dummy_legacy_plugin] do not show latest unstable version with capital characters that matches the given string" {
@@ -73,7 +73,7 @@ teardown() {
   echo "status: $status"
   echo "output: $output"
   [ "5.1.0" = "$output" ]
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "[latest_command - dummy_legacy_plugin] an invalid version should return an error" {
@@ -93,11 +93,11 @@ teardown() {
   run asdf latest --all
   echo "output $output"
   [ "$(echo -e "dummy\t2.0.0\tinstalled\nlegacy-dummy\t5.1.0\tmissing\n")" = "$output" ]
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "[latest_command - all plugins] not installed plugin should return missing" {
   run asdf latest --all
   [ "$(echo -e "dummy\t2.0.0\tmissing\nlegacy-dummy\t5.1.0\tmissing\n")" = "$output" ]
-  [ "$status" -eq 0 ]
+  assert_success
 }

--- a/test/list_command.bats
+++ b/test/list_command.bats
@@ -19,8 +19,8 @@ teardown() {
   run asdf install dummy 1.0.0
   run asdf install dummy 1.1.0
   run asdf list
-  [[ "$output" == *"$(echo -e "dummy\n  1.0.0\n  1.1.0")"* ]]
-  [[ "$output" == *"$(echo -e "dummy-broken\n  No versions installed")"* ]]
+  assert_output -p "$(echo -e "dummy\n  1.0.0\n  1.1.0")"
+  assert_output -p "$(echo -e "dummy-broken\n  No versions installed")"
   assert_success
 }
 
@@ -31,8 +31,8 @@ teardown() {
   run asdf install dummy 1.1.0
 
   run asdf list
-  [[ "$output" == *"$(echo -e "dummy\n  1.0.0\n *1.1.0")"* ]]
-  [[ "$output" == *"$(echo -e "dummy-broken\n  No versions installed")"* ]]
+  assert_output -p "$(echo -e "dummy\n  1.0.0\n *1.1.0")"
+  assert_output -p "$(echo -e "dummy-broken\n  No versions installed")"
   assert_success
 }
 
@@ -43,10 +43,10 @@ teardown() {
   run asdf install dummy 1.0.0
   run asdf install tummy 2.0.0
   run asdf list
-  [[ "$output" == *"$(echo -e "dummy\n  1.0.0")"* ]]
-  [[ "$output" == *"$(echo -e "dummy-broken\n  No versions installed")"* ]]
-  [[ "$output" == *"$(echo -e "mummy\n  No versions installed")"* ]]
-  [[ "$output" == *"$(echo -e "tummy\n  2.0.0")"* ]]
+  assert_output -p "$(echo -e "dummy\n  1.0.0")"
+  assert_output -p "$(echo -e "dummy-broken\n  No versions installed")"
+  assert_output -p "$(echo -e "mummy\n  No versions installed")"
+  assert_output -p "$(echo -e "tummy\n  2.0.0")"
   assert_success
 }
 
@@ -101,7 +101,7 @@ teardown() {
 
 @test "list_all_command displays stderr then stdout when failing" {
   run asdf list-all dummy-broken
-  [[ "$output" == *"List-all failed!"* ]]
+  assert_output -p "List-all failed!"
   [[ "$output" == *"Attempting to list versions" ]]
 }
 

--- a/test/list_command.bats
+++ b/test/list_command.bats
@@ -21,7 +21,7 @@ teardown() {
   run asdf list
   [[ "$output" == *"$(echo -e "dummy\n  1.0.0\n  1.1.0")"* ]]
   [[ "$output" == *"$(echo -e "dummy-broken\n  No versions installed")"* ]]
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "list_command should list plugins with installed versions and any selected versions marked with asterisk" {
@@ -33,7 +33,7 @@ teardown() {
   run asdf list
   [[ "$output" == *"$(echo -e "dummy\n  1.0.0\n *1.1.0")"* ]]
   [[ "$output" == *"$(echo -e "dummy-broken\n  No versions installed")"* ]]
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "list_command should continue listing even when no version is installed for any of the plugins" {
@@ -47,7 +47,7 @@ teardown() {
   [[ "$output" == *"$(echo -e "dummy-broken\n  No versions installed")"* ]]
   [[ "$output" == *"$(echo -e "mummy\n  No versions installed")"* ]]
   [[ "$output" == *"$(echo -e "tummy\n  2.0.0")"* ]]
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "list_command with plugin should list installed versions" {
@@ -55,7 +55,7 @@ teardown() {
   run asdf install dummy 1.1.0
   run asdf list dummy
   [ "$(echo -e "  1.0.0\n  1.1.0")" = "$output" ]
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "list_command with version filters installed versions" {
@@ -64,7 +64,7 @@ teardown() {
   run asdf install dummy 2.0
   run asdf list dummy 1
   [ "$(echo -e "  1.0\n  1.1")" = "$output" ]
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "list_command with an invalid version should return an error" {
@@ -78,13 +78,13 @@ teardown() {
 @test "list_all_command lists available versions" {
   run asdf list-all dummy
   [ "$(echo -e "1.0.0\n1.1.0\n2.0.0")" = "$output" ]
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "list_all_command with version filters available versions" {
   run asdf list-all dummy 1
   [ "$(echo -e "1.0.0\n1.1.0")" = "$output" ]
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "list_all_command with an invalid version should return an error" {

--- a/test/list_command.bats
+++ b/test/list_command.bats
@@ -54,7 +54,7 @@ teardown() {
   run asdf install dummy 1.0.0
   run asdf install dummy 1.1.0
   run asdf list dummy
-  [ "$(echo -e "  1.0.0\n  1.1.0")" = "$output" ]
+  [ "$output" = "$(echo -e "  1.0.0\n  1.1.0")" ]
   assert_success
 }
 
@@ -63,7 +63,7 @@ teardown() {
   run asdf install dummy 1.1
   run asdf install dummy 2.0
   run asdf list dummy 1
-  [ "$(echo -e "  1.0\n  1.1")" = "$output" ]
+  [ "$output" = "$(echo -e "  1.0\n  1.1")" ]
   assert_success
 }
 
@@ -71,25 +71,25 @@ teardown() {
   run asdf install dummy 1.0
   run asdf install dummy 1.1
   run asdf list dummy 2
-  [ "No compatible versions installed (dummy 2)" = "$output" ]
+  assert_output "No compatible versions installed (dummy 2)"
   [ "$status" -eq 1 ]
 }
 
 @test "list_all_command lists available versions" {
   run asdf list-all dummy
-  [ "$(echo -e "1.0.0\n1.1.0\n2.0.0")" = "$output" ]
+  [ "$output" = "$(echo -e "1.0.0\n1.1.0\n2.0.0")" ]
   assert_success
 }
 
 @test "list_all_command with version filters available versions" {
   run asdf list-all dummy 1
-  [ "$(echo -e "1.0.0\n1.1.0")" = "$output" ]
+  [ "$output" = "$(echo -e "1.0.0\n1.1.0")" ]
   assert_success
 }
 
 @test "list_all_command with an invalid version should return an error" {
   run asdf list-all dummy 3
-  [ "No compatible versions available (dummy 3)" = "$output" ]
+  assert_output "No compatible versions available (dummy 3)"
   [ "$status" -eq 1 ]
 }
 

--- a/test/plugin_add_command.bats
+++ b/test/plugin_add_command.bats
@@ -109,7 +109,7 @@ teardown() {
 @test "plugin_add command with no URL specified fails if the plugin doesn't exist" {
   run asdf plugin add "does-not-exist"
   [ "$status" -eq 1 ]
-  echo "$output" | grep "plugin does-not-exist not found in repository"
+  assert_line -p "plugin does-not-exist not found in repository"
 }
 
 @test "plugin_add command executes post-plugin add script" {

--- a/test/plugin_add_command.bats
+++ b/test/plugin_add_command.bats
@@ -18,7 +18,7 @@ teardown() {
   assert_success
 
   run asdf plugin list
-  [ "$output" = "plugin_with-all-valid-chars-123" ]
+  assert_output "plugin_with-all-valid-chars-123"
 }
 
 @test "plugin_add command with LANG=sv_SE.UTF-8 and plugin name matching all valid regex chars succeeds" {
@@ -33,7 +33,7 @@ teardown() {
   assert_success
 
   run asdf plugin-list
-  [ "$output" = "plugin-with-w" ]
+  assert_output "plugin-with-w"
 
   LANG="$ORIGINAL_LANG"
 }
@@ -41,19 +41,19 @@ teardown() {
 @test "plugin_add command with plugin name not matching valid regex fails 1" {
   run asdf plugin add "invalid\$plugin\$name"
   [ "$status" -eq 1 ]
-  [ "$output" = "invalid\$plugin\$name is invalid. Name may only contain lowercase letters, numbers, '_', and '-'" ]
+  assert_output "invalid\$plugin\$name is invalid. Name may only contain lowercase letters, numbers, '_', and '-'"
 }
 
 @test "plugin_add command with plugin name not matching valid regex fails 2" {
   run asdf plugin add "#invalid#plugin#name"
   [ "$status" -eq 1 ]
-  [ "$output" = "#invalid#plugin#name is invalid. Name may only contain lowercase letters, numbers, '_', and '-'" ]
+  assert_output "#invalid#plugin#name is invalid. Name may only contain lowercase letters, numbers, '_', and '-'"
 }
 
 @test "plugin_add command with plugin name not matching valid regex fails 3" {
   run asdf plugin add "Ruby"
   [ "$status" -eq 1 ]
-  [ "$output" = "Ruby is invalid. Name may only contain lowercase letters, numbers, '_', and '-'" ]
+  assert_output "Ruby is invalid. Name may only contain lowercase letters, numbers, '_', and '-'"
 }
 
 @test "plugin_add command with no URL specified adds a plugin using repo" {
@@ -61,7 +61,7 @@ teardown() {
   assert_success
 
   run asdf plugin list
-  [ "$output" = "elixir" ]
+  assert_output "elixir"
 }
 
 @test "plugin_add command with no URL specified adds a plugin when short name repository is enabled" {
@@ -73,7 +73,7 @@ teardown() {
 
   local expected="elixir"
   run asdf plugin list
-  [ "$output" = "$expected" ]
+  assert_output -- "$expected"
 }
 
 @test "plugin_add command with no URL specified fails to add a plugin when disabled" {
@@ -83,7 +83,7 @@ teardown() {
 
   run asdf plugin add "elixir"
   [ "$status" -eq 1 ]
-  [ "$output" = "$expected" ]
+  assert_output -- "$expected"
 }
 
 @test "plugin_add command with URL specified adds a plugin using repo" {
@@ -94,7 +94,7 @@ teardown() {
 
   run asdf plugin list
   # whitespace between 'elixir' and url is from printf %-15s %s format
-  [ "$output" = "dummy" ]
+  assert_output "dummy"
 }
 
 @test "plugin_add command with URL specified run twice returns error second time" {
@@ -103,7 +103,7 @@ teardown() {
   run asdf plugin add "dummy" "${BASE_DIR}/repo-dummy"
   run asdf plugin add "dummy" "${BASE_DIR}/repo-dummy"
   [ "$status" -eq 2 ]
-  [ "$output" = "Plugin named dummy already added" ]
+  assert_output "Plugin named dummy already added"
 }
 
 @test "plugin_add command with no URL specified fails if the plugin doesn't exist" {
@@ -116,7 +116,7 @@ teardown() {
   install_mock_plugin_repo "dummy"
 
   run asdf plugin add "dummy" "${BASE_DIR}/repo-dummy"
-  [ "$output" = "plugin add path=${ASDF_DIR}/plugins/dummy source_url=${BASE_DIR}/repo-dummy" ]
+  assert_output "plugin add path=${ASDF_DIR}/plugins/dummy source_url=${BASE_DIR}/repo-dummy"
 }
 
 @test "plugin_add command executes configured pre hook (generic)" {
@@ -130,7 +130,7 @@ EOM
 
   local expected_output="ADD dummy
 plugin add path=${ASDF_DIR}/plugins/dummy source_url=${BASE_DIR}/repo-dummy"
-  [ "$output" = "${expected_output}" ]
+  assert_output -- "${expected_output}"
 }
 
 @test "plugin_add command executes configured pre hook (specific)" {
@@ -144,7 +144,7 @@ EOM
 
   local expected_output="ADD
 plugin add path=${ASDF_DIR}/plugins/dummy source_url=${BASE_DIR}/repo-dummy"
-  [ "$output" = "${expected_output}" ]
+  assert_output -- "${expected_output}"
 }
 
 @test "plugin_add command executes configured post hook (generic)" {
@@ -158,7 +158,7 @@ EOM
 
   local expected_output="plugin add path=${ASDF_DIR}/plugins/dummy source_url=${BASE_DIR}/repo-dummy
 ADD dummy"
-  [ "$output" = "${expected_output}" ]
+  assert_output -- "${expected_output}"
 }
 
 @test "plugin_add command executes configured post hook (specific)" {
@@ -172,5 +172,5 @@ EOM
 
   local expected_output="plugin add path=${ASDF_DIR}/plugins/dummy source_url=${BASE_DIR}/repo-dummy
 ADD"
-  [ "$output" = "${expected_output}" ]
+  assert_output -- "${expected_output}"
 }

--- a/test/plugin_add_command.bats
+++ b/test/plugin_add_command.bats
@@ -15,7 +15,7 @@ teardown() {
   install_mock_plugin_repo "plugin_with-all-valid-chars-123"
 
   run asdf plugin add "plugin_with-all-valid-chars-123" "${BASE_DIR}/repo-plugin_with-all-valid-chars-123"
-  [ "$status" -eq 0 ]
+  assert_success
 
   run asdf plugin list
   [ "$output" = "plugin_with-all-valid-chars-123" ]
@@ -30,7 +30,7 @@ teardown() {
   # https://stackoverflow.com/questions/52570103/regular-expression-a-za-z-seems-to-not-include-letter-w-and-wA
   # https://github.com/asdf-vm/asdf/issues/1237
   run asdf plugin add "plugin-with-w" "${BASE_DIR}/repo-plugin-with-w"
-  [ "$status" -eq 0 ]
+  assert_success
 
   run asdf plugin-list
   [ "$output" = "plugin-with-w" ]
@@ -58,7 +58,7 @@ teardown() {
 
 @test "plugin_add command with no URL specified adds a plugin using repo" {
   run asdf plugin add "elixir"
-  [ "$status" -eq 0 ]
+  assert_success
 
   run asdf plugin list
   [ "$output" = "elixir" ]
@@ -69,7 +69,7 @@ teardown() {
   echo "disable_plugin_short_name_repository=no" >"$ASDF_CONFIG_DEFAULT_FILE"
 
   run asdf plugin add "elixir"
-  [ "$status" -eq 0 ]
+  assert_success
 
   local expected="elixir"
   run asdf plugin list
@@ -90,7 +90,7 @@ teardown() {
   install_mock_plugin_repo "dummy"
 
   run asdf plugin add "dummy" "${BASE_DIR}/repo-dummy"
-  [ "$status" -eq 0 ]
+  assert_success
 
   run asdf plugin list
   # whitespace between 'elixir' and url is from printf %-15s %s format

--- a/test/plugin_extension_command.bats
+++ b/test/plugin_extension_command.bats
@@ -23,10 +23,10 @@ teardown() {
   touch "$plugin_path/lib/commands/command-foo-bar.bash"
   run asdf help
   assert_success
-  echo "$output" | grep "PLUGIN dummy" # should present plugin section
+  assert_line -p "PLUGIN dummy"
   listed_cmds=$(echo "$output" | grep -c "asdf dummy")
   [ "$listed_cmds" -eq 3 ]
-  echo "$output" | grep "asdf dummy foo bar" # should present commands without hyphens
+  assert_line -p "asdf dummy foo bar"
 }
 
 @test "asdf help shows extension commands for plugin with hyphens in the name" {
@@ -43,11 +43,11 @@ teardown() {
 
   run asdf help
   assert_success
-  [[ "$output" == *"PLUGIN $plugin_name"* ]]
+  assert_output -p "PLUGIN $plugin_name"
   listed_cmds=$(grep -c "asdf $plugin_name" <<<"${output}")
   [[ $listed_cmds -eq 3 ]]
-  [[ "$output" == *"asdf $plugin_name foo"* ]]
-  [[ "$output" == *"asdf $plugin_name foo bar"* ]]
+  assert_output -p "asdf $plugin_name foo"
+  assert_output -p "asdf $plugin_name foo bar"
 }
 
 @test "asdf can execute plugin bin commands" {

--- a/test/plugin_extension_command.bats
+++ b/test/plugin_extension_command.bats
@@ -22,7 +22,7 @@ teardown() {
   touch "$plugin_path/lib/commands/command-foo.bash"
   touch "$plugin_path/lib/commands/command-foo-bar.bash"
   run asdf help
-  [ "$status" -eq 0 ]
+  assert_success
   echo "$output" | grep "PLUGIN dummy" # should present plugin section
   listed_cmds=$(echo "$output" | grep -c "asdf dummy")
   [ "$listed_cmds" -eq 3 ]
@@ -42,7 +42,7 @@ teardown() {
   touch "$plugin_path/lib/commands/command-foo-bar.bash"
 
   run asdf help
-  [ "$status" -eq 0 ]
+  assert_success
   [[ "$output" == *"PLUGIN $plugin_name"* ]]
   listed_cmds=$(grep -c "asdf $plugin_name" <<<"${output}")
   [[ $listed_cmds -eq 3 ]]
@@ -63,7 +63,7 @@ EOF
   expected="this is an executable bar"
 
   run asdf dummy foo bar
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$expected" ]
 }
 
@@ -76,7 +76,7 @@ EOF
   expected="sourced script has asdf utils $plugin_path bar"
 
   run asdf dummy foo bar
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$expected" ]
 }
 
@@ -93,7 +93,7 @@ EOF
   expected="hello"
 
   run asdf dummy
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$expected" ]
 }
 
@@ -110,6 +110,6 @@ EOF
   expected="hello world"
 
   run asdf dummy world
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$expected" ]
 }

--- a/test/plugin_extension_command.bats
+++ b/test/plugin_extension_command.bats
@@ -64,7 +64,7 @@ EOF
 
   run asdf dummy foo bar
   assert_success
-  [ "$output" = "$expected" ]
+  assert_output -- "$expected"
 }
 
 @test "asdf can source plugin bin scripts" {
@@ -77,7 +77,7 @@ EOF
 
   run asdf dummy foo bar
   assert_success
-  [ "$output" = "$expected" ]
+  assert_output -- "$expected"
 }
 
 @test "asdf can execute plugin default command without arguments" {
@@ -94,7 +94,7 @@ EOF
 
   run asdf dummy
   assert_success
-  [ "$output" = "$expected" ]
+  assert_output -- "$expected"
 }
 
 @test "asdf can execute plugin default command with arguments" {
@@ -111,5 +111,5 @@ EOF
 
   run asdf dummy world
   assert_success
-  [ "$output" = "$expected" ]
+  assert_output -- "$expected"
 }

--- a/test/plugin_list_all_command.bats
+++ b/test/plugin_list_all_command.bats
@@ -33,7 +33,7 @@ dummy                        *http://example.com/dummy
 foo                           http://example.com/foo"
 
   run asdf plugin list all
-  [ "$status" -eq 0 ]
+  assert_success
   [[ "$output" == *"$expected_plugin_repo_sync"* ]]
   [[ "$output" == *"$expected_plugins_list"* ]]
 }
@@ -47,7 +47,7 @@ dummy                        *http://example.com/dummy
 foo                           http://example.com/foo"
 
   run asdf plugin list all
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$expected" ]
 }
 
@@ -60,7 +60,7 @@ dummy                        *http://example.com/dummy
 foo                           http://example.com/foo"
 
   run asdf plugin list all
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$expected" ]
 }
 
@@ -71,6 +71,6 @@ dummy                        *http://example.com/dummy
 foo                           http://example.com/foo"
 
   run asdf plugin list all
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$expected" ]
 }

--- a/test/plugin_list_all_command.bats
+++ b/test/plugin_list_all_command.bats
@@ -34,8 +34,8 @@ foo                           http://example.com/foo"
 
   run asdf plugin list all
   assert_success
-  [[ "$output" == *"$expected_plugin_repo_sync"* ]]
-  [[ "$output" == *"$expected_plugins_list"* ]]
+  assert_output -p "$expected_plugin_repo_sync"
+  assert_output -p "$expected_plugins_list"
 }
 
 @test "plugin_list_all no immediate repo sync expected because check_duration is greater than 0" {

--- a/test/plugin_list_all_command.bats
+++ b/test/plugin_list_all_command.bats
@@ -20,7 +20,7 @@ teardown() {
 
   run asdf plugin list all
   [ "$status" -eq 1 ]
-  [ "$output" = "$expected" ]
+  assert_output -- "$expected"
 }
 
 @test "plugin_list_all should sync repo when check_duration set to 0" {
@@ -48,7 +48,7 @@ foo                           http://example.com/foo"
 
   run asdf plugin list all
   assert_success
-  [ "$output" = "$expected" ]
+  assert_output -- "$expected"
 }
 
 @test "plugin_list_all skips repo sync because check_duration is set to never" {
@@ -61,7 +61,7 @@ foo                           http://example.com/foo"
 
   run asdf plugin list all
   assert_success
-  [ "$output" = "$expected" ]
+  assert_output -- "$expected"
 }
 
 @test "plugin_list_all list all plugins in the repository" {
@@ -72,5 +72,5 @@ foo                           http://example.com/foo"
 
   run asdf plugin list all
   assert_success
-  [ "$output" = "$expected" ]
+  assert_output -- "$expected"
 }

--- a/test/plugin_remove_command.bats
+++ b/test/plugin_remove_command.bats
@@ -13,11 +13,11 @@ teardown() {
 
 @test "plugin_remove command removes the plugin directory" {
   run asdf install dummy 1.0
-  [ "$status" -eq 0 ]
+  assert_success
   [ -d "$ASDF_DIR/downloads/dummy" ]
 
   run asdf plugin-remove "dummy"
-  [ "$status" -eq 0 ]
+  assert_success
   [ ! -d "$ASDF_DIR/downloads/dummy" ]
 }
 

--- a/test/plugin_remove_command.bats
+++ b/test/plugin_remove_command.bats
@@ -24,5 +24,5 @@ teardown() {
 @test "plugin_remove command fails if the plugin doesn't exist" {
   run asdf plugin-remove "does-not-exist"
   [ "$status" -eq 1 ]
-  echo "$output" | grep "No such plugin: does-not-exist"
+  assert_line -p "No such plugin: does-not-exist"
 }

--- a/test/plugin_test_command.bats
+++ b/test/plugin_test_command.bats
@@ -27,12 +27,12 @@ teardown() {
   run asdf plugin-test dummy "${BASE_DIR}/repo-dummy"
   echo "status = ${status}"
   echo "output = ${output}"
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "plugin_test_command works with all options provided" {
   run asdf plugin-test dummy "${BASE_DIR}/repo-dummy" --asdf-tool-version 1.0.0 --asdf-plugin-gitref master
   echo "status = ${status}"
   echo "output = ${output}"
-  [ "$status" -eq 0 ]
+  assert_success
 }

--- a/test/plugin_test_command.bats
+++ b/test/plugin_test_command.bats
@@ -14,13 +14,13 @@ teardown() {
 @test "plugin_test_command with no URL specified prints an error" {
   run asdf plugin-test "elixir"
   [ "$status" -eq 1 ]
-  [ "$output" = "FAILED: please provide a plugin name and url" ]
+  assert_output "FAILED: please provide a plugin name and url"
 }
 
 @test "plugin_test_command with no name or URL specified prints an error" {
   run asdf plugin-test
   [ "$status" -eq 1 ]
-  [ "$output" = "FAILED: please provide a plugin name and url" ]
+  assert_output "FAILED: please provide a plugin name and url"
 }
 
 @test "plugin_test_command works with no options provided" {

--- a/test/plugin_update_command.bats
+++ b/test/plugin_update_command.bats
@@ -117,7 +117,7 @@ teardown() {
   local command="asdf plugin-update --all"
   # Count the number of update processes remaining after the update command is completed.
   run bash -c "${command} >/dev/null && ps -o 'ppid,args' | awk '{if(\$1==1 && \$0 ~ /${command}/ ) print}' | wc -l"
-  [[ 0 -eq "$output" ]]
+  assert_output '0'
 }
 
 @test "asdf plugin-update executes post-plugin update script" {

--- a/test/plugin_update_command.bats
+++ b/test/plugin_update_command.bats
@@ -16,7 +16,7 @@ teardown() {
   run asdf plugin-update dummy
   repo_head="$(git --git-dir "$ASDF_DIR/plugins/dummy/.git" --work-tree "$ASDF_DIR/plugins/dummy" rev-parse --abbrev-ref HEAD)"
   assert_success
-  [[ "$output" =~ "Updating dummy to master"* ]]
+  assert_output -p "Updating dummy to master"
   [ "$repo_head" = "master" ]
 }
 
@@ -34,7 +34,7 @@ teardown() {
   repo_head="$(git --git-dir "$ASDF_DIR/plugins/dummy/.git" --work-tree "$ASDF_DIR/plugins/dummy" rev-parse --abbrev-ref HEAD)"
 
   assert_success
-  [[ "$output" =~ "Updating dummy to main"* ]]
+  assert_line "Updating dummy to main"
   [ "$repo_head" = "main" ]
 }
 
@@ -52,7 +52,7 @@ teardown() {
   repo_head="$(git --git-dir "$ASDF_DIR/plugins/dummy/.git" --work-tree "$ASDF_DIR/plugins/dummy" rev-parse --abbrev-ref HEAD)"
 
   assert_success
-  [[ "$output" =~ "Updating dummy to my/default"* ]]
+  assert_line "Updating dummy to my/default"
   [ "$repo_head" = "my/default" ]
 }
 
@@ -76,7 +76,7 @@ teardown() {
   repo_head="$(git --git-dir "$ASDF_DIR/plugins/dummy/.git" --work-tree "$ASDF_DIR/plugins/dummy" rev-parse --abbrev-ref HEAD)"
 
   assert_success
-  [[ "$output" =~ "Updating dummy to main"* ]]
+  assert_line "Updating dummy to main"
   [ "$repo_head" = "main" ]
 }
 

--- a/test/plugin_update_command.bats
+++ b/test/plugin_update_command.bats
@@ -15,7 +15,7 @@ teardown() {
 @test "asdf plugin-update should pull latest default branch (refs/remotes/origin/HEAD) for plugin" {
   run asdf plugin-update dummy
   repo_head="$(git --git-dir "$ASDF_DIR/plugins/dummy/.git" --work-tree "$ASDF_DIR/plugins/dummy" rev-parse --abbrev-ref HEAD)"
-  [ "$status" -eq 0 ]
+  assert_success
   [[ "$output" =~ "Updating dummy to master"* ]]
   [ "$repo_head" = "master" ]
 }
@@ -33,7 +33,7 @@ teardown() {
   run asdf plugin-update dummy
   repo_head="$(git --git-dir "$ASDF_DIR/plugins/dummy/.git" --work-tree "$ASDF_DIR/plugins/dummy" rev-parse --abbrev-ref HEAD)"
 
-  [ "$status" -eq 0 ]
+  assert_success
   [[ "$output" =~ "Updating dummy to main"* ]]
   [ "$repo_head" = "main" ]
 }
@@ -51,7 +51,7 @@ teardown() {
   run asdf plugin-update dummy
   repo_head="$(git --git-dir "$ASDF_DIR/plugins/dummy/.git" --work-tree "$ASDF_DIR/plugins/dummy" rev-parse --abbrev-ref HEAD)"
 
-  [ "$status" -eq 0 ]
+  assert_success
   [[ "$output" =~ "Updating dummy to my/default"* ]]
   [ "$repo_head" = "my/default" ]
 }
@@ -75,30 +75,30 @@ teardown() {
   run asdf plugin-update dummy
   repo_head="$(git --git-dir "$ASDF_DIR/plugins/dummy/.git" --work-tree "$ASDF_DIR/plugins/dummy" rev-parse --abbrev-ref HEAD)"
 
-  [ "$status" -eq 0 ]
+  assert_success
   [[ "$output" =~ "Updating dummy to main"* ]]
   [ "$repo_head" = "main" ]
 }
 
 @test "asdf plugin-update should not remove plugin versions" {
   run asdf install dummy 1.1
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$ASDF_DIR/installs/dummy/1.1/version")" = "1.1" ]
   run asdf plugin-update dummy
-  [ "$status" -eq 0 ]
+  assert_success
   [ -f "$ASDF_DIR/installs/dummy/1.1/version" ]
   run asdf plugin-update --all
-  [ "$status" -eq 0 ]
+  assert_success
   [ -f "$ASDF_DIR/installs/dummy/1.1/version" ]
 }
 
 @test "asdf plugin-update should not remove plugins" {
   # dummy plugin is already installed
   run asdf plugin-update dummy
-  [ "$status" -eq 0 ]
+  assert_success
   [ -d "$ASDF_DIR/plugins/dummy" ]
   run asdf plugin-update --all
-  [ "$status" -eq 0 ]
+  assert_success
   [ -d "$ASDF_DIR/plugins/dummy" ]
 }
 
@@ -106,10 +106,10 @@ teardown() {
   run asdf install dummy 1.1
   [ -f "$ASDF_DIR/shims/dummy" ]
   run asdf plugin-update dummy
-  [ "$status" -eq 0 ]
+  assert_success
   [ -f "$ASDF_DIR/shims/dummy" ]
   run asdf plugin-update --all
-  [ "$status" -eq 0 ]
+  assert_success
   [ -f "$ASDF_DIR/shims/dummy" ]
 }
 

--- a/test/remove_command.bats
+++ b/test/remove_command.bats
@@ -15,19 +15,19 @@ teardown() {
 
   run asdf plugin-remove "dummy"
   assert_success
-  [ "$output" = "plugin-remove ${ASDF_DIR}/plugins/dummy" ]
+  assert_output "plugin-remove ${ASDF_DIR}/plugins/dummy"
 }
 
 @test "plugin_remove_command should exit with 1 when not passed any arguments" {
   run asdf plugin-remove
   [ "$status" -eq 1 ]
-  [ "$output" = "No plugin given" ]
+  assert_output "No plugin given"
 }
 
 @test "plugin_remove_command should exit with 1 when passed invalid plugin name" {
   run asdf plugin-remove "does-not-exist"
   [ "$status" -eq 1 ]
-  [ "$output" = "No such plugin: does-not-exist" ]
+  assert_output "No such plugin: does-not-exist"
 }
 
 @test "plugin_remove_command should remove installed versions" {
@@ -71,7 +71,7 @@ teardown() {
 
   run asdf plugin-remove dummy
 
-  [ "$output" = "plugin-remove ${ASDF_DIR}/plugins/dummy" ]
+  assert_output "plugin-remove ${ASDF_DIR}/plugins/dummy"
 }
 
 @test "plugin_remove_command executes configured pre hook (generic)" {
@@ -85,7 +85,7 @@ EOM
 
   local expected_output="REMOVE dummy
 plugin-remove ${ASDF_DIR}/plugins/dummy"
-  [ "$output" = "${expected_output}" ]
+  assert_output -- "${expected_output}"
 }
 
 @test "plugin_remove_command executes configured pre hook (specific)" {
@@ -99,7 +99,7 @@ EOM
 
   local expected_output="REMOVE
 plugin-remove ${ASDF_DIR}/plugins/dummy"
-  [ "$output" = "${expected_output}" ]
+  assert_output -- "${expected_output}"
 }
 
 @test "plugin_remove_command executes configured post hook (generic)" {
@@ -113,7 +113,7 @@ EOM
 
   local expected_output="plugin-remove ${ASDF_DIR}/plugins/dummy
 REMOVE dummy"
-  [ "$output" = "${expected_output}" ]
+  assert_output -- "${expected_output}"
 }
 
 @test "plugin_remove_command executes configured post hook (specific)" {
@@ -127,5 +127,5 @@ EOM
 
   local expected_output="plugin-remove ${ASDF_DIR}/plugins/dummy
 REMOVE"
-  [ "$output" = "${expected_output}" ]
+  assert_output -- "${expected_output}"
 }

--- a/test/remove_command.bats
+++ b/test/remove_command.bats
@@ -14,7 +14,7 @@ teardown() {
   install_dummy_plugin
 
   run asdf plugin-remove "dummy"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "plugin-remove ${ASDF_DIR}/plugins/dummy" ]
 }
 
@@ -33,22 +33,22 @@ teardown() {
 @test "plugin_remove_command should remove installed versions" {
   install_dummy_plugin
   run asdf install dummy 1.0
-  [ "$status" -eq 0 ]
+  assert_success
   [ -d "$ASDF_DIR/installs/dummy" ]
 
   run asdf plugin-remove dummy
-  [ "$status" -eq 0 ]
+  assert_success
   [ ! -d "$ASDF_DIR/installs/dummy" ]
 }
 
 @test "plugin_remove_command should also remove shims for that plugin" {
   install_dummy_plugin
   run asdf install dummy 1.0
-  [ "$status" -eq 0 ]
+  assert_success
   [ -f "$ASDF_DIR/shims/dummy" ]
 
   run asdf plugin-remove dummy
-  [ "$status" -eq 0 ]
+  assert_success
   [ ! -f "$ASDF_DIR/shims/dummy" ]
 }
 
@@ -60,7 +60,7 @@ teardown() {
   echo "# asdf-plugin: gummy" >"$ASDF_DIR/shims/gummy"
 
   run asdf plugin-remove dummy
-  [ "$status" -eq 0 ]
+  assert_success
 
   # unrelated shim should exist
   [ -f "$ASDF_DIR/shims/gummy" ]

--- a/test/reshim_command.bats
+++ b/test/reshim_command.bats
@@ -20,26 +20,26 @@ teardown() {
   run asdf install dummy 1.0
 
   run asdf reshim
-  [ "$status" -eq 0 ]
+  assert_success
 
   run grep "asdf-plugin: dummy 1.0.1" "$ASDF_DIR/shims/dummy"
-  [ "$status" -eq 0 ]
+  assert_success
   run grep "asdf-plugin: dummy 1.0\$" "$ASDF_DIR/shims/dummy"
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "reshim command should remove shims of removed binaries" {
   run asdf install dummy 1.0
-  [ "$status" -eq 0 ]
+  assert_success
   [ -f "$ASDF_DIR/shims/dummy" ]
 
   run asdf reshim dummy
-  [ "$status" -eq 0 ]
+  assert_success
   [ -f "$ASDF_DIR/shims/dummy" ]
 
   run rm "$ASDF_DIR/installs/dummy/1.0/bin/dummy"
   run asdf reshim dummy
-  [ "$status" -eq 0 ]
+  assert_success
   [ ! -f "$ASDF_DIR/shims/dummy" ]
 }
 
@@ -49,12 +49,12 @@ teardown() {
 
   run rm "$ASDF_DIR/installs/dummy/1.0/bin/dummy"
   run asdf reshim dummy
-  [ "$status" -eq 0 ]
+  assert_success
   [ -f "$ASDF_DIR/shims/dummy" ]
   run grep "asdf-plugin: dummy 1.0" "$ASDF_DIR/shims/dummy"
   [ "$status" -eq 1 ]
   run grep "asdf-plugin: dummy 1.1" "$ASDF_DIR/shims/dummy"
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "reshim should not remove metadata of removed prefix versions" {
@@ -62,10 +62,10 @@ teardown() {
   run asdf install dummy 1.0.1
   run rm "$ASDF_DIR/installs/dummy/1.0/bin/dummy"
   run asdf reshim dummy
-  [ "$status" -eq 0 ]
+  assert_success
   [ -f "$ASDF_DIR/shims/dummy" ]
   run grep "asdf-plugin: dummy 1.0.1" "$ASDF_DIR/shims/dummy"
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "reshim should not duplicate shims" {
@@ -73,19 +73,19 @@ teardown() {
 
   run asdf install dummy 1.0
   run asdf install dummy 1.1
-  [ "$status" -eq 0 ]
+  assert_success
   [ -f "$ASDF_DIR/shims/dummy" ]
 
   run rm "$ASDF_DIR/shims/"*
-  [ "$status" -eq 0 ]
+  assert_success
   [ "0" -eq "$(ls "$ASDF_DIR/shims/"dummy* | wc -l)" ]
 
   run asdf reshim dummy
-  [ "$status" -eq 0 ]
+  assert_success
   [ "1" -eq "$(ls "$ASDF_DIR/shims/"dummy* | wc -l)" ]
 
   run asdf reshim dummy
-  [ "$status" -eq 0 ]
+  assert_success
   [ "1" -eq "$(ls "$ASDF_DIR/shims/"dummy* | wc -l)" ]
 }
 
@@ -94,17 +94,17 @@ teardown() {
 
   run asdf install dummy 1.0
   run asdf install dummy 1.1
-  [ "$status" -eq 0 ]
+  assert_success
   [ -f "$ASDF_DIR/shims/dummy" ]
   [ ! -f "$ASDF_DIR/shims/subdir" ]
 
   run rm "$ASDF_DIR/shims/"*
-  [ "$status" -eq 0 ]
+  assert_success
   [ "0" -eq "$(ls "$ASDF_DIR/shims/"dummy* | wc -l)" ]
   [ "0" -eq "$(ls "$ASDF_DIR/shims/"subdir* | wc -l)" ]
 
   run asdf reshim dummy
-  [ "$status" -eq 0 ]
+  assert_success
   [ "1" -eq "$(ls "$ASDF_DIR/shims/"dummy* | wc -l)" ]
   [ "0" -eq "$(ls "$ASDF_DIR/shims/"subdir* | wc -l)" ]
 
@@ -113,10 +113,10 @@ teardown() {
 @test "reshim without arguments reshims all installed plugins" {
   run asdf install dummy 1.0
   run rm "$ASDF_DIR/shims/"*
-  [ "$status" -eq 0 ]
+  assert_success
   [ "0" -eq "$(ls "$ASDF_DIR/shims/"dummy* | wc -l)" ]
   run asdf reshim
-  [ "$status" -eq 0 ]
+  assert_success
   [ "1" -eq "$(ls "$ASDF_DIR/shims/"dummy* | wc -l)" ]
 }
 
@@ -151,11 +151,11 @@ EOM
 
   sed -i.bak -e 's/exec /exec \/borked_path_due_to_homebrew_update/' "$dummy_shim"
   run grep 'borked_path_due_to_homebrew_update' "$dummy_shim" # Sanity check
-  [ "$status" -eq 0 ]
+  assert_success
 
   run asdf reshim dummy "path:$ASDF_DIR/installs/dummy/path"
   run grep -v 'borked_path_due_to_homebrew_update' "$dummy_shim"
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "reshim should allow local path versions" {
@@ -167,9 +167,9 @@ EOM
 
   run asdf reshim dummy "path:$ASDF_DIR/installs/dummy/path"
 
-  [ "$status" -eq 0 ]
+  assert_success
   run grep "asdf-plugin: dummy 1.0" "$ASDF_DIR/shims/dummy"
-  [ "$status" -eq 0 ]
+  assert_success
   run grep "asdf-plugin: dummy path:$ASDF_DIR/installs/dummy" "$ASDF_DIR/shims/dummy"
-  [ "$status" -eq 0 ]
+  assert_success
 }

--- a/test/reshim_command.bats
+++ b/test/reshim_command.bats
@@ -128,7 +128,7 @@ pre_asdf_reshim_dummy = echo RESHIM
 EOM
 
   run asdf reshim dummy 1.0
-  [ "$output" = "RESHIM" ]
+  assert_output "RESHIM"
 }
 
 @test "reshim command executes configured post hook" {
@@ -139,7 +139,7 @@ post_asdf_reshim_dummy = echo RESHIM
 EOM
 
   run asdf reshim dummy 1.0
-  [ "$output" = "RESHIM" ]
+  assert_output "RESHIM"
 }
 
 # Fixes https://github.com/asdf-vm/asdf/issues/1115

--- a/test/shim_env_command.bats
+++ b/test/shim_env_command.bats
@@ -22,7 +22,7 @@ teardown() {
 @test "asdf env without argument should display help" {
   run asdf env
   [ "$status" -eq 1 ]
-  echo "$output" | grep "usage: asdf env <command>"
+  assert_line -p "usage: asdf env <command>"
 }
 
 @test "asdf env should execute under the environment used for a shim" {

--- a/test/shim_env_command.bats
+++ b/test/shim_env_command.bats
@@ -31,7 +31,7 @@ teardown() {
 
   run asdf env dummy which dummy
   assert_success
-  [ "$output" = "$ASDF_DIR/installs/dummy/1.0/bin/dummy" ]
+  assert_output -- "$ASDF_DIR/installs/dummy/1.0/bin/dummy"
 }
 
 @test "asdf env should execute under plugin custom environment used for a shim" {
@@ -59,11 +59,11 @@ teardown() {
   assert_success
 
   run grep 'FOO=bar' <<<"$output"
-  [ "$output" = "" ]
+  assert_output ""
   [ "$status" -eq 1 ]
 
   run asdf env dummy which dummy
-  [ "$output" = "$ASDF_DIR/shims/dummy" ]
+  assert_output -- "$ASDF_DIR/shims/dummy"
   assert_success
 }
 

--- a/test/shim_env_command.bats
+++ b/test/shim_env_command.bats
@@ -30,7 +30,7 @@ teardown() {
   run asdf install
 
   run asdf env dummy which dummy
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$ASDF_DIR/installs/dummy/1.0/bin/dummy" ]
 }
 
@@ -42,7 +42,7 @@ teardown() {
   chmod +x "$ASDF_DIR/plugins/dummy/bin/exec-env"
 
   run asdf env dummy
-  [ "$status" -eq 0 ]
+  assert_success
   echo "$output" | grep 'FOO=bar'
 }
 
@@ -56,7 +56,7 @@ teardown() {
   echo "dummy system" >"$PROJECT_DIR/.tool-versions"
 
   run asdf env dummy
-  [ "$status" -eq 0 ]
+  assert_success
 
   run grep 'FOO=bar' <<<"$output"
   [ "$output" = "" ]
@@ -64,7 +64,7 @@ teardown() {
 
   run asdf env dummy which dummy
   [ "$output" = "$ASDF_DIR/shims/dummy" ]
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "asdf env should set PATH correctly" {
@@ -72,7 +72,7 @@ teardown() {
   run asdf install
 
   run asdf env dummy
-  [ "$status" -eq 0 ]
+  assert_success
 
   # Should set path
   path_line=$(echo "$output" | grep '^PATH=')

--- a/test/shim_env_command.bats
+++ b/test/shim_env_command.bats
@@ -59,7 +59,7 @@ teardown() {
   assert_success
 
   run grep 'FOO=bar' <<<"$output"
-  assert_output ""
+  assert_output ''
   [ "$status" -eq 1 ]
 
   run asdf env dummy which dummy

--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -31,7 +31,7 @@ teardown() {
 
   run asdf exec dummy world hello
   [ "$output" = "This is Dummy 1.0! hello world" ]
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "asdf exec should pass all arguments to executable even if shim is not in PATH" {
@@ -45,7 +45,7 @@ teardown() {
 
   run env PATH="$path" asdf exec dummy world hello
   [ "$output" = "This is Dummy 1.0! hello world" ]
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "shim exec should pass all arguments to executable" {
@@ -54,7 +54,7 @@ teardown() {
 
   run "$ASDF_DIR/shims/dummy" world hello
   [ "$output" = "This is Dummy 1.0! hello world" ]
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "shim exec should pass stdin to executable" {
@@ -68,7 +68,7 @@ teardown() {
 
   run echo "$(echo hello | "$ASDF_DIR/shims/upper")"
   [ "$output" = "HELLO" ]
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "shim exec should fail if no version is selected" {
@@ -136,7 +136,7 @@ teardown() {
   echo "dummy 1.0 3.0 2.0.0" >"$PROJECT_DIR/.tool-versions"
 
   run "$ASDF_DIR/shims/dummy" world hello
-  [ "$status" -eq 0 ]
+  assert_success
 
   echo "$output" | grep -q "This is Dummy 3.0! hello world" 2>/dev/null
 }
@@ -148,7 +148,7 @@ teardown() {
   echo "dummy 1.0" >>"$PROJECT_DIR/.tool-versions"
 
   run "$ASDF_DIR/shims/dummy" world hello
-  [ "$status" -eq 0 ]
+  assert_success
 
   echo "$output" | grep -q "This is Dummy 3.0! hello world" 2>/dev/null
 }
@@ -168,12 +168,12 @@ teardown() {
   cd "$PROJECT_DIR"/A
   run "$ASDF_DIR/shims/dummy" world hello
   [ "$output" = "This is Dummy 1.0! hello world" ]
-  [ "$status" -eq 0 ]
+  assert_success
 
   cd "$PROJECT_DIR"/B
   run "$ASDF_DIR/shims/dummy" world hello
   [ "$output" = "This is Mummy 3.0! hello world" ]
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "shim exec should determine correct executable on a project with two plugins set that provide the same tool" {
@@ -190,7 +190,7 @@ teardown() {
 
   run "$ASDF_DIR/shims/dummy" world hello
   [ "$output" = "This is Mummy 3.0! hello world" ]
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "shim exec should fallback to system executable when specified version is system" {
@@ -414,7 +414,7 @@ pre_dummy_dummy = echo PRE $version $1 $2
 EOM
 
   run "$ASDF_DIR/shims/dummy" hello world
-  [ "$status" -eq 0 ]
+  assert_success
   echo "$output" | grep "PRE 1.0 hello world"
   echo "$output" | grep "This is Dummy 1.0! world hello"
 }
@@ -446,5 +446,5 @@ EOM
 
   run asdf exec dummy world hello
   [ "$output" = "This is Dummy 1.0! hello world" ]
-  [ "$status" -eq 0 ]
+  assert_success
 }

--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -30,7 +30,7 @@ teardown() {
   run asdf install
 
   run asdf exec dummy world hello
-  [ "$output" = "This is Dummy 1.0! hello world" ]
+  assert_output "This is Dummy 1.0! hello world"
   assert_success
 }
 
@@ -40,11 +40,11 @@ teardown() {
 
   path=$(echo "$PATH" | sed -e "s|$(asdf_data_dir)/shims||g; s|::|:|g")
   run env PATH="$path" which dummy
-  [ "$output" = "" ]
+  assert_output ""
   [ "$status" -eq 1 ]
 
   run env PATH="$path" asdf exec dummy world hello
-  [ "$output" = "This is Dummy 1.0! hello world" ]
+  assert_output "This is Dummy 1.0! hello world"
   assert_success
 }
 
@@ -53,7 +53,7 @@ teardown() {
   run asdf install
 
   run "$ASDF_DIR/shims/dummy" world hello
-  [ "$output" = "This is Dummy 1.0! hello world" ]
+  assert_output "This is Dummy 1.0! hello world"
   assert_success
 }
 
@@ -67,7 +67,7 @@ teardown() {
   run asdf reshim dummy 1.0
 
   run echo "$(echo hello | "$ASDF_DIR/shims/upper")"
-  [ "$output" = "HELLO" ]
+  assert_output "HELLO"
   assert_success
 }
 
@@ -167,12 +167,12 @@ teardown() {
 
   cd "$PROJECT_DIR"/A
   run "$ASDF_DIR/shims/dummy" world hello
-  [ "$output" = "This is Dummy 1.0! hello world" ]
+  assert_output "This is Dummy 1.0! hello world"
   assert_success
 
   cd "$PROJECT_DIR"/B
   run "$ASDF_DIR/shims/dummy" world hello
-  [ "$output" = "This is Mummy 3.0! hello world" ]
+  assert_output "This is Mummy 3.0! hello world"
   assert_success
 }
 
@@ -189,7 +189,7 @@ teardown() {
   echo "dummy 1.0" >>"$PROJECT_DIR/.tool-versions"
 
   run "$ASDF_DIR/shims/dummy" world hello
-  [ "$output" = "This is Mummy 3.0! hello world" ]
+  assert_output "This is Mummy 3.0! hello world"
   assert_success
 }
 
@@ -203,7 +203,7 @@ teardown() {
   chmod +x "$PROJECT_DIR/foo/dummy"
 
   run env "PATH=$PATH:$PROJECT_DIR/foo" "$ASDF_DIR/shims/dummy" hello
-  [ "$output" = "System" ]
+  assert_output "System"
 }
 
 # NOTE: The name of this test is linked to a condition in `test_helpers.bash. See
@@ -220,7 +220,7 @@ teardown() {
   echo "dummy path:$CUSTOM_DUMMY_PATH" >"$PROJECT_DIR/.tool-versions"
 
   run "$ASDF_DIR/shims/dummy" hello
-  [ "$output" = "System" ]
+  assert_output "System"
 }
 
 @test "shim exec should execute system if set first" {
@@ -234,7 +234,7 @@ teardown() {
   chmod +x "$PROJECT_DIR/foo/dummy"
 
   run env "PATH=$PATH:$PROJECT_DIR/foo" "$ASDF_DIR/shims/dummy" hello
-  [ "$output" = "System" ]
+  assert_output "System"
 }
 
 @test "shim exec should use custom exec-env for tool" {
@@ -247,7 +247,7 @@ teardown() {
 
   echo "dummy 2.0.0" >"$PROJECT_DIR/.tool-versions"
   run "$ASDF_DIR/shims/foo"
-  [ "$output" = "sourced custom" ]
+  assert_output "sourced custom"
 }
 
 @test "shim exec with custom exec-env using ASDF_INSTALL_PATH" {
@@ -260,7 +260,7 @@ teardown() {
 
   echo "dummy 2.0.0" >"$PROJECT_DIR/.tool-versions"
   run "$ASDF_DIR/shims/foo"
-  [ "$output" = "$ASDF_DIR/installs/dummy/2.0.0/foo custom" ]
+  assert_output -- "$ASDF_DIR/installs/dummy/2.0.0/foo custom"
 }
 
 @test "shim exec doest not use custom exec-env for system version" {
@@ -278,7 +278,7 @@ teardown() {
   chmod +x "$PROJECT_DIR/sys/foo"
 
   run env "PATH=$PATH:$PROJECT_DIR/sys" "$ASDF_DIR/shims/foo"
-  [ "$output" = "x System" ]
+  assert_output "x System"
 }
 
 @test "shim exec should prepend the plugin paths on execution" {
@@ -292,7 +292,7 @@ teardown() {
   echo "dummy 2.0.0" >"$PROJECT_DIR/.tool-versions"
 
   run "$ASDF_DIR/shims/foo"
-  [ "$output" = "$ASDF_DIR/installs/dummy/2.0.0/bin/dummy" ]
+  assert_output -- "$ASDF_DIR/installs/dummy/2.0.0/bin/dummy"
 }
 
 @test "shim exec should be able to find other shims in path" {
@@ -317,10 +317,10 @@ teardown() {
   run asdf reshim
 
   run "$ASDF_DIR/shims/foo"
-  [ "$output" = "$ASDF_DIR/installs/dummy/2.0.0/bin/dummy" ]
+  assert_output -- "$ASDF_DIR/installs/dummy/2.0.0/bin/dummy"
 
   run "$ASDF_DIR/shims/bar"
-  [ "$output" = "$ASDF_DIR/shims/gummy" ]
+  assert_output -- "$ASDF_DIR/shims/gummy"
 }
 
 @test "shim exec should remove shim_path from path on system version execution" {
@@ -334,7 +334,7 @@ teardown() {
 
   run env "PATH=$PATH:$PROJECT_DIR/sys" "$ASDF_DIR/shims/dummy"
   echo "$status $output"
-  [ "$output" = "$ASDF_DIR/shims/dummy" ]
+  assert_output -- "$ASDF_DIR/shims/dummy"
 }
 
 @test "shim exec can take version from legacy file if configured" {
@@ -344,13 +344,13 @@ teardown() {
   echo "2.0.0" >"$PROJECT_DIR/.dummy-version"
 
   run "$ASDF_DIR/shims/dummy" world hello
-  [ "$output" = "This is Dummy 2.0.0! hello world" ]
+  assert_output "This is Dummy 2.0.0! hello world"
 }
 
 @test "shim exec can take version from environment variable" {
   run asdf install dummy 2.0.0
   run env ASDF_DUMMY_VERSION=2.0.0 "$ASDF_DIR/shims/dummy" world hello
-  [ "$output" = "This is Dummy 2.0.0! hello world" ]
+  assert_output "This is Dummy 2.0.0! hello world"
 }
 
 @test "shim exec uses plugin list-bin-paths" {
@@ -370,7 +370,7 @@ teardown() {
   run asdf reshim dummy 1.0
 
   run "$ASDF_DIR/shims/foo"
-  [ "$output" = "CUSTOM" ]
+  assert_output "CUSTOM"
 }
 
 @test "shim exec uses plugin custom exec-path hook" {
@@ -389,7 +389,7 @@ teardown() {
   echo "dummy 1.0" >"$PROJECT_DIR/.tool-versions"
 
   run "$ASDF_DIR/shims/dummy"
-  [ "$output" = "CUSTOM" ]
+  assert_output "CUSTOM"
 }
 
 @test "shim exec uses plugin custom exec-path hook that defaults" {
@@ -402,7 +402,7 @@ teardown() {
   echo "dummy 1.0" >"$PROJECT_DIR/.tool-versions"
 
   run "$ASDF_DIR/shims/dummy"
-  [ "$output" = "This is Dummy 1.0!" ]
+  assert_output "This is Dummy 1.0!"
 }
 
 @test "shim exec executes configured pre-hook" {
@@ -433,7 +433,7 @@ pre_dummy_dummy = pre $1 no $plugin_name $2
 EOM
 
   run env PATH="$PATH:$HOME/hook" "$ASDF_DIR/shims/dummy" hello world
-  [ "$output" = "hello no dummy world" ]
+  assert_output "hello no dummy world"
   [ "$status" -eq 1 ]
 }
 
@@ -445,6 +445,6 @@ EOM
   run asdf install
 
   run asdf exec dummy world hello
-  [ "$output" = "This is Dummy 1.0! hello world" ]
+  assert_output "This is Dummy 1.0! hello world"
   assert_success
 }

--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -40,7 +40,7 @@ teardown() {
 
   path=$(echo "$PATH" | sed -e "s|$(asdf_data_dir)/shims||g; s|::|:|g")
   run env PATH="$path" which dummy
-  assert_output ""
+  assert_output ''
   [ "$status" -eq 1 ]
 
   run env PATH="$path" asdf exec dummy world hello

--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -22,7 +22,7 @@ teardown() {
 @test "asdf exec without argument should display help" {
   run asdf exec
   [ "$status" -eq 1 ]
-  echo "$output" | grep "usage: asdf exec <command>"
+  assert_line -p "usage: asdf exec <command>"
 }
 
 @test "asdf exec should pass all arguments to executable" {
@@ -78,7 +78,7 @@ teardown() {
 
   run "$ASDF_DIR/shims/dummy" world hello
   [ "$status" -eq 126 ]
-  echo "$output" | grep -q "No version is set for command dummy" 2>/dev/null
+  assert_line -p "No version is set for command dummy"
 }
 
 @test "shim exec should suggest which plugin to use when no version is selected" {
@@ -90,10 +90,10 @@ teardown() {
   run "$ASDF_DIR/shims/dummy" world hello
   [ "$status" -eq 126 ]
 
-  echo "$output" | grep -q "No version is set for command dummy" 2>/dev/null
-  echo "$output" | grep -q "Consider adding one of the following versions in your config file at $PROJECT_DIR/.tool-versions" 2>/dev/null
-  echo "$output" | grep -q "dummy 1.0" 2>/dev/null
-  echo "$output" | grep -q "dummy 2.0.0" 2>/dev/null
+  assert_line -p "No version is set for command dummy"
+  assert_line -p "Consider adding one of the following versions in your config file at $PROJECT_DIR/.tool-versions"
+  assert_line -p "dummy 1.0"
+  assert_line -p "dummy 2.0.0"
 }
 
 @test "shim exec should suggest different plugins providing same tool when no version is selected" {
@@ -108,10 +108,10 @@ teardown() {
   run "$ASDF_DIR/shims/dummy" world hello
   [ "$status" -eq 126 ]
 
-  echo "$output" | grep -q "No version is set for command dummy" 2>/dev/null
-  echo "$output" | grep -q "Consider adding one of the following versions in your config file at $PROJECT_DIR/.tool-versions" 2>/dev/null
-  echo "$output" | grep -q "dummy 1.0" 2>/dev/null
-  echo "$output" | grep -q "mummy 3.0" 2>/dev/null
+  assert_line -p "No version is set for command dummy"
+  assert_line -p "Consider adding one of the following versions in your config file at $PROJECT_DIR/.tool-versions"
+  assert_line -p "dummy 1.0"
+  assert_line -p "mummy 3.0"
 }
 
 @test "shim exec should suggest to install missing version" {
@@ -121,12 +121,12 @@ teardown() {
 
   run "$ASDF_DIR/shims/dummy" world hello
   [ "$status" -eq 126 ]
-  echo "$output" | grep -q "No preset version installed for command dummy" 2>/dev/null
-  echo "$output" | grep -q "Please install a version by running one of the following:" 2>/dev/null
-  echo "$output" | grep -q "asdf install dummy 2.0.0" 2>/dev/null
-  echo "$output" | grep -q "asdf install dummy 1.3" 2>/dev/null
-  echo "$output" | grep -q "or add one of the following versions in your config file at $PROJECT_DIR/.tool-versions" 2>/dev/null
-  echo "$output" | grep -q "dummy 1.0" 2>/dev/null
+  assert_line -p "No preset version installed for command dummy"
+  assert_line -p "Please install a version by running one of the following:"
+  assert_line -p "asdf install dummy 2.0.0"
+  assert_line -p "asdf install dummy 1.3"
+  assert_line -p "or add one of the following versions in your config file at $PROJECT_DIR/.tool-versions"
+  assert_line -p "dummy 1.0"
 }
 
 @test "shim exec should execute first plugin that is installed and set" {
@@ -138,7 +138,7 @@ teardown() {
   run "$ASDF_DIR/shims/dummy" world hello
   assert_success
 
-  echo "$output" | grep -q "This is Dummy 3.0! hello world" 2>/dev/null
+  assert_line -p "This is Dummy 3.0! hello world"
 }
 
 @test "shim exec should only use the first version found for a plugin" {
@@ -150,7 +150,7 @@ teardown() {
   run "$ASDF_DIR/shims/dummy" world hello
   assert_success
 
-  echo "$output" | grep -q "This is Dummy 3.0! hello world" 2>/dev/null
+  assert_line -p "This is Dummy 3.0! hello world"
 }
 
 @test "shim exec should determine correct executable on two projects using different plugins that provide the same tool" {
@@ -415,8 +415,8 @@ EOM
 
   run "$ASDF_DIR/shims/dummy" hello world
   assert_success
-  echo "$output" | grep "PRE 1.0 hello world"
-  echo "$output" | grep "This is Dummy 1.0! world hello"
+  assert_line -p "PRE 1.0 hello world"
+  assert_line -p "This is Dummy 1.0! world hello"
 }
 
 @test "shim exec doesnt execute command if pre-hook failed" {

--- a/test/shim_versions_command.bats
+++ b/test/shim_versions_command.bats
@@ -25,6 +25,6 @@ teardown() {
   run asdf shim-versions dummy
   assert_success
 
-  echo "$output" | grep "dummy 3.0"
-  echo "$output" | grep "dummy 1.0"
+  assert_line -p "dummy 3.0"
+  assert_line -p "dummy 1.0"
 }

--- a/test/shim_versions_command.bats
+++ b/test/shim_versions_command.bats
@@ -23,7 +23,7 @@ teardown() {
   run asdf reshim dummy
 
   run asdf shim-versions dummy
-  [ "$status" -eq 0 ]
+  assert_success
 
   echo "$output" | grep "dummy 3.0"
   echo "$output" | grep "dummy 1.0"

--- a/test/test_helpers.bash
+++ b/test/test_helpers.bash
@@ -2,8 +2,8 @@
 
 bats_require_minimum_version 1.7.0
 
-# shellcheck source=lib/utils.bash
-. "$(dirname "$BATS_TEST_DIRNAME")"/lib/utils.bash
+. "${BATS_TEST_DIRNAME%/*}/node_modules/@hyperupcall/bats-all/load.bash"
+. "${BATS_TEST_DIRNAME%/*}/lib/utils.bash"
 
 setup_asdf_dir() {
   if [ "$BATS_TEST_NAME" = 'test_shim_exec_should_use_path_executable_when_specified_version_path-3a-3cpath-3e' ]; then

--- a/test/uninstall_command.bats
+++ b/test/uninstall_command.bats
@@ -22,7 +22,7 @@ teardown() {
 
 @test "uninstall_command should remove the plugin with that version from asdf" {
   run asdf install dummy 1.1.0
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$ASDF_DIR/installs/dummy/1.1.0/version")" = "1.1.0" ]
   run asdf uninstall dummy 1.1.0
   [ ! -f "$ASDF_DIR/installs/dummy/1.1.0/version" ]
@@ -30,13 +30,13 @@ teardown() {
 
 @test "uninstall_command should invoke the plugin bin/uninstall if available" {
   run asdf install dummy 1.1.0
-  [ "$status" -eq 0 ]
+  assert_success
   mkdir -p "$ASDF_DIR/plugins/dummy/bin"
   echo "echo custom uninstall" >"$ASDF_DIR/plugins/dummy/bin/uninstall"
   chmod 755 "$ASDF_DIR/plugins/dummy/bin/uninstall"
   run asdf uninstall dummy 1.1.0
   [ "$output" = "custom uninstall" ]
-  [ "$status" -eq 0 ]
+  assert_success
 }
 
 @test "uninstall_command should remove the plugin shims if no other version is installed" {
@@ -67,7 +67,7 @@ teardown() {
 
   run asdf uninstall dummy 1.0.0
   run grep "asdf-plugin: dummy 1.1.0" "$ASDF_DIR/shims/dummy"
-  [ "$status" -eq 0 ]
+  assert_success
   run grep "asdf-plugin: dummy 1.0.0" "$ASDF_DIR/shims/dummy"
   [ "$status" -eq 1 ]
 }

--- a/test/uninstall_command.bats
+++ b/test/uninstall_command.bats
@@ -16,7 +16,7 @@ teardown() {
 
 @test "uninstall_command should fail when no such version is installed" {
   run asdf uninstall dummy 3.14
-  [ "$output" = "No such version" ]
+  assert_output "No such version"
   [ "$status" -eq 1 ]
 }
 
@@ -35,7 +35,7 @@ teardown() {
   echo "echo custom uninstall" >"$ASDF_DIR/plugins/dummy/bin/uninstall"
   chmod 755 "$ASDF_DIR/plugins/dummy/bin/uninstall"
   run asdf uninstall dummy 1.1.0
-  [ "$output" = "custom uninstall" ]
+  assert_output "custom uninstall"
   assert_success
 }
 
@@ -90,7 +90,7 @@ EOM
 
   run asdf install dummy 1.0.0
   run asdf uninstall dummy 1.0.0
-  [ "$output" = "will uninstall dummy 1.0.0" ]
+  assert_output "will uninstall dummy 1.0.0"
 }
 
 @test "uninstall command executes configured post hook" {
@@ -100,5 +100,5 @@ EOM
 
   run asdf install dummy 1.0.0
   run asdf uninstall dummy 1.0.0
-  [ "$output" = "removed dummy 1.0.0" ]
+  assert_output "removed dummy 1.0.0"
 }

--- a/test/update_command.bats
+++ b/test/update_command.bats
@@ -61,14 +61,14 @@ teardown() {
   touch "$ASDF_DIR/asdf_updates_disabled"
   run asdf update
   [ "$status" -eq 42 ]
-  [ "$(echo -e "Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf.")" = "$output" ]
+  [ "$output" = "$(echo -e "Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf.")" ]
 }
 
 @test "asdf update is a noop for non-git repos" {
   rm -rf "$ASDF_DIR/.git/"
   run asdf update
   [ "$status" -eq 42 ]
-  [ "$(echo -e "Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf.")" = "$output" ]
+  [ "$output" = "$(echo -e "Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf.")" ]
 }
 
 @test "asdf update fails with exit code 1" {

--- a/test/update_command.bats
+++ b/test/update_command.bats
@@ -28,7 +28,7 @@ teardown() {
 
 @test "asdf update --head should checkout the master branch" {
   run asdf update --head
-  [ "$status" -eq 0 ]
+  assert_success
   cd "$ASDF_DIR"
   [ "$(git rev-parse --abbrev-ref HEAD)" = "master" ]
 }
@@ -38,7 +38,7 @@ teardown() {
   tag=$(git tag | grep -vi "rc" | tail -1)
   if [ -n "$tag" ]; then
     run asdf update
-    [ "$status" -eq 0 ]
+    assert_success
     cd "$ASDF_DIR"
     git tag | grep "$tag"
   fi
@@ -51,7 +51,7 @@ teardown() {
     export ASDF_CONFIG_DEFAULT_FILE="$BATS_TMPDIR/asdfrc_defaults"
     echo "use_release_candidates = yes" >"$ASDF_CONFIG_DEFAULT_FILE"
     run asdf update
-    [ "$status" -eq 0 ]
+    assert_success
     cd "$ASDF_DIR"
     git tag | grep "$tag"
   fi
@@ -79,23 +79,23 @@ teardown() {
 
 @test "asdf update should not remove plugin versions" {
   run asdf install dummy 1.1.0
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$ASDF_DIR/installs/dummy/1.1.0/version")" = "1.1.0" ]
   run asdf update
-  [ "$status" -eq 0 ]
+  assert_success
   [ -f "$ASDF_DIR/installs/dummy/1.1.0/version" ]
   run asdf update --head
-  [ "$status" -eq 0 ]
+  assert_success
   [ -f "$ASDF_DIR/installs/dummy/1.1.0/version" ]
 }
 
 @test "asdf update should not remove plugins" {
   # dummy plugin is already installed
   run asdf update
-  [ "$status" -eq 0 ]
+  assert_success
   [ -d "$ASDF_DIR/plugins/dummy" ]
   run asdf update --head
-  [ "$status" -eq 0 ]
+  assert_success
   [ -d "$ASDF_DIR/plugins/dummy" ]
 }
 
@@ -103,9 +103,9 @@ teardown() {
   run asdf install dummy 1.1.0
   [ -f "$ASDF_DIR/shims/dummy" ]
   run asdf update
-  [ "$status" -eq 0 ]
+  assert_success
   [ -f "$ASDF_DIR/shims/dummy" ]
   run asdf update --head
-  [ "$status" -eq 0 ]
+  assert_success
   [ -f "$ASDF_DIR/shims/dummy" ]
 }

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -36,7 +36,7 @@ teardown() {
 @test "get_install_path should output path when path version is provided" {
   run get_install_path foo path "/some/path"
   assert_success
-  [ "$output" = "/some/path" ]
+  assert_output "/some/path"
 }
 
 @test "get_download_path should output version path when version is provided" {
@@ -57,13 +57,13 @@ teardown() {
 @test "get_download_path should output nothing when path version is provided" {
   run get_download_path foo path "/some/path"
   assert_success
-  [ "$output" = "" ]
+  assert_output ""
 }
 
 @test "check_if_version_exists should exit with 1 if plugin does not exist" {
   run check_if_version_exists "inexistent" "1.0.0"
   [ "$status" -eq 1 ]
-  [ "$output" = "No such plugin: inexistent" ]
+  assert_output "No such plugin: inexistent"
 }
 
 @test "check_if_version_exists should exit with 1 if version does not exist" {
@@ -74,20 +74,20 @@ teardown() {
 @test "version_not_installed_text is correct" {
   run version_not_installed_text "dummy" "1.0.0"
   assert_success
-  [ "$output" = "version 1.0.0 is not installed for dummy" ]
+  assert_output "version 1.0.0 is not installed for dummy"
 }
 
 @test "check_if_version_exists should be noop if version exists" {
   run check_if_version_exists "dummy" "0.1.0"
   assert_success
-  [ "$output" = "" ]
+  assert_output ""
 }
 
 @test "check_if_version_exists should be noop if version is system" {
   mkdir -p "$ASDF_DIR/plugins/foo"
   run check_if_version_exists "foo" "system"
   assert_success
-  [ "$output" = "" ]
+  assert_output ""
 }
 
 @test "check_if_version_exists should be ok for ref:version install" {
@@ -95,26 +95,26 @@ teardown() {
   mkdir -p "$ASDF_DIR/installs/foo/ref-master"
   run check_if_version_exists "foo" "ref:master"
   assert_success
-  [ "$output" = "" ]
+  assert_output ""
 }
 
 @test "check_if_plugin_exists should exit with 1 when plugin is empty string" {
   run check_if_plugin_exists
   [ "$status" -eq 1 ]
-  [ "$output" = "No plugin given" ]
+  assert_output "No plugin given"
 }
 
 @test "check_if_plugin_exists should be noop if plugin exists" {
   run check_if_plugin_exists "dummy"
   assert_success
-  [ "$output" = "" ]
+  assert_output ""
 }
 
 @test "parse_asdf_version_file should output version" {
   echo "dummy 0.1.0" >"$PROJECT_DIR/.tool-versions"
   run parse_asdf_version_file "$PROJECT_DIR/.tool-versions" dummy
   assert_success
-  [ "$output" = "0.1.0" ]
+  assert_output "0.1.0"
 }
 
 @test "parse_asdf_version_file should output path on project with spaces" {
@@ -124,21 +124,21 @@ teardown() {
   echo "dummy 0.1.0" >"$PROJECT_DIR/.tool-versions"
   run parse_asdf_version_file "$PROJECT_DIR/.tool-versions" dummy
   assert_success
-  [ "$output" = "0.1.0" ]
+  assert_output "0.1.0"
 }
 
 @test "parse_asdf_version_file should output path version with spaces" {
   echo "dummy path:/some/dummy path" >"$PROJECT_DIR/.tool-versions"
   run parse_asdf_version_file "$PROJECT_DIR/.tool-versions" dummy
   assert_success
-  [ "$output" = "path:/some/dummy path" ]
+  assert_output "path:/some/dummy path"
 }
 
 @test "parse_asdf_version_file should output path version with tilda" {
   echo "dummy path:~/some/dummy path" >"$PROJECT_DIR/.tool-versions"
   run parse_asdf_version_file "$PROJECT_DIR/.tool-versions" dummy
   assert_success
-  [ "$output" = "path:$HOME/some/dummy path" ]
+  assert_output "path:$HOME/some/dummy path"
 }
 
 @test "find_versions should return .tool-versions if legacy is disabled" {
@@ -147,7 +147,7 @@ teardown() {
 
   run find_versions "dummy" "$PROJECT_DIR"
   assert_success
-  [ "$output" = "0.1.0|$PROJECT_DIR/.tool-versions" ]
+  assert_output "0.1.0|$PROJECT_DIR/.tool-versions"
 }
 
 @test "find_versions should return the legacy file if supported" {
@@ -157,7 +157,7 @@ teardown() {
 
   run find_versions "dummy" "$PROJECT_DIR"
   assert_success
-  [ "$output" = "0.2.0|$PROJECT_DIR/.dummy-version" ]
+  assert_output "0.2.0|$PROJECT_DIR/.dummy-version"
 }
 
 @test "find_versions skips .tool-version file that don't list the plugin" {
@@ -166,7 +166,7 @@ teardown() {
 
   run find_versions "dummy" "$PROJECT_DIR"
   assert_success
-  [ "$output" = "0.1.0|$HOME/.tool-versions" ]
+  assert_output "0.1.0|$HOME/.tool-versions"
 }
 
 @test "find_versions should return .tool-versions if unsupported" {
@@ -177,7 +177,7 @@ teardown() {
 
   run find_versions "dummy" "$PROJECT_DIR"
   assert_success
-  [ "$output" = "0.1.0|$HOME/.tool-versions" ]
+  assert_output "0.1.0|$HOME/.tool-versions"
 }
 
 @test "find_versions should return the version set by environment variable" {
@@ -185,7 +185,7 @@ teardown() {
 
   run find_versions "dummy" "$PROJECT_DIR"
   assert_success
-  [ "$output" = "0.2.0|ASDF_DUMMY_VERSION environment variable" ]
+  assert_output "0.2.0|ASDF_DUMMY_VERSION environment variable"
 }
 
 @test "asdf_data_dir should return user dir if configured" {
@@ -193,7 +193,7 @@ teardown() {
 
   run asdf_data_dir
   assert_success
-  [ "$output" = "$ASDF_DATA_DIR" ]
+  assert_output -- "$ASDF_DATA_DIR"
 }
 
 @test "asdf_data_dir should return ~/.asdf when ASDF_DATA_DIR is not set" {
@@ -201,7 +201,7 @@ teardown() {
 
   run asdf_data_dir
   assert_success
-  [ "$output" = "$HOME/.asdf" ]
+  assert_output -- "$HOME/.asdf"
 }
 
 @test "check_if_plugin_exists should work with a custom data directory" {
@@ -215,7 +215,7 @@ teardown() {
 
   run check_if_plugin_exists "dummy2"
   assert_success
-  [ "$output" = "" ]
+  assert_output ""
 }
 
 @test "find_versions should return \$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME if set" {
@@ -224,7 +224,7 @@ teardown() {
 
   run find_versions "dummy" "$PROJECT_DIR"
   assert_success
-  [ "$output" = "0.1.0|$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME" ]
+  assert_output "0.1.0|$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME"
 }
 
 @test "find_versions should check \$HOME legacy files before \$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME" {
@@ -243,7 +243,7 @@ teardown() {
   echo "dummy 0.2.0" >.tool-versions
   run get_preset_version_for "dummy"
   assert_success
-  [ "$output" = "0.2.0" ]
+  assert_output "0.2.0"
 }
 
 @test "get_preset_version_for returns the global version from home when project is outside of home" {
@@ -252,7 +252,7 @@ teardown() {
   mkdir -p "$PROJECT_DIR"
   run get_preset_version_for "dummy"
   assert_success
-  [ "$output" = "0.1.0" ]
+  assert_output "0.1.0"
 }
 
 @test "get_preset_version_for returns the tool version from env if ASDF_{TOOL}_VERSION is defined" {
@@ -260,7 +260,7 @@ teardown() {
   echo "dummy 0.2.0" >.tool-versions
   ASDF_DUMMY_VERSION=3.0.0 run get_preset_version_for "dummy"
   assert_success
-  [ "$output" = "3.0.0" ]
+  assert_output "3.0.0"
 }
 
 @test "get_preset_version_for should return branch reference version" {
@@ -268,7 +268,7 @@ teardown() {
   echo "dummy ref:master" >"$PROJECT_DIR/.tool-versions"
   run get_preset_version_for "dummy"
   assert_success
-  [ "$output" = "ref:master" ]
+  assert_output "ref:master"
 }
 
 @test "get_preset_version_for should return path version" {
@@ -276,7 +276,7 @@ teardown() {
   echo "dummy path:/some/place with spaces" >"$PROJECT_DIR/.tool-versions"
   run get_preset_version_for "dummy"
   assert_success
-  [ "$output" = "path:/some/place with spaces" ]
+  assert_output "path:/some/place with spaces"
 }
 
 @test "get_preset_version_for should return path version with tilda" {
@@ -284,14 +284,14 @@ teardown() {
   echo "dummy path:~/some/place with spaces" >"$PROJECT_DIR/.tool-versions"
   run get_preset_version_for "dummy"
   assert_success
-  [ "$output" = "path:$HOME/some/place with spaces" ]
+  assert_output "path:$HOME/some/place with spaces"
 }
 
 @test "get_executable_path for system version should return system path" {
   mkdir -p "$ASDF_DIR/plugins/foo"
   run get_executable_path "foo" "system" "ls"
   assert_success
-  [ "$output" = "$(which ls)" ]
+  assert_output -- "$(which ls)"
 }
 
 @test "get_executable_path for system version should not use asdf shims" {
@@ -315,7 +315,7 @@ teardown() {
 
   run get_executable_path "foo" "1.0.0" "bin/dummy"
   assert_success
-  [ "$output" = "$executable_path" ]
+  assert_output -- "$executable_path"
 }
 
 @test "get_executable_path for ref:version installed version should resolve to ref-version" {
@@ -327,7 +327,7 @@ teardown() {
 
   run get_executable_path "foo" "ref:master" "bin/dummy"
   assert_success
-  [ "$output" = "$executable_path" ]
+  assert_output -- "$executable_path"
 }
 
 @test "find_tool_versions will find a .tool-versions path if it exists in current directory" {
@@ -336,7 +336,7 @@ teardown() {
 
   run find_tool_versions
   assert_success
-  [ "$output" = "$PROJECT_DIR/.tool-versions" ]
+  assert_output -- "$PROJECT_DIR/.tool-versions"
 }
 
 @test "find_tool_versions will find a .tool-versions path if it exists in parent directory" {
@@ -346,7 +346,7 @@ teardown() {
 
   run find_tool_versions
   assert_success
-  [ "$output" = "$PROJECT_DIR/.tool-versions" ]
+  assert_output -- "$PROJECT_DIR/.tool-versions"
 }
 
 @test "get_version_from_env returns the version set in the environment variable" {
@@ -354,14 +354,14 @@ teardown() {
   run get_version_from_env 'dummy'
 
   assert_success
-  [ "$output" = '0.1.0' ]
+  assert_output '0.1.0'
 }
 
 @test "get_version_from_env returns nothing when environment variable is not set" {
   run get_version_from_env 'dummy'
 
   assert_success
-  [ "$output" = '' ]
+  assert_output ''
 }
 
 @test "resolve_symlink converts the symlink path to the real file path" {
@@ -370,7 +370,7 @@ teardown() {
 
   run resolve_symlink bar
   assert_success
-  [ "$output" = "$PWD/foo" ]
+  assert_output -- "$PWD/foo"
   rm -f foo bar
 }
 
@@ -380,7 +380,7 @@ teardown() {
 
   run resolve_symlink baz/bar
   assert_success
-  [ "$output" = "$PWD/baz/../foo" ]
+  assert_output -- "$PWD/baz/../foo"
   rm -f foo bar
 }
 
@@ -390,7 +390,7 @@ teardown() {
 
   run resolve_symlink bar
   assert_success
-  [ "$output" = "$PWD/foo" ]
+  assert_output -- "$PWD/foo"
   rm -f foo bar
 }
 
@@ -401,13 +401,13 @@ ruby 2.0.0
 EOF
   run strip_tool_version_comments test_file
   assert_success
-  [ "$output" = "ruby 2.0.0" ]
+  assert_output "ruby 2.0.0"
 }
 @test "strip_tool_version_comments removes lines that only contain comments even with missing newline" {
   echo -n "# comment line" >test_file
   run strip_tool_version_comments test_file
   assert_success
-  [ "$output" = "" ]
+  assert_output ""
 }
 
 @test "strip_tool_version_comments removes trailing comments on lines containing version information" {
@@ -416,14 +416,14 @@ ruby 2.0.0 # inline comment
 EOF
   run strip_tool_version_comments test_file
   assert_success
-  [ "$output" = "ruby 2.0.0" ]
+  assert_output "ruby 2.0.0"
 }
 
 @test "strip_tool_version_comments removes trailing comments on lines containing version information even with missing newline" {
   echo -n "ruby 2.0.0 # inline comment" >test_file
   run strip_tool_version_comments test_file
   assert_success
-  [ "$output" = "ruby 2.0.0" ]
+  assert_output "ruby 2.0.0"
 }
 
 @test "strip_tool_version_comments removes all comments from the version file" {
@@ -440,7 +440,7 @@ EOF
   )"
   run strip_tool_version_comments test_file
   assert_success
-  [ "$output" = "$expected" ]
+  assert_output -- "$expected"
 }
 
 @test "with_shim_executable doesn't crash when executable names contain dashes" {
@@ -459,5 +459,5 @@ EOF
 
   run with_shim_executable test-dash callback
   assert_success
-  [ "$output" = "$message" ]
+  assert_output -- "$message"
 }

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -235,7 +235,7 @@ teardown() {
 
   run find_versions "dummy" "$PROJECT_DIR"
   assert_success
-  [[ "$output" == *"0.1.0|$HOME/.dummy-version"* ]]
+  assert_output -p "0.1.0|$HOME/.dummy-version"
 }
 
 @test "get_preset_version_for returns the current version" {

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -57,7 +57,7 @@ teardown() {
 @test "get_download_path should output nothing when path version is provided" {
   run get_download_path foo path "/some/path"
   assert_success
-  assert_output ""
+  assert_output ''
 }
 
 @test "check_if_version_exists should exit with 1 if plugin does not exist" {
@@ -80,14 +80,14 @@ teardown() {
 @test "check_if_version_exists should be noop if version exists" {
   run check_if_version_exists "dummy" "0.1.0"
   assert_success
-  assert_output ""
+  assert_output ''
 }
 
 @test "check_if_version_exists should be noop if version is system" {
   mkdir -p "$ASDF_DIR/plugins/foo"
   run check_if_version_exists "foo" "system"
   assert_success
-  assert_output ""
+  assert_output ''
 }
 
 @test "check_if_version_exists should be ok for ref:version install" {
@@ -95,7 +95,7 @@ teardown() {
   mkdir -p "$ASDF_DIR/installs/foo/ref-master"
   run check_if_version_exists "foo" "ref:master"
   assert_success
-  assert_output ""
+  assert_output ''
 }
 
 @test "check_if_plugin_exists should exit with 1 when plugin is empty string" {
@@ -107,7 +107,7 @@ teardown() {
 @test "check_if_plugin_exists should be noop if plugin exists" {
   run check_if_plugin_exists "dummy"
   assert_success
-  assert_output ""
+  assert_output ''
 }
 
 @test "parse_asdf_version_file should output version" {
@@ -215,7 +215,7 @@ teardown() {
 
   run check_if_plugin_exists "dummy2"
   assert_success
-  assert_output ""
+  assert_output ''
 }
 
 @test "find_versions should return \$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME if set" {
@@ -407,7 +407,7 @@ EOF
   echo -n "# comment line" >test_file
   run strip_tool_version_comments test_file
   assert_success
-  assert_output ""
+  assert_output ''
 }
 
 @test "strip_tool_version_comments removes trailing comments on lines containing version information" {

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -21,27 +21,27 @@ teardown() {
 
 @test "get_install_path should output version path when version is provided" {
   run get_install_path foo version "1.0.0"
-  [ "$status" -eq 0 ]
+  assert_success
   install_path=${output#"$HOME/"}
   [ "$install_path" = ".asdf/installs/foo/1.0.0" ]
 }
 
 @test "get_install_path should output custom path when custom install type is provided" {
   run get_install_path foo custom "1.0.0"
-  [ "$status" -eq 0 ]
+  assert_success
   install_path=${output#"$HOME/"}
   [ "$install_path" = ".asdf/installs/foo/custom-1.0.0" ]
 }
 
 @test "get_install_path should output path when path version is provided" {
   run get_install_path foo path "/some/path"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "/some/path" ]
 }
 
 @test "get_download_path should output version path when version is provided" {
   run get_download_path foo version "1.0.0"
-  [ "$status" -eq 0 ]
+  assert_success
   download_path=${output#"$HOME/"}
   echo "$download_path"
   [ "$download_path" = ".asdf/downloads/foo/1.0.0" ]
@@ -49,14 +49,14 @@ teardown() {
 
 @test "get_download_path should output custom path when custom download type is provided" {
   run get_download_path foo custom "1.0.0"
-  [ "$status" -eq 0 ]
+  assert_success
   download_path=${output#"$HOME/"}
   [ "$download_path" = ".asdf/downloads/foo/custom-1.0.0" ]
 }
 
 @test "get_download_path should output nothing when path version is provided" {
   run get_download_path foo path "/some/path"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "" ]
 }
 
@@ -73,20 +73,20 @@ teardown() {
 
 @test "version_not_installed_text is correct" {
   run version_not_installed_text "dummy" "1.0.0"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "version 1.0.0 is not installed for dummy" ]
 }
 
 @test "check_if_version_exists should be noop if version exists" {
   run check_if_version_exists "dummy" "0.1.0"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "" ]
 }
 
 @test "check_if_version_exists should be noop if version is system" {
   mkdir -p "$ASDF_DIR/plugins/foo"
   run check_if_version_exists "foo" "system"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "" ]
 }
 
@@ -94,7 +94,7 @@ teardown() {
   mkdir -p "$ASDF_DIR/plugins/foo"
   mkdir -p "$ASDF_DIR/installs/foo/ref-master"
   run check_if_version_exists "foo" "ref:master"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "" ]
 }
 
@@ -106,14 +106,14 @@ teardown() {
 
 @test "check_if_plugin_exists should be noop if plugin exists" {
   run check_if_plugin_exists "dummy"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "" ]
 }
 
 @test "parse_asdf_version_file should output version" {
   echo "dummy 0.1.0" >"$PROJECT_DIR/.tool-versions"
   run parse_asdf_version_file "$PROJECT_DIR/.tool-versions" dummy
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "0.1.0" ]
 }
 
@@ -123,21 +123,21 @@ teardown() {
 
   echo "dummy 0.1.0" >"$PROJECT_DIR/.tool-versions"
   run parse_asdf_version_file "$PROJECT_DIR/.tool-versions" dummy
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "0.1.0" ]
 }
 
 @test "parse_asdf_version_file should output path version with spaces" {
   echo "dummy path:/some/dummy path" >"$PROJECT_DIR/.tool-versions"
   run parse_asdf_version_file "$PROJECT_DIR/.tool-versions" dummy
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "path:/some/dummy path" ]
 }
 
 @test "parse_asdf_version_file should output path version with tilda" {
   echo "dummy path:~/some/dummy path" >"$PROJECT_DIR/.tool-versions"
   run parse_asdf_version_file "$PROJECT_DIR/.tool-versions" dummy
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "path:$HOME/some/dummy path" ]
 }
 
@@ -146,7 +146,7 @@ teardown() {
   echo "0.2.0" >"$PROJECT_DIR/.dummy-version"
 
   run find_versions "dummy" "$PROJECT_DIR"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "0.1.0|$PROJECT_DIR/.tool-versions" ]
 }
 
@@ -156,7 +156,7 @@ teardown() {
   echo "0.2.0" >"$PROJECT_DIR/.dummy-version"
 
   run find_versions "dummy" "$PROJECT_DIR"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "0.2.0|$PROJECT_DIR/.dummy-version" ]
 }
 
@@ -165,7 +165,7 @@ teardown() {
   echo "another_plugin 0.3.0" >"$PROJECT_DIR/.tool-versions"
 
   run find_versions "dummy" "$PROJECT_DIR"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "0.1.0|$HOME/.tool-versions" ]
 }
 
@@ -176,7 +176,7 @@ teardown() {
   rm "$ASDF_DIR/plugins/dummy/bin/list-legacy-filenames"
 
   run find_versions "dummy" "$PROJECT_DIR"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "0.1.0|$HOME/.tool-versions" ]
 }
 
@@ -184,7 +184,7 @@ teardown() {
   export ASDF_DUMMY_VERSION=0.2.0
 
   run find_versions "dummy" "$PROJECT_DIR"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "0.2.0|ASDF_DUMMY_VERSION environment variable" ]
 }
 
@@ -192,7 +192,7 @@ teardown() {
   ASDF_DATA_DIR="/tmp/wadus"
 
   run asdf_data_dir
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$ASDF_DATA_DIR" ]
 }
 
@@ -200,7 +200,7 @@ teardown() {
   unset ASDF_DATA_DIR
 
   run asdf_data_dir
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$HOME/.asdf" ]
 }
 
@@ -214,7 +214,7 @@ teardown() {
   install_mock_plugin_version "dummy2" "0.1.0" "$ASDF_DATA_DIR"
 
   run check_if_plugin_exists "dummy2"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "" ]
 }
 
@@ -223,7 +223,7 @@ teardown() {
   echo "dummy 0.1.0" >"$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME"
 
   run find_versions "dummy" "$PROJECT_DIR"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "0.1.0|$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME" ]
 }
 
@@ -234,7 +234,7 @@ teardown() {
   echo "legacy_version_file = yes" >"$HOME/.asdfrc"
 
   run find_versions "dummy" "$PROJECT_DIR"
-  [ "$status" -eq 0 ]
+  assert_success
   [[ "$output" == *"0.1.0|$HOME/.dummy-version"* ]]
 }
 
@@ -242,7 +242,7 @@ teardown() {
   cd "$PROJECT_DIR"
   echo "dummy 0.2.0" >.tool-versions
   run get_preset_version_for "dummy"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "0.2.0" ]
 }
 
@@ -251,7 +251,7 @@ teardown() {
   PROJECT_DIR=$BASE_DIR/project
   mkdir -p "$PROJECT_DIR"
   run get_preset_version_for "dummy"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "0.1.0" ]
 }
 
@@ -259,7 +259,7 @@ teardown() {
   cd "$PROJECT_DIR"
   echo "dummy 0.2.0" >.tool-versions
   ASDF_DUMMY_VERSION=3.0.0 run get_preset_version_for "dummy"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "3.0.0" ]
 }
 
@@ -267,7 +267,7 @@ teardown() {
   cd "$PROJECT_DIR"
   echo "dummy ref:master" >"$PROJECT_DIR/.tool-versions"
   run get_preset_version_for "dummy"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "ref:master" ]
 }
 
@@ -275,7 +275,7 @@ teardown() {
   cd "$PROJECT_DIR"
   echo "dummy path:/some/place with spaces" >"$PROJECT_DIR/.tool-versions"
   run get_preset_version_for "dummy"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "path:/some/place with spaces" ]
 }
 
@@ -283,14 +283,14 @@ teardown() {
   cd "$PROJECT_DIR"
   echo "dummy path:~/some/place with spaces" >"$PROJECT_DIR/.tool-versions"
   run get_preset_version_for "dummy"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "path:$HOME/some/place with spaces" ]
 }
 
 @test "get_executable_path for system version should return system path" {
   mkdir -p "$ASDF_DIR/plugins/foo"
   run get_executable_path "foo" "system" "ls"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$(which ls)" ]
 }
 
@@ -300,7 +300,7 @@ teardown() {
   chmod +x "$ASDF_DIR/shims/dummy_executable"
 
   run which dummy_executable
-  [ "$status" -eq 0 ]
+  assert_success
 
   run get_executable_path "foo" "system" "dummy_executable"
   [ "$status" -eq 1 ]
@@ -314,7 +314,7 @@ teardown() {
   chmod +x "$executable_path"
 
   run get_executable_path "foo" "1.0.0" "bin/dummy"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$executable_path" ]
 }
 
@@ -326,7 +326,7 @@ teardown() {
   chmod +x "$executable_path"
 
   run get_executable_path "foo" "ref:master" "bin/dummy"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$executable_path" ]
 }
 
@@ -335,7 +335,7 @@ teardown() {
   cd "$PROJECT_DIR"
 
   run find_tool_versions
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$PROJECT_DIR/.tool-versions" ]
 }
 
@@ -345,7 +345,7 @@ teardown() {
   cd "$PROJECT_DIR"/child
 
   run find_tool_versions
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$PROJECT_DIR/.tool-versions" ]
 }
 
@@ -353,14 +353,14 @@ teardown() {
   export ASDF_DUMMY_VERSION=0.1.0
   run get_version_from_env 'dummy'
 
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = '0.1.0' ]
 }
 
 @test "get_version_from_env returns nothing when environment variable is not set" {
   run get_version_from_env 'dummy'
 
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = '' ]
 }
 
@@ -369,7 +369,7 @@ teardown() {
   ln -s "$PWD/foo" bar
 
   run resolve_symlink bar
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$PWD/foo" ]
   rm -f foo bar
 }
@@ -379,7 +379,7 @@ teardown() {
   ln -s ../foo baz/bar
 
   run resolve_symlink baz/bar
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$PWD/baz/../foo" ]
   rm -f foo bar
 }
@@ -389,7 +389,7 @@ teardown() {
   ln -s foo bar
 
   run resolve_symlink bar
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$PWD/foo" ]
   rm -f foo bar
 }
@@ -400,13 +400,13 @@ teardown() {
 ruby 2.0.0
 EOF
   run strip_tool_version_comments test_file
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "ruby 2.0.0" ]
 }
 @test "strip_tool_version_comments removes lines that only contain comments even with missing newline" {
   echo -n "# comment line" >test_file
   run strip_tool_version_comments test_file
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "" ]
 }
 
@@ -415,14 +415,14 @@ EOF
 ruby 2.0.0 # inline comment
 EOF
   run strip_tool_version_comments test_file
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "ruby 2.0.0" ]
 }
 
 @test "strip_tool_version_comments removes trailing comments on lines containing version information even with missing newline" {
   echo -n "ruby 2.0.0 # inline comment" >test_file
   run strip_tool_version_comments test_file
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "ruby 2.0.0" ]
 }
 
@@ -439,7 +439,7 @@ erlang 18.2.1
 EOF
   )"
   run strip_tool_version_comments test_file
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$expected" ]
 }
 
@@ -458,6 +458,6 @@ EOF
   }
 
   run with_shim_executable test-dash callback
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$message" ]
 }

--- a/test/version_commands.bats
+++ b/test/version_commands.bats
@@ -53,19 +53,19 @@ teardown() {
 
 @test "local should create a local .tool-versions file if it doesn't exist" {
   run asdf local "dummy" "1.1.0"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.1.0" ]
 }
 
 @test "[local - dummy_plugin] with latest should use the latest installed version" {
   run asdf local "dummy" "latest"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 2.0.0" ]
 }
 
 @test "[local - dummy_plugin] with latest:version should use the latest valid installed version" {
   run asdf local "dummy" "latest:1.0"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.0.0" ]
 }
 
@@ -77,13 +77,13 @@ teardown() {
 
 @test "[local - dummy_legacy_plugin] with latest should use the latest installed version" {
   run asdf local "legacy-dummy" "latest"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$PROJECT_DIR/.tool-versions")" = "legacy-dummy 5.1.0" ]
 }
 
 @test "[local - dummy_legacy_plugin] with latest:version should use the latest valid installed version" {
   run asdf local "legacy-dummy" "latest:1.0"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$PROJECT_DIR/.tool-versions")" = "legacy-dummy 1.0.0" ]
 }
 
@@ -95,7 +95,7 @@ teardown() {
 
 @test "local should allow multiple versions" {
   run asdf local "dummy" "1.1.0" "1.0.0"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.1.0 1.0.0" ]
 }
 
@@ -107,7 +107,7 @@ teardown() {
   run asdf local "dummy" "1.1.0"
 
   tool_version_contents=$(cat "$WHITESPACE_DIR/.tool-versions")
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$tool_version_contents" = "dummy 1.1.0" ]
 }
 
@@ -115,7 +115,7 @@ teardown() {
   echo 'dummy 1.0.0' >>"$PROJECT_DIR/.tool-versions"
 
   run asdf local "dummy" "1.1.0"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(ls "$PROJECT_DIR/.tool-versions"* | wc -l)" -eq 1 ]
 }
 
@@ -123,7 +123,7 @@ teardown() {
   echo 'dummy 1.0.0' >>"$PROJECT_DIR/.tool-versions"
 
   run asdf local "dummy" "1.1.0"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.1.0" ]
 }
 
@@ -131,7 +131,7 @@ teardown() {
   echo -n 'foobar 1.0.0' >>"$PROJECT_DIR/.tool-versions"
 
   run asdf local "dummy" "1.1.0"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$PROJECT_DIR/.tool-versions")" = $'foobar 1.0.0\ndummy 1.1.0' ]
 }
 
@@ -139,7 +139,7 @@ teardown() {
   echo 'foobar 1.0.0' >>"$PROJECT_DIR/.tool-versions"
 
   run asdf local "dummy" "1.1.0"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$PROJECT_DIR/.tool-versions")" = $'foobar 1.0.0\ndummy 1.1.0' ]
 }
 
@@ -152,7 +152,7 @@ teardown() {
 @test "local should set a path:dir if dir exists " {
   mkdir -p "$PROJECT_DIR/local"
   run asdf local "dummy" "path:$PROJECT_DIR/local"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy path:$PROJECT_DIR/local" ]
 }
 
@@ -178,7 +178,7 @@ teardown() {
   cd "$CHILD_DIR"
   touch "$PROJECT_DIR/.tool-versions"
   run asdf local -p "dummy" "1.1.0" "1.0.0"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.1.0 1.0.0" ]
 }
 
@@ -186,7 +186,7 @@ teardown() {
   cd "$CHILD_DIR"
   echo 'dummy 1.0.0' >>"$PROJECT_DIR/.tool-versions"
   run asdf local -p "dummy" "1.1.0"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.1.0" ]
 }
 
@@ -194,25 +194,25 @@ teardown() {
   cd "$CHILD_DIR"
   touch "$PROJECT_DIR/.tool-versions"
   run asdf local -p "dummy" "1.1.0"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.1.0" ]
 }
 
 @test "global should create a global .tool-versions file if it doesn't exist" {
   run asdf global "dummy" "1.1.0"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$HOME/.tool-versions")" = "dummy 1.1.0" ]
 }
 
 @test "[global - dummy_plugin] with latest should use the latest installed version" {
   run asdf global "dummy" "latest"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$HOME/.tool-versions")" = "dummy 2.0.0" ]
 }
 
 @test "[global - dummy_plugin] with latest:version should use the latest valid installed version" {
   run asdf global "dummy" "latest:1.0"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$HOME/.tool-versions")" = "dummy 1.0.0" ]
 }
 
@@ -224,13 +224,13 @@ teardown() {
 
 @test "[global - dummy_legacy_plugin] with latest should use the latest installed version" {
   run asdf global "legacy-dummy" "latest"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$HOME/.tool-versions")" = "legacy-dummy 5.1.0" ]
 }
 
 @test "[global - dummy_legacy_plugin] with latest:version should use the latest valid installed version" {
   run asdf global "legacy-dummy" "latest:1.0"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$HOME/.tool-versions")" = "legacy-dummy 1.0.0" ]
 }
 
@@ -242,14 +242,14 @@ teardown() {
 
 @test "global should accept multiple versions" {
   run asdf global "dummy" "1.1.0" "1.0.0"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$HOME/.tool-versions")" = "dummy 1.1.0 1.0.0" ]
 }
 
 @test "global should overwrite the existing version if it's set" {
   echo 'dummy 1.0.0' >>"$HOME/.tool-versions"
   run asdf global "dummy" "1.1.0"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$HOME/.tool-versions")" = "dummy 1.1.0" ]
 }
 
@@ -257,7 +257,7 @@ teardown() {
   echo -n 'foobar 1.0.0' >>"$HOME/.tool-versions"
 
   run asdf global "dummy" "1.1.0"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$HOME/.tool-versions")" = $'foobar 1.0.0\ndummy 1.1.0' ]
 }
 
@@ -265,7 +265,7 @@ teardown() {
   echo 'foobar 1.0.0' >>"$HOME/.tool-versions"
 
   run asdf global "dummy" "1.1.0"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$HOME/.tool-versions")" = $'foobar 1.0.0\ndummy 1.1.0' ]
 }
 
@@ -278,14 +278,14 @@ teardown() {
 @test "global should set a path:dir if dir exists " {
   mkdir -p "$PROJECT_DIR/local"
   run asdf global "dummy" "path:$PROJECT_DIR/local"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$HOME/.tool-versions")" = "dummy path:$PROJECT_DIR/local" ]
 }
 
 @test "local should write to ASDF_DEFAULT_TOOL_VERSIONS_FILENAME" {
   export ASDF_DEFAULT_TOOL_VERSIONS_FILENAME="local-tool-versions"
   run asdf local "dummy" "1.1.0"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME")" = "dummy 1.1.0" ]
   [ -z "$(cat .tool-versions)" ]
   unset ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
@@ -295,7 +295,7 @@ teardown() {
   export ASDF_DEFAULT_TOOL_VERSIONS_FILENAME="local-tool-versions"
   echo 'dummy 1.0.0' >>"$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME"
   run asdf local "dummy" "1.1.0"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME")" = "dummy 1.1.0" ]
   [ -z "$(cat .tool-versions)" ]
   unset ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
@@ -304,7 +304,7 @@ teardown() {
 @test "global should write to ASDF_DEFAULT_TOOL_VERSIONS_FILENAME" {
   export ASDF_DEFAULT_TOOL_VERSIONS_FILENAME="global-tool-versions"
   run asdf global "dummy" "1.1.0"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$HOME/$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME")" = "dummy 1.1.0" ]
   [ -z "$(cat "$HOME/.tool-versions")" ]
   unset ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
@@ -314,7 +314,7 @@ teardown() {
   export ASDF_DEFAULT_TOOL_VERSIONS_FILENAME="global-tool-versions"
   echo 'dummy 1.0.0' >>"$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME"
   run asdf global "dummy" "1.1.0"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$HOME/$ASDF_DEFAULT_TOOL_VERSIONS_FILENAME")" = "dummy 1.1.0" ]
   [ -z "$(cat "$HOME/.tool-versions")" ]
   unset ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
@@ -325,7 +325,7 @@ teardown() {
   touch other-dir/.tool-versions
   ln -s other-dir/.tool-versions .tool-versions
   run asdf local "dummy" "1.1.0"
-  [ "$status" -eq 0 ]
+  assert_success
   [ -L .tool-versions ]
   [ "$(cat other-dir/.tool-versions)" = "dummy 1.1.0" ]
 }
@@ -336,7 +336,7 @@ teardown() {
   ln -s other-dir/.tool-versions .tool-versions
   run asdf local "dummy" "1.1.0"
   run asdf local "dummy" "1.1.0"
-  [ "$status" -eq 0 ]
+  assert_success
   [ -L .tool-versions ]
   [ "$(cat other-dir/.tool-versions)" = "dummy 1.1.0" ]
 }
@@ -347,7 +347,7 @@ teardown() {
   ln -s other-dir/.tool-versions "$HOME/.tool-versions"
 
   run asdf global "dummy" "1.1.0"
-  [ "$status" -eq 0 ]
+  assert_success
   [ -L "$HOME/.tool-versions" ]
   [ "$(cat "$HOME/other-dir/.tool-versions")" = "dummy 1.1.0" ]
 }
@@ -359,7 +359,7 @@ teardown() {
 
   run asdf global "dummy" "1.1.0"
   run asdf global "dummy" "1.1.0"
-  [ "$status" -eq 0 ]
+  assert_success
   [ -L "$HOME/.tool-versions" ]
   [ "$(cat "$HOME/other-dir/.tool-versions")" = "dummy 1.1.0" ]
 }
@@ -417,37 +417,37 @@ false"
 
 @test "export-shell-version should export version if it exists" {
   run asdf export-shell-version sh "dummy" "1.1.0"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "export ASDF_DUMMY_VERSION=\"1.1.0\"" ]
 }
 
 @test "export-shell-version should use set when shell is fish" {
   run asdf export-shell-version fish "dummy" "1.1.0"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "set -gx ASDF_DUMMY_VERSION \"1.1.0\"" ]
 }
 
 @test "export-shell-version should use set-env when shell is elvish" {
   run asdf export-shell-version elvish "dummy" "1.1.0"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = $'set-env\nASDF_DUMMY_VERSION\n1.1.0' ]
 }
 
 @test "export-shell-version should unset when --unset flag is passed" {
   run asdf export-shell-version sh "dummy" "--unset"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "unset ASDF_DUMMY_VERSION" ]
 }
 
 @test "export-shell-version should use set -e when --unset flag is passed and shell is fish" {
   run asdf export-shell-version fish "dummy" "--unset"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "set -e ASDF_DUMMY_VERSION" ]
 }
 
 @test "export-shell-version should use unset-env when --unset flag is passed and shell is elvish" {
   run asdf export-shell-version elvish "dummy" "--unset"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = $'unset-env\nASDF_DUMMY_VERSION' ]
 }
 
@@ -468,27 +468,27 @@ false"
 @test "[global - dummy_plugin] should support latest" {
   echo 'dummy 1.0.0' >>"$HOME/.tool-versions"
   run asdf global "dummy" "1.0.0" "latest"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$HOME/.tool-versions")" = "dummy 1.0.0 2.0.0" ]
 }
 
 @test "[global - dummy_legacy_plugin] should support latest" {
   echo 'legacy-dummy 1.0.0' >>"$HOME/.tool-versions"
   run asdf global "legacy-dummy" "1.0.0" "latest"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$HOME/.tool-versions")" = "legacy-dummy 1.0.0 5.1.0" ]
 }
 
 @test "[local - dummy_plugin] should support latest" {
   echo 'dummy 1.0.0' >>"$PROJECT_DIR/.tool-versions"
   run asdf local "dummy" "1.0.0" "latest"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$PROJECT_DIR/.tool-versions")" = "dummy 1.0.0 2.0.0" ]
 }
 
 @test "[local - dummy_legacy_plugin] should support latest" {
   echo 'legacy-dummy 1.0.0' >>"$PROJECT_DIR/.tool-versions"
   run asdf local "legacy-dummy" "1.0.0" "latest"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$(cat "$PROJECT_DIR/.tool-versions")" = "legacy-dummy 1.0.0 5.1.0" ]
 }

--- a/test/version_commands.bats
+++ b/test/version_commands.bats
@@ -36,19 +36,19 @@ teardown() {
 @test "local should emit an error when called with incorrect arity" {
   run asdf local "dummy"
   [ "$status" -eq 1 ]
-  [ "$output" = "Usage: asdf local <name> <version>" ]
+  assert_output "Usage: asdf local <name> <version>"
 }
 
 @test "local should emit an error when plugin does not exist" {
   run asdf local "inexistent" "1.0.0"
   [ "$status" -eq 1 ]
-  [ "$output" = "No such plugin: inexistent" ]
+  assert_output "No such plugin: inexistent"
 }
 
 @test "local should emit an error when plugin version does not exist" {
   run asdf local "dummy" "0.0.1"
   [ "$status" -eq 1 ]
-  [ "$output" = "version 0.0.1 is not installed for dummy" ]
+  assert_output "version 0.0.1 is not installed for dummy"
 }
 
 @test "local should create a local .tool-versions file if it doesn't exist" {
@@ -72,7 +72,7 @@ teardown() {
 @test "[local - dummy_plugin] with latest:version should return an error for invalid versions" {
   run asdf local "dummy" "latest:99"
   [ "$status" -eq 1 ]
-  [ "$output" = "No compatible versions available (dummy 99)" ]
+  assert_output "No compatible versions available (dummy 99)"
 }
 
 @test "[local - dummy_legacy_plugin] with latest should use the latest installed version" {
@@ -90,7 +90,7 @@ teardown() {
 @test "[local - dummy_legacy_plugin] with latest:version should return an error for invalid versions" {
   run asdf local "legacy-dummy" "latest:99"
   [ "$status" -eq 1 ]
-  [ "$output" = "No compatible versions available (legacy-dummy 99)" ]
+  assert_output "No compatible versions available (legacy-dummy 99)"
 }
 
 @test "local should allow multiple versions" {
@@ -145,7 +145,7 @@ teardown() {
 
 @test "local should fail to set a path:dir if dir does not exists " {
   run asdf local "dummy" "path:$PROJECT_DIR/local"
-  [ "$output" = "version path:$PROJECT_DIR/local is not installed for dummy" ]
+  assert_output "version path:$PROJECT_DIR/local is not installed for dummy"
   [ "$status" -eq 1 ]
 }
 
@@ -159,19 +159,19 @@ teardown() {
 @test "local -p/--parent should set should emit an error when called with incorrect arity" {
   run asdf local -p "dummy"
   [ "$status" -eq 1 ]
-  [ "$output" = "Usage: asdf local <name> <version>" ]
+  assert_output "Usage: asdf local <name> <version>"
 }
 
 @test "local -p/--parent should emit an error when plugin does not exist" {
   run asdf local -p "inexistent" "1.0.0"
   [ "$status" -eq 1 ]
-  [ "$output" = "No such plugin: inexistent" ]
+  assert_output "No such plugin: inexistent"
 }
 
 @test "local -p/--parent should emit an error when plugin version does not exist" {
   run asdf local -p "dummy" "0.0.1"
   [ "$status" -eq 1 ]
-  [ "$output" = "version 0.0.1 is not installed for dummy" ]
+  assert_output "version 0.0.1 is not installed for dummy"
 }
 
 @test "local -p/--parent should allow multiple versions" {
@@ -219,7 +219,7 @@ teardown() {
 @test "[global - dummy_plugin] with latest:version should return an error for invalid versions" {
   run asdf global "dummy" "latest:99"
   [ "$status" -eq 1 ]
-  [ "$output" = "No compatible versions available (dummy 99)" ]
+  assert_output "No compatible versions available (dummy 99)"
 }
 
 @test "[global - dummy_legacy_plugin] with latest should use the latest installed version" {
@@ -237,7 +237,7 @@ teardown() {
 @test "[global - dummy_legacy_plugin] with latest:version should return an error for invalid versions" {
   run asdf global "legacy-dummy" "latest:99"
   [ "$status" -eq 1 ]
-  [ "$output" = "No compatible versions available (legacy-dummy 99)" ]
+  assert_output "No compatible versions available (legacy-dummy 99)"
 }
 
 @test "global should accept multiple versions" {
@@ -271,7 +271,7 @@ teardown() {
 
 @test "global should fail to set a path:dir if dir does not exists " {
   run asdf global "dummy" "path:$PROJECT_DIR/local"
-  [ "$output" = "version path:$PROJECT_DIR/local is not installed for dummy" ]
+  assert_output "version path:$PROJECT_DIR/local is not installed for dummy"
   [ "$status" -eq 1 ]
 }
 
@@ -387,13 +387,13 @@ version 1.0.0 is not installed for nonexistent"
 
   run asdf shell "nonexistent" "1.0.0"
   [ "$status" -eq 1 ]
-  [ "$output" = "$expected" ]
+  assert_output -- "$expected"
 }
 
 @test "shell should emit an error when wrapper function is not loaded" {
   run asdf shell "dummy" "1.1.0"
   [ "$status" -eq 1 ]
-  [ "$output" = "Shell integration is not enabled. Please ensure you source asdf in your shell setup." ]
+  assert_output "Shell integration is not enabled. Please ensure you source asdf in your shell setup."
 }
 
 @test "export-shell-version should emit an error when plugin does not exist" {
@@ -403,7 +403,7 @@ false"
 
   run asdf export-shell-version sh "nonexistent" "1.0.0"
   [ "$status" -eq 1 ]
-  [ "$output" = "$expected" ]
+  assert_output -- "$expected"
 }
 
 @test "export-shell-version should emit an error when version does not exist" {
@@ -412,43 +412,43 @@ false"
 
   run asdf export-shell-version sh "dummy" "nonexistent"
   [ "$status" -eq 1 ]
-  [ "$output" = "$expected" ]
+  assert_output -- "$expected"
 }
 
 @test "export-shell-version should export version if it exists" {
   run asdf export-shell-version sh "dummy" "1.1.0"
   assert_success
-  [ "$output" = "export ASDF_DUMMY_VERSION=\"1.1.0\"" ]
+  assert_output "export ASDF_DUMMY_VERSION=\"1.1.0\""
 }
 
 @test "export-shell-version should use set when shell is fish" {
   run asdf export-shell-version fish "dummy" "1.1.0"
   assert_success
-  [ "$output" = "set -gx ASDF_DUMMY_VERSION \"1.1.0\"" ]
+  assert_output "set -gx ASDF_DUMMY_VERSION \"1.1.0\""
 }
 
 @test "export-shell-version should use set-env when shell is elvish" {
   run asdf export-shell-version elvish "dummy" "1.1.0"
   assert_success
-  [ "$output" = $'set-env\nASDF_DUMMY_VERSION\n1.1.0' ]
+  assert_output $'set-env\nASDF_DUMMY_VERSION\n1.1.0'
 }
 
 @test "export-shell-version should unset when --unset flag is passed" {
   run asdf export-shell-version sh "dummy" "--unset"
   assert_success
-  [ "$output" = "unset ASDF_DUMMY_VERSION" ]
+  assert_output "unset ASDF_DUMMY_VERSION"
 }
 
 @test "export-shell-version should use set -e when --unset flag is passed and shell is fish" {
   run asdf export-shell-version fish "dummy" "--unset"
   assert_success
-  [ "$output" = "set -e ASDF_DUMMY_VERSION" ]
+  assert_output "set -e ASDF_DUMMY_VERSION"
 }
 
 @test "export-shell-version should use unset-env when --unset flag is passed and shell is elvish" {
   run asdf export-shell-version elvish "dummy" "--unset"
   assert_success
-  [ "$output" = $'unset-env\nASDF_DUMMY_VERSION' ]
+  assert_output $'unset-env\nASDF_DUMMY_VERSION'
 }
 
 @test "[shell - dummy_plugin] wrapper function should support latest" {

--- a/test/where_command.bats
+++ b/test/where_command.bats
@@ -17,13 +17,13 @@ teardown() {
 @test "where shows install location of selected version" {
   run asdf where 'dummy' '1.0'
   assert_success
-  [ "$output" = "$ASDF_DIR/installs/dummy/1.0" ]
+  assert_output -- "$ASDF_DIR/installs/dummy/1.0"
 }
 
 @test "where understands versions installed by ref" {
   run asdf where 'dummy' 'ref:master'
   assert_success
-  [ "$output" = "$ASDF_DIR/installs/dummy/ref-master" ]
+  assert_output -- "$ASDF_DIR/installs/dummy/ref-master"
 }
 
 @test "where shows install location of current version if no version specified" {
@@ -32,32 +32,32 @@ teardown() {
   run asdf where 'dummy'
 
   assert_success
-  [ "$output" = "$ASDF_DIR/installs/dummy/2.1" ]
+  assert_output -- "$ASDF_DIR/installs/dummy/2.1"
 }
 
 @test "where shows install location of first current version if not version specified and multiple current versions" {
   echo 'dummy 2.1 1.0' >>"$HOME/.tool-versions"
   run asdf where 'dummy'
   assert_success
-  [ "$output" = "$ASDF_DIR/installs/dummy/2.1" ]
+  assert_output -- "$ASDF_DIR/installs/dummy/2.1"
 }
 
 @test "where should error when the plugin doesn't exist" {
   run asdf where "foobar"
   [ "$status" -eq 1 ]
-  [ "$output" = "No such plugin: foobar" ]
+  assert_output "No such plugin: foobar"
 }
 
 @test "where should error when version is not installed" {
   run asdf where 'dummy' '1.6'
   [ "$status" -eq 1 ]
-  [ "$output" = "Version not installed" ]
+  assert_output "Version not installed"
 }
 
 @test "where should error when system version is set" {
   run asdf where 'dummy' 'system'
   [ "$status" -eq 1 ]
-  [ "$output" = "System version is selected" ]
+  assert_output "System version is selected"
 }
 
 @test "where should error when no current version selected and version not specified" {
@@ -67,5 +67,5 @@ teardown() {
   expected="No version is set for dummy; please run \`asdf <global | shell | local> dummy <version>\`"
 
   [ "$status" -eq 1 ]
-  [ "$output" = "$expected" ]
+  assert_output -- "$expected"
 }

--- a/test/where_command.bats
+++ b/test/where_command.bats
@@ -16,13 +16,13 @@ teardown() {
 
 @test "where shows install location of selected version" {
   run asdf where 'dummy' '1.0'
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$ASDF_DIR/installs/dummy/1.0" ]
 }
 
 @test "where understands versions installed by ref" {
   run asdf where 'dummy' 'ref:master'
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$ASDF_DIR/installs/dummy/ref-master" ]
 }
 
@@ -31,14 +31,14 @@ teardown() {
 
   run asdf where 'dummy'
 
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$ASDF_DIR/installs/dummy/2.1" ]
 }
 
 @test "where shows install location of first current version if not version specified and multiple current versions" {
   echo 'dummy 2.1 1.0' >>"$HOME/.tool-versions"
   run asdf where 'dummy'
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$ASDF_DIR/installs/dummy/2.1" ]
 }
 

--- a/test/which_command.bats
+++ b/test/which_command.bats
@@ -22,7 +22,7 @@ teardown() {
 
   run asdf which "dummy"
   assert_success
-  [ "$output" = "$ASDF_DIR/installs/dummy/1.0/bin/dummy" ]
+  assert_output -- "$ASDF_DIR/installs/dummy/1.0/bin/dummy"
 }
 
 @test "which should fail for unknown binary" {
@@ -30,7 +30,7 @@ teardown() {
 
   run asdf which "sunny"
   [ "$status" -eq 1 ]
-  [ "$output" = "unknown command: sunny. Perhaps you have to reshim?" ]
+  assert_output "unknown command: sunny. Perhaps you have to reshim?"
 }
 
 @test "which should show dummy 1.0 other binary" {
@@ -42,7 +42,7 @@ teardown() {
 
   run asdf which "other_bin"
   assert_success
-  [ "$output" = "$ASDF_DIR/installs/dummy/1.0/bin/subdir/other_bin" ]
+  assert_output -- "$ASDF_DIR/installs/dummy/1.0/bin/subdir/other_bin"
 }
 
 @test "which should show path of system version" {
@@ -55,7 +55,7 @@ teardown() {
 
   run env "PATH=$PATH:$PROJECT_DIR/sys" asdf which "dummy"
   assert_success
-  [ "$output" = "$PROJECT_DIR/sys/dummy" ]
+  assert_output -- "$PROJECT_DIR/sys/dummy"
 }
 
 @test "which report when missing executable on system version" {
@@ -64,7 +64,7 @@ teardown() {
 
   run asdf which "dummy"
   [ "$status" -eq 1 ]
-  [ "$output" = "No dummy executable found for dummy system" ]
+  assert_output "No dummy executable found for dummy system"
 }
 
 @test "which should inform when no binary is found" {
@@ -72,7 +72,7 @@ teardown() {
 
   run asdf which "bazbat"
   [ "$status" -eq 1 ]
-  [ "$output" = "unknown command: bazbat. Perhaps you have to reshim?" ]
+  assert_output "unknown command: bazbat. Perhaps you have to reshim?"
 }
 
 @test "which should use path returned by exec-path when present" {
@@ -81,7 +81,7 @@ teardown() {
 
   run asdf which "dummy"
   assert_success
-  [ "$output" = "$ASDF_DIR/installs/dummy/1.0/bin/custom/dummy" ]
+  assert_output -- "$ASDF_DIR/installs/dummy/1.0/bin/custom/dummy"
 }
 
 @test "which should return the path set by the legacy file" {
@@ -94,7 +94,7 @@ teardown() {
 
   run asdf which "dummy"
   assert_success
-  [ "$output" = "$ASDF_DIR/installs/dummy/1.1/bin/dummy" ]
+  assert_output -- "$ASDF_DIR/installs/dummy/1.1/bin/dummy"
 }
 
 @test "which should not return shim path" {
@@ -104,5 +104,5 @@ teardown() {
 
   run env PATH="$PATH:$ASDF_DIR/shims" asdf which dummy
   [ "$status" -eq 1 ]
-  [ "$output" = "No dummy executable found for dummy 1.0" ]
+  assert_output "No dummy executable found for dummy 1.0"
 }

--- a/test/which_command.bats
+++ b/test/which_command.bats
@@ -21,7 +21,7 @@ teardown() {
   cd "$PROJECT_DIR"
 
   run asdf which "dummy"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$ASDF_DIR/installs/dummy/1.0/bin/dummy" ]
 }
 
@@ -41,7 +41,7 @@ teardown() {
   run asdf reshim dummy 1.0
 
   run asdf which "other_bin"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$ASDF_DIR/installs/dummy/1.0/bin/subdir/other_bin" ]
 }
 
@@ -54,7 +54,7 @@ teardown() {
   chmod +x "$PROJECT_DIR/sys/dummy"
 
   run env "PATH=$PATH:$PROJECT_DIR/sys" asdf which "dummy"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$PROJECT_DIR/sys/dummy" ]
 }
 
@@ -80,7 +80,7 @@ teardown() {
   install_dummy_exec_path_script "dummy"
 
   run asdf which "dummy"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$ASDF_DIR/installs/dummy/1.0/bin/custom/dummy" ]
 }
 
@@ -93,7 +93,7 @@ teardown() {
   echo 'legacy_version_file = yes' >"$HOME/.asdfrc"
 
   run asdf which "dummy"
-  [ "$status" -eq 0 ]
+  assert_success
   [ "$output" = "$ASDF_DIR/installs/dummy/1.1/bin/dummy" ]
 }
 


### PR DESCRIPTION
# Summary

There are [several](https://bats-core.readthedocs.io/en/stable/writing-tests.html#libraries-and-add-ons) helper libraries to make it easier to write tests and understand failures if they occur.

For example, if `[ have = want ]` is replaced with `assert_equal 'have' 'want'` (a function from [bats-assert](https://github.com/bats-core/bats-assert)), then the following will be printed.

```txt
-- values do not equal --
expected : want
actual   : have
--
```

This also solves the issue of rogue printing statements that I continue to find during tests.

### Dependency Management

Before this is merged, I wanted to inquire about the preferred approach to using this dependency (I am assuming the consensus is that the tradeoff of the dependency is worth the DX benefit it yields)

To get started quickly, I just used my [`@hyperupcall/bats-all`](https://github.com/hyperupcall/bats-all) library. Using it is faster than sourcing each individual testing library and I'm trying to get it listed on the [bats site](https://github.com/bats-core/bats-core/pull/717). It is also an option to install each package separately (`bats-support`, `bats-file`, and `bats-assert`).

As for managing the dependency, I wasn't sure if git modules or subtrees were preferred, so I went with `npm` since it seemed like the simplest and cleanest approach.

## TODO

- [ ] Add to docs in testing section
- [ ] Replace more `$output` checks with bats testing functions
- [ ] Replace `[ -f` checks with bats testing functions
- [ ] Ignore (node_modules) through tests, gitignore, *checkstyle*, if we choose to use npm
