### PR TITLE
test: rm useless `echo` usage in tests

### DIFF
--- a/test/latest_command.bats
+++ b/test/latest_command.bats
@@ -38,48 +38,36 @@ teardown() {
 ####################################################
 @test "[latest_command - dummy_legacy_plugin] shows latest stable version" {
   run asdf latest legacy-dummy
-  echo "status: $status"
-  echo "output: $output"
   [ "5.1.0" = "$output" ]
   [ "$status" -eq 0 ]
 }
 
 @test "[latest_command - dummy_legacy_plugin] shows latest stable version that matches the given string" {
   run asdf latest legacy-dummy 1
-  echo "status: $status"
-  echo "output: $output"
   [ "1.1.0" = "$output" ]
   [ "$status" -eq 0 ]
 }
 
 @test "[latest_command - dummy_legacy_plugin] No stable version should return an error" {
   run asdf latest legacy-dummy 3
-  echo "status: $status"
-  echo "output: $output"
   [ -z "$output" ]
   [ "$status" -eq 1 ]
 }
 
 @test "[latest_command - dummy_legacy_plugin] do not show latest unstable version that matches the given string" {
   run asdf latest legacy-dummy 4
-  echo "status: $status"
-  echo "output: $output"
   [ "4.0.0" = "$output" ]
   [ "$status" -eq 0 ]
 }
 
 @test "[latest_command - dummy_legacy_plugin] do not show latest unstable version with capital characters that matches the given string" {
   run asdf latest legacy-dummy 5
-  echo "status: $status"
-  echo "output: $output"
   [ "5.1.0" = "$output" ]
   [ "$status" -eq 0 ]
 }
 
 @test "[latest_command - dummy_legacy_plugin] an invalid version should return an error" {
   run asdf latest legacy-dummy 6
-  echo "status: $status"
-  echo "output: $output"
   [ "No compatible versions available (legacy-dummy 6)" = "$output" ]
   [ "$status" -eq 1 ]
 }
@@ -91,13 +79,12 @@ teardown() {
   run asdf install dummy 2.0.0
   run asdf install legacy-dummy 4.0.0
   run asdf latest --all
-  echo "output $output"
-  [ "$(echo -e "dummy\t2.0.0\tinstalled\nlegacy-dummy\t5.1.0\tmissing\n")" = "$output" ]
+  [ $'dummy\t2.0.0\tinstalled\nlegacy-dummy\t5.1.0\tmissing' = "$output" ]
   [ "$status" -eq 0 ]
 }
 
 @test "[latest_command - all plugins] not installed plugin should return missing" {
   run asdf latest --all
-  [ "$(echo -e "dummy\t2.0.0\tmissing\nlegacy-dummy\t5.1.0\tmissing\n")" = "$output" ]
+  [ $'dummy\t2.0.0\tmissing\nlegacy-dummy\t5.1.0\tmissing' = "$output" ]
   [ "$status" -eq 0 ]
 }

--- a/test/list_command.bats
+++ b/test/list_command.bats
@@ -19,8 +19,8 @@ teardown() {
   run asdf install dummy 1.0.0
   run asdf install dummy 1.1.0
   run asdf list
-  [[ "$output" == *"$(echo -e "dummy\n  1.0.0\n  1.1.0")"* ]]
-  [[ "$output" == *"$(echo -e "dummy-broken\n  No versions installed")"* ]]
+  [[ "$output" == *$'dummy\n  1.0.0\n  1.1.0'* ]]
+  [[ "$output" == *$'dummy-broken\n  No versions installed'* ]]
   [ "$status" -eq 0 ]
 }
 
@@ -31,8 +31,8 @@ teardown() {
   run asdf install dummy 1.1.0
 
   run asdf list
-  [[ "$output" == *"$(echo -e "dummy\n  1.0.0\n *1.1.0")"* ]]
-  [[ "$output" == *"$(echo -e "dummy-broken\n  No versions installed")"* ]]
+  [[ "$output" == *$'dummy\n  1.0.0\n *1.1.0'* ]]
+  [[ "$output" == *$'dummy-broken\n  No versions installed'* ]]
   [ "$status" -eq 0 ]
 }
 
@@ -43,10 +43,10 @@ teardown() {
   run asdf install dummy 1.0.0
   run asdf install tummy 2.0.0
   run asdf list
-  [[ "$output" == *"$(echo -e "dummy\n  1.0.0")"* ]]
-  [[ "$output" == *"$(echo -e "dummy-broken\n  No versions installed")"* ]]
-  [[ "$output" == *"$(echo -e "mummy\n  No versions installed")"* ]]
-  [[ "$output" == *"$(echo -e "tummy\n  2.0.0")"* ]]
+  [[ "$output" == *$'dummy\n  1.0.0'* ]]
+  [[ "$output" == *$'dummy-broken\n  No versions installed'* ]]
+  [[ "$output" == *$'mummy\n  No versions installed'* ]]
+  [[ "$output" == *$'tummy\n  2.0.0'* ]]
   [ "$status" -eq 0 ]
 }
 
@@ -54,7 +54,7 @@ teardown() {
   run asdf install dummy 1.0.0
   run asdf install dummy 1.1.0
   run asdf list dummy
-  [ "$(echo -e "  1.0.0\n  1.1.0")" = "$output" ]
+  [ $'  1.0.0\n  1.1.0' = "$output" ]
   [ "$status" -eq 0 ]
 }
 
@@ -63,7 +63,7 @@ teardown() {
   run asdf install dummy 1.1
   run asdf install dummy 2.0
   run asdf list dummy 1
-  [ "$(echo -e "  1.0\n  1.1")" = "$output" ]
+  [ $'  1.0\n  1.1' = "$output" ]
   [ "$status" -eq 0 ]
 }
 
@@ -77,13 +77,13 @@ teardown() {
 
 @test "list_all_command lists available versions" {
   run asdf list-all dummy
-  [ "$(echo -e "1.0.0\n1.1.0\n2.0.0")" = "$output" ]
+  [ $'1.0.0\n1.1.0\n2.0.0' = "$output" ]
   [ "$status" -eq 0 ]
 }
 
 @test "list_all_command with version filters available versions" {
   run asdf list-all dummy 1
-  [ "$(echo -e "1.0.0\n1.1.0")" = "$output" ]
+  [ $'1.0.0\n1.1.0' = "$output" ]
   [ "$status" -eq 0 ]
 }
 

--- a/test/plugin_test_command.bats
+++ b/test/plugin_test_command.bats
@@ -25,14 +25,10 @@ teardown() {
 
 @test "plugin_test_command works with no options provided" {
   run asdf plugin-test dummy "${BASE_DIR}/repo-dummy"
-  echo "status = ${status}"
-  echo "output = ${output}"
   [ "$status" -eq 0 ]
 }
 
 @test "plugin_test_command works with all options provided" {
   run asdf plugin-test dummy "${BASE_DIR}/repo-dummy" --asdf-tool-version 1.0.0 --asdf-plugin-gitref master
-  echo "status = ${status}"
-  echo "output = ${output}"
   [ "$status" -eq 0 ]
 }

--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -333,7 +333,6 @@ teardown() {
   chmod +x "$PROJECT_DIR/sys/dummy"
 
   run env "PATH=$PATH:$PROJECT_DIR/sys" "$ASDF_DIR/shims/dummy"
-  echo "$status $output"
   [ "$output" = "$ASDF_DIR/shims/dummy" ]
 }
 

--- a/test/uninstall_command.bats
+++ b/test/uninstall_command.bats
@@ -32,7 +32,7 @@ teardown() {
   run asdf install dummy 1.1.0
   [ "$status" -eq 0 ]
   mkdir -p "$ASDF_DIR/plugins/dummy/bin"
-  echo "echo custom uninstall" >"$ASDF_DIR/plugins/dummy/bin/uninstall"
+  printf '%s\n' "echo custom uninstall" >"$ASDF_DIR/plugins/dummy/bin/uninstall"
   chmod 755 "$ASDF_DIR/plugins/dummy/bin/uninstall"
   run asdf uninstall dummy 1.1.0
   [ "$output" = "custom uninstall" ]

--- a/test/update_command.bats
+++ b/test/update_command.bats
@@ -61,14 +61,14 @@ teardown() {
   touch "$ASDF_DIR/asdf_updates_disabled"
   run asdf update
   [ "$status" -eq 42 ]
-  [ "$(echo -e "Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf.")" = "$output" ]
+  [ $'Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf.' = "$output" ]
 }
 
 @test "asdf update is a noop for non-git repos" {
   rm -rf "$ASDF_DIR/.git/"
   run asdf update
   [ "$status" -eq 42 ]
-  [ "$(echo -e "Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf.")" = "$output" ]
+  [ $'Update command disabled. Please use the package manager that you used to install asdf to upgrade asdf.' = "$output" ]
 }
 
 @test "asdf update fails with exit code 1" {

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -43,7 +43,6 @@ teardown() {
   run get_download_path foo version "1.0.0"
   [ "$status" -eq 0 ]
   download_path=${output#"$HOME/"}
-  echo "$download_path"
   [ "$download_path" = ".asdf/downloads/foo/1.0.0" ]
 }
 


### PR DESCRIPTION
# Summary

Sorry for all the PRs, here is another that fixes useless `echo -e`s and extraneous `echo`s