### PR TITLE
chore: rm format script config for removed files

### DIFF
--- a/scripts/format.bash
+++ b/scripts/format.bash
@@ -2,10 +2,6 @@
 
 set -euo pipefail
 
-# check .sh files
-shfmt --language-dialect posix --indent 2 --write \
-  lib/*.sh
-
 # check .bash files
 shfmt --language-dialect bash --indent 2 --write \
   completions/*.bash \


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

This updates the `scripts/format.bash` script to no longer try and format files removed in #1525 

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->
