### PR TITLE
fix: remove leading asterick in Fish completion

### DIFF
--- a/completions/asdf.fish
+++ b/completions/asdf.fish
@@ -31,7 +31,7 @@ function __fish_asdf_arg_at -a number
 end
 
 function __fish_asdf_list_versions -a plugin
-    asdf list $plugin 2>/dev/null | sed -e 's/^[[:space:]]*//'
+    asdf list $plugin 2>/dev/null | string trim | string trim --left --chars '*'
 end
 
 function __fish_asdf_list_all -a plugin


### PR DESCRIPTION
# Summary

Fixes: #1542

The recommended fix was good, but this uses only builtins
