### PR TITLE
fix: rename internal function `asdf_tool_versions_filename`

### DIFF
--- a/bin/asdf
+++ b/bin/asdf
@@ -69,7 +69,7 @@ asdf_cmd() {
   fi
 
   # Internal Variables
-  ASDF_DEFAULT_TOOL_VERSIONS_FILENAME=$(asdf_default_tool_versions_filename)
+  ASDF_DEFAULT_TOOL_VERSIONS_FILENAME=$(asdf_tool_versions_filename)
   export ASDF_DEFAULT_TOOL_VERSIONS_FILENAME
 
   ASDF_CONFIG_FILE=$(asdf_config_file)

--- a/lib/functions/versions.bash
+++ b/lib/functions/versions.bash
@@ -17,7 +17,7 @@ version_command() {
   local file_name
   local file
 
-  file_name="$(asdf_default_tool_versions_filename)"
+  file_name="$(asdf_tool_versions_filename)"
 
   if [ "$cmd" = "global" ]; then
     file="$HOME/$file_name"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -16,7 +16,7 @@ asdf_version() {
   fi
 }
 
-asdf_default_tool_versions_filename() {
+asdf_tool_versions_filename() {
   printf '%s\n' "${ASDF_DEFAULT_TOOL_VERSIONS_FILENAME:-.tool-versions}"
 }
 
@@ -163,7 +163,7 @@ get_version_in_dir() {
 
   local asdf_version
 
-  file_name=$(asdf_default_tool_versions_filename)
+  file_name=$(asdf_tool_versions_filename)
   asdf_version=$(parse_asdf_version_file "$search_path/$file_name" "$plugin_name")
 
   if [ -n "$asdf_version" ]; then
@@ -456,7 +456,7 @@ get_plugin_source_url() {
 }
 
 find_tool_versions() {
-  find_file_upwards "$(asdf_default_tool_versions_filename)"
+  find_file_upwards "$(asdf_tool_versions_filename)"
 }
 
 find_file_upwards() {


### PR DESCRIPTION
# Summary

Applied suggestions from [here](https://github.com/asdf-vm/asdf/pull/1485#discussion_r1164088836) and [here](https://github.com/asdf-vm/asdf/pull/1518#discussion_r1159820722).
