### PR TITLE
Support force (re)installing

### DIFF
--- a/lib/functions/installs.bash
+++ b/lib/functions/installs.bash
@@ -179,7 +179,7 @@ install_tool_version() {
   concurrency=$(get_concurrency)
   trap 'handle_cancel $install_path' INT
 
-  if [ -d "$install_path" ]; then
+  if [ -d "$install_path" ] && [ "${ASDF_FORCE_INSTALL}" != "true" ]; then
     printf "%s %s is already installed\n" "$plugin_name" "$full_version"
   else
 


### PR DESCRIPTION
# Summary

This PR introduces a new `ASDF_` environment variable called `ASDF_FORCE_INSTALL` which can be set to `true` to force a (re)install.

Taking Ruby as an example, it's desirable to want to re-install (instead of uninstall and install) when you want to apply a new set of Ruby patches, but don't want to lose the currently installed Ruby gems.