### PR TITLE
docs: fix uninstall instructions for Fish Shell

### DIFF
--- a/docs/manage/core.md
+++ b/docs/manage/core.md
@@ -221,7 +221,7 @@ rm -rf ~/.config/fish/completions/asdf.fish
 2. Remove the `$HOME/.asdf` dir:
 
 ```shell:no-line-numbers
-rm -rf "${ASDF_DATA_DIR:-$HOME/.asdf}"
+rm -rf (string join : -- $ASDF_DATA_DIR $HOME/.asdf)
 ```
 
 3. Run this command to remove all `asdf` config files:
@@ -271,7 +271,7 @@ pacman -Rs asdf-vm
 3. Remove the `$HOME/.asdf` dir:
 
 ```shell:no-line-numbers
-rm -rf "${ASDF_DATA_DIR:-$HOME/.asdf}"
+rm -rf (string join : -- $ASDF_DATA_DIR $HOME/.asdf)
 ```
 
 4. Run this command to remove all `asdf` config files:

--- a/docs/pt-br/manage/core.md
+++ b/docs/pt-br/manage/core.md
@@ -223,7 +223,7 @@ rm -rf ~/.config/fish/completions/asdf.fish
 2. Remova o diretório `$HOME/.asdf`:
 
 ```shell
-rm -rf "${ASDF_DATA_DIR:-$HOME/.asdf}"
+rm -rf (string join : -- $ASDF_DATA_DIR $HOME/.asdf)
 ```
 
 3. Execute o comando para remover todos os arquivos de configurações do `asdf`:
@@ -273,7 +273,7 @@ pacman -Rs asdf-vm
 3. Remova o diretório `$HOME/.asdf`:
 
 ```shell
-rm -rf "${ASDF_DATA_DIR:-$HOME/.asdf}"
+rm -rf (string join : -- $ASDF_DATA_DIR $HOME/.asdf)
 ```
 
 4. Execute o comando para remover todos os arquivos de configurações do `asdf`:

--- a/docs/zh-hans/manage/core.md
+++ b/docs/zh-hans/manage/core.md
@@ -221,7 +221,7 @@ rm -rf ~/.config/fish/completions/asdf.fish
 2. 移除 `$HOME/.asdf` 目录：
 
 ```shell:no-line-numbers
-rm -rf "${ASDF_DATA_DIR:-$HOME/.asdf}"
+rm -rf (string join : -- $ASDF_DATA_DIR $HOME/.asdf)
 ```
 
 3. 执行以下命令移除 `asdf` 所有配置文件：
@@ -271,7 +271,7 @@ pacman -Rs asdf-vm
 3. 移除 `$HOME/.asdf` 目录：
 
 ```shell:no-line-numbers
-rm -rf "${ASDF_DATA_DIR:-$HOME/.asdf}"
+rm -rf (string join : -- $ASDF_DATA_DIR $HOME/.asdf)
 ```
 
 4. 执行以下命令移除 `asdf` 所有配置文件：


### PR DESCRIPTION
# Summary

Fix uninstall instructions for Fish Shell.

## Other Information

The syntax used is not supported in Fish Shell https://stackoverflow.com/questions/75492179/how-to-convert-export-line-from-bash-to-fishvariable-expansion-shortcuts. I'm not sure if the new version is the most correct, but it at least works.
