### PR TITLE
ci: custom release PR sections & titles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,12 @@ jobs:
         with:
           release-type: simple
           bump-minor-pre-major: true # remove this to enable breaking changes causing 1.0.0 tag
+          changelog-types: |
+            [
+              { "type": "feat", "section": "Features", "hidden": false },
+              { "type": "fix", "section": "Patches", "hidden": false },
+              { "type": "docs", "section": "Documentation", "hidden": false }
+            ]
           extra-files: |
             SECURITY.md
             docs/guide/getting-started.md


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

Use custom release-please PR section titles.

- Currently all `fix:` commits are categorized under "Bug Fixes". With our use of [Convention Commits](https://www.conventionalcommits.org/en/v1.0.0/), `fix:` actually covers all changes which require a Patch version update. So we should just call that changelog section "Patches".
- track documentation changes in the Changelog as well (I have found our previous changelogs which tracked this information to be helpful when identifying when behaviour was added and if there was accompanying docs from separate PRs).

I expect this change to result in PR & Changelog sections as:

```diff
BREAKING CHANGES

Features

-Bug Fixes
+Patches

+Documentation
```

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->

* I am unsure if this configuration affects the "BREAKING CHANGES" section. I assume not.
* This will not change past sections of the changelog
* We can observe the results of this change in our Release PRs as it shows the diff to the Changelog file, and if we're unhappy we can update it again before the release.