### PR TITLE
feat: sync command (for install plugins and tools from .tool-versions)

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -60,6 +60,8 @@ asdf shim-versions <command>            List the plugins and versions that
 asdf update                             Update asdf to the latest stable release
 asdf update --head                      Update asdf to the latest on the master branch
 
+asdf sync [--local | --global]          Add all plugins and install require version
+
 RESOURCES
 GitHub: https://github.com/asdf-vm/asdf
 Docs:   https://asdf-vm.com

--- a/lib/commands/command-plugin-list-all.bash
+++ b/lib/commands/command-plugin-list-all.bash
@@ -1,29 +1,3 @@
 # -*- sh -*-
 
-plugin_list_all_command() {
-  initialize_or_update_plugin_repository
-
-  local plugins_index_path
-  plugins_index_path="$(asdf_data_dir)/repository/plugins"
-
-  local plugins_local_path
-  plugins_local_path="$(get_plugin_path)"
-
-  if find "$plugins_index_path" -mindepth 1 -type d &>/dev/null; then
-    (
-      for index_plugin in "$plugins_index_path"/*; do
-        index_plugin_name=$(basename "$index_plugin")
-        source_url=$(get_plugin_source_url "$index_plugin_name")
-        installed_flag=" "
-
-        [[ -d "${plugins_local_path}/${index_plugin_name}" ]] && installed_flag='*'
-
-        printf "%s\t%s\n" "$index_plugin_name" "$installed_flag$source_url"
-      done
-    ) | awk '{ printf("%-28s", $1); sub(/^[^*]/, " &", $2); $1=""; print $0 }'
-  else
-    printf "%s%s\n" "error: index of plugins not found at " "$plugins_index_path"
-  fi
-}
-
 plugin_list_all_command "$@"

--- a/lib/commands/command-sync.bash
+++ b/lib/commands/command-sync.bash
@@ -17,6 +17,7 @@ sync_command() {
         local tool_versions_file="${HOME}"/"${ASDF_DEFAULT_TOOL_VERSIONS_FILENAME:-.tool-versions}"
   else
     display_error "usage: asdf sync [--local | --global]"
+    exit 1
   fi
 
   if [ -f "${tool_versions_file}" ]; then

--- a/lib/commands/command-sync.bash
+++ b/lib/commands/command-sync.bash
@@ -32,7 +32,7 @@ sync_command() {
 
         echo "Sync ${plugin_name} in version ${plugin_version}"
         if ! plugin_list_command | grep -E "^${plugin_name}$" > /dev/null 2>&1; then
-          if grep -E "^${plugin_name}$" "${plugin_list_tmpfile}"; then
+          if grep -E "^${plugin_name}$" "${plugin_list_tmpfile}" > /dev/null 2>&1; then
             plugin_add_command "${plugin_name}"
             install_command "${plugin_name}" "${plugin_version}"
           else

--- a/lib/commands/command-sync.bash
+++ b/lib/commands/command-sync.bash
@@ -1,0 +1,42 @@
+# -*- sh -*-
+
+# shellcheck source=lib/functions/plugins.bash
+. "$(dirname "$(dirname "$0")")/lib/functions/plugins.bash"
+# shellcheck source=lib/functions/versions.bash
+. "$(dirname "$(dirname "$0")")/lib/functions/versions.bash"
+# shellcheck source=lib/commands/reshim.bash
+. "$(dirname "$ASDF_CMD_FILE")/reshim.bash"
+# shellcheck source=lib/functions/installs.bash
+. "$(dirname "$(dirname "$0")")/lib/functions/installs.bash"
+
+sync_command() {
+  
+  if [[ "$1" == "--local" || "$1" == "" ]]; then
+        local tool_versions_file=./"${ASDF_DEFAULT_TOOL_VERSIONS_FILENAME:-.tool-versions}"
+  elif [ "$1" == "--global" ]; then
+        local tool_versions_file="${HOME}"/"${ASDF_DEFAULT_TOOL_VERSIONS_FILENAME:-.tool-versions}"
+  else
+    display_error "usage: asdf sync [--local | --global]"
+  fi
+
+  if [ -f "${tool_versions_file}" ]; then
+      local plugin
+      readonly plugin_list_tmpfile=$(mktemp)
+
+      while read plugin; do
+        local plugin_name=$(echo "${plugin}" | awk '{print $1}' )
+        local plugin_version=$(echo "${plugin}" | awk '{print $2}' )
+
+        if ! plugin_list_command | grep -E "^${plugin_name}$"; then
+          plugin_add_command "${plugin_name}"
+        fi
+        install_command "${plugin_name}" "${plugin_version}"
+      done < "${tool_versions_file}"
+  else
+      display_error "No ${tool_versions_file} here"
+      exit 1
+  fi
+  
+}
+
+sync_command "$@"

--- a/lib/commands/command-sync.bash
+++ b/lib/commands/command-sync.bash
@@ -12,46 +12,46 @@
 sync_command() { 
   local temp_dir
   temp_dir=${TMPDIR:-/tmp}
-  
+
   if [[ "$1" == "--local" || "$1" == "" ]]; then
-        local tool_versions_file=./"${ASDF_DEFAULT_TOOL_VERSIONS_FILENAME:-.tool-versions}"
+    local tool_versions_file=./"${ASDF_DEFAULT_TOOL_VERSIONS_FILENAME:-.tool-versions}"
   elif [ "$1" == "--global" ]; then
-        local tool_versions_file="${HOME}"/"${ASDF_DEFAULT_TOOL_VERSIONS_FILENAME:-.tool-versions}"
+    local tool_versions_file="${HOME}"/"${ASDF_DEFAULT_TOOL_VERSIONS_FILENAME:-.tool-versions}"
   else
     display_error "usage: asdf sync [--local | --global]"
     exit 1
   fi
 
   if [ -f "${tool_versions_file}" ]; then
-      local plugin
-      local plugin_list_tmpfile
-      plugin_list_tmpfile=$(mktemp "$temp_dir/asdf-command-sync-list-plugins.XXXXXX")
+    local plugin
+    local plugin_list_tmpfile
+    plugin_list_tmpfile=$(mktemp "$temp_dir/asdf-command-sync-list-plugins.XXXXXX")
 
-      plugin_list_all_command | awk '{print $1}'> "${plugin_list_tmpfile}"
+    plugin_list_all_command | awk '{print $1}'> "${plugin_list_tmpfile}"
 
-      while read plugin; do
-        local plugin_name
-        plugin_name=$(echo "${plugin}" | awk '{print $1}' )
-        local plugin_version
-        plugin_version=$(echo "${plugin}" | awk '{print $2}' )
+    while read -r plugin; do
+      local plugin_name
+      plugin_name=$(echo "${plugin}" | awk '{print $1}' )
+      local plugin_version
+      plugin_version=$(echo "${plugin}" | awk '{print $2}' )
 
-        echo "Sync ${plugin_name} in version ${plugin_version}"
-        if ! plugin_list_command | grep -E "^${plugin_name}$" > /dev/null 2>&1; then
-          if grep -E "^${plugin_name}$" "${plugin_list_tmpfile}" > /dev/null 2>&1; then
-            plugin_add_command "${plugin_name}"
-            install_command "${plugin_name}" "${plugin_version}"
-          else
-            display_error "plugin ${plugin_name} not found in repository"
-          fi
-        else
+      echo "Sync ${plugin_name} in version ${plugin_version}"
+      if ! plugin_list_command "" | grep -E "^${plugin_name}$" > /dev/null 2>&1; then
+        if grep -E "^${plugin_name}$" "${plugin_list_tmpfile}" > /dev/null 2>&1; then
+          plugin_add_command "${plugin_name}"
           install_command "${plugin_name}" "${plugin_version}"
+        else
+          display_error "plugin ${plugin_name} not found in repository"
         fi
-        
+      else
+        install_command "${plugin_name}" "${plugin_version}"
+      fi
+      
 
-      done < "${tool_versions_file}"
+    done < "${tool_versions_file}"
   else
-      display_error "No ${tool_versions_file} here"
-      exit 1
+    display_error "No ${tool_versions_file} here"
+    exit 1
   fi
   
 }

--- a/lib/commands/command-sync.bash
+++ b/lib/commands/command-sync.bash
@@ -23,12 +23,19 @@ sync_command() {
       local plugin
       readonly plugin_list_tmpfile=$(mktemp)
 
+      plugin_list_all_command | awk '{print $1}'> "${plugin_list_tmpfile}"
+
       while read plugin; do
         local plugin_name=$(echo "${plugin}" | awk '{print $1}' )
         local plugin_version=$(echo "${plugin}" | awk '{print $2}' )
 
-        if ! plugin_list_command | grep -E "^${plugin_name}$"; then
-          plugin_add_command "${plugin_name}"
+        echo "Sync ${plugin_name} in version ${plugin_version}"
+        if ! plugin_list_command | grep -E "^${plugin_name}$" > /dev/null 2>&1; then
+          if grep -E "^${plugin_name}$"; then
+            plugin_add_command "${plugin_name}"
+          else
+            display_error "plugin ${plugin_name} not found in repository"
+          fi
         fi
         install_command "${plugin_name}" "${plugin_version}"
       done < "${tool_versions_file}"

--- a/lib/commands/command-sync.bash
+++ b/lib/commands/command-sync.bash
@@ -9,7 +9,9 @@
 # shellcheck source=lib/functions/installs.bash
 . "$(dirname "$(dirname "$0")")/lib/functions/installs.bash"
 
-sync_command() {
+sync_command() { 
+  local temp_dir
+  temp_dir=${TMPDIR:-/tmp}
   
   if [[ "$1" == "--local" || "$1" == "" ]]; then
         local tool_versions_file=./"${ASDF_DEFAULT_TOOL_VERSIONS_FILENAME:-.tool-versions}"
@@ -22,13 +24,16 @@ sync_command() {
 
   if [ -f "${tool_versions_file}" ]; then
       local plugin
-      readonly plugin_list_tmpfile=$(mktemp)
+      local plugin_list_tmpfile
+      plugin_list_tmpfile=$(mktemp "$temp_dir/asdf-command-sync-list-plugins.XXXXXX")
 
       plugin_list_all_command | awk '{print $1}'> "${plugin_list_tmpfile}"
 
       while read plugin; do
-        local plugin_name=$(echo "${plugin}" | awk '{print $1}' )
-        local plugin_version=$(echo "${plugin}" | awk '{print $2}' )
+        local plugin_name
+        plugin_name=$(echo "${plugin}" | awk '{print $1}' )
+        local plugin_version
+        plugin_version=$(echo "${plugin}" | awk '{print $2}' )
 
         echo "Sync ${plugin_name} in version ${plugin_version}"
         if ! plugin_list_command | grep -E "^${plugin_name}$" > /dev/null 2>&1; then

--- a/lib/commands/command-sync.bash
+++ b/lib/commands/command-sync.bash
@@ -31,13 +31,17 @@ sync_command() {
 
         echo "Sync ${plugin_name} in version ${plugin_version}"
         if ! plugin_list_command | grep -E "^${plugin_name}$" > /dev/null 2>&1; then
-          if grep -E "^${plugin_name}$"; then
+          if grep -E "^${plugin_name}$" "${plugin_list_tmpfile}"; then
             plugin_add_command "${plugin_name}"
+            install_command "${plugin_name}" "${plugin_version}"
           else
             display_error "plugin ${plugin_name} not found in repository"
           fi
+        else
+          install_command "${plugin_name}" "${plugin_version}"
         fi
-        install_command "${plugin_name}" "${plugin_version}"
+        
+
       done < "${tool_versions_file}"
   else
       display_error "No ${tool_versions_file} here"

--- a/lib/functions/plugins.bash
+++ b/lib/functions/plugins.bash
@@ -46,6 +46,32 @@ plugin_list_command() {
   fi
 }
 
+plugin_list_all_command() {
+  initialize_or_update_plugin_repository
+
+  local plugins_index_path
+  plugins_index_path="$(asdf_data_dir)/repository/plugins"
+
+  local plugins_local_path
+  plugins_local_path="$(get_plugin_path)"
+
+  if find "$plugins_index_path" -mindepth 1 -type d &>/dev/null; then
+    (
+      for index_plugin in "$plugins_index_path"/*; do
+        index_plugin_name=$(basename "$index_plugin")
+        source_url=$(get_plugin_source_url "$index_plugin_name")
+        installed_flag=" "
+
+        [[ -d "${plugins_local_path}/${index_plugin_name}" ]] && installed_flag='*'
+
+        printf "%s\t%s\n" "$index_plugin_name" "$installed_flag$source_url"
+      done
+    ) | awk '{ printf("%-28s", $1); sub(/^[^*]/, " &", $2); $1=""; print $0 }'
+  else
+    printf "%s%s\n" "error: index of plugins not found at " "$plugins_index_path"
+  fi
+}
+
 plugin_add_command() {
   if [[ $# -lt 1 || $# -gt 2 ]]; then
     display_error "usage: asdf plugin add <name> [<git-url>]"


### PR DESCRIPTION
# Summary

If you install a new computer and asdf, It's really long to add all the plugins and versions of tools you need. Same if a project uses specific versions of tools.
With this feature, you can add all plugins and install all required versions of tools in on single command, from the .tool-versions file.

The name of command is temporary, it will have to be discussed. I chose `sync`, because we synchronize the versions.

## Other Information

Example :
```shell
# Sync local .tool-versions (example in asdf repository)
$ asdf sync # or asdf sync --local
Preparing downloading 1.8.2 from https://github.com/bats-core/bats-core.git
* Downloading Bats-core(version:1.8.2) to /home/mamounet/.asdf/downloads/bats/1.8.2
Cloning into '/home/mamounet/.asdf/downloads/bats/1.8.2'...
[...]
shellcheck-v0.9.0/shellcheck
Downloading shfmt from https://github.com/mvdan/sh/releases/download/v3.6.0/shfmt_v3.6.0_linux_amd64


# Sync global ~/.tool-versions
$ asdf sync --global
nodejs
nodejs 19.8.1 is already installed
bat
bat 0.23.0 is already installed
[...]
yq
yq 4.33.3 is already installed
restic
restic 0.15.2 is already installed
marp-cli
marp-cli 1.5.1 is already installed
```