### PR TITLE
fix: Introduce `ASDF_FORCE_PREPEND` variable on POSIX entrypoint

### DIFF
--- a/asdf.sh
+++ b/asdf.sh
@@ -59,7 +59,6 @@ fi
 _asdf_bin="$ASDF_DIR/bin"
 _asdf_shims="${ASDF_DATA_DIR:-$HOME/.asdf}/shims"
 
-
 _asdf_should_prepend=no
 if [ -n "${ASDF_FORCE_PREPEND+x}" ]; then
   _asdf_should_prepend=$ASDF_FORCE_PREPEND
@@ -79,6 +78,7 @@ else
     if [ "$_asdf_output" = 'Darwin' ]; then
       _asdf_should_prepend=yes
     fi
+    unset -v _asdf_output
   fi
 fi
 

--- a/asdf.sh
+++ b/asdf.sh
@@ -59,6 +59,36 @@ fi
 _asdf_bin="$ASDF_DIR/bin"
 _asdf_shims="${ASDF_DATA_DIR:-$HOME/.asdf}/shims"
 
+# If ASDF_FORCE_PREPEND is set, remove any existing instances of asdf from PATH so
+# the prepending done after is always at the frontmost part of the PATH.
+if [ -n "${ASDF_FORCE_PREPEND+x}" ]; then
+  if [ -n "$BASH_VERSION" ] || [ -n "$ZSH_VERSION" ]; then
+    # shellcheck disable=SC3060
+    case ":$PATH:" in
+      *":${_asdf_bin}:"*) PATH=${PATH//$_asdf_bin:/} ;;
+    esac
+    # shellcheck disable=SC3060
+    case ":$PATH:" in
+      *":${_asdf_shims}:"*) PATH=${PATH//$_asdf_shims:/} ;;
+    esac
+  else
+    _path=${PATH}:
+    _new_path=
+    while [ -n "$_path" ]; do
+      _part=${_path%%:*}
+      _path=${_path#*:}
+
+      if [ "$_part" = "$_asdf_bin" ] || [ "$_part" = "$_asdf_shims" ]; then
+        continue
+      fi
+
+      _new_path="$_new_path${_new_path:+:}$_part"
+    done
+    PATH=$_new_path
+    unset -v _path _new_path _part
+  fi
+fi
+
 case ":$PATH:" in
   *":$_asdf_bin:"*) : ;;
   *) PATH="$_asdf_bin:$PATH" ;;

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -362,7 +362,7 @@ export ASDF_DIR="/opt/asdf-vm"
 `asdf` scripts need to be sourced **after** you have set your `$PATH` and **after** you have sourced your framework (oh-my-zsh etc).
 
 ::: warning
-On macOS, starting a Bash or Zsh shell automatically calls a utility called `path_helper`. `path_helper` has poor logic and rearranges items in `PATH` (and `MANPATH`) in a bad way. To workaround this, set the `ASDF_FORCE_PREPEND` variable before sourcing `asdf`, like so: `ASDF_FORCE_PREPEND= . "<path-to-asdf-directory>/asdf.sh"`.
+On macOS, starting a Bash or Zsh shell automatically calls a utility called `path_helper`. `path_helper` can rearrange items in `PATH` (and `MANPATH`) causing inconsistent behavior for tools which require specific ordering. To workaround this, set the `ASDF_FORCE_PREPEND` variable before sourcing `asdf`, like so: `ASDF_FORCE_PREPEND= . "<path-to-asdf-directory>/asdf.sh"`.
 :::
 
 Restart your shell so that `PATH` changes take effect. Opening a new terminal tab will usually do it.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -51,7 +51,9 @@ We highly recommend using the official `git` method.
 
 ## 3. Install asdf
 
-There are many different combinations of Shells, OSs & Installation methods all of which affect the configuration here. Expand the selection below that best matches your system:
+There are many different combinations of Shells, OSs & Installation methods all of which affect the configuration here. Expand the selection below that best matches your system.
+
+**macOS users, be sure to read the warning about `path_helper` at the end of this section.**
 
 ::: details Bash & Git
 
@@ -358,6 +360,10 @@ export ASDF_DIR="/opt/asdf-vm"
 :::
 
 `asdf` scripts need to be sourced **after** you have set your `$PATH` and **after** you have sourced your framework (oh-my-zsh etc).
+
+::: warning
+On macOS, starting a Bash or Zsh shell automatically calls a utility called `path_helper`. `path_helper` has poor logic and rearranges items in `PATH` (and `MANPATH`) in a bad way. To workaround this, set the `ASDF_FORCE_PREPEND` variable before sourcing `asdf`, like so: `ASDF_FORCE_PREPEND= . "<path-to-asdf-directory>/asdf.sh"`.
+:::
 
 Restart your shell so that `PATH` changes take effect. Opening a new terminal tab will usually do it.
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -362,7 +362,7 @@ export ASDF_DIR="/opt/asdf-vm"
 `asdf` scripts need to be sourced **after** you have set your `$PATH` and **after** you have sourced your framework (oh-my-zsh etc).
 
 ::: warning
-On macOS, starting a Bash or Zsh shell automatically calls a utility called `path_helper`. `path_helper` can rearrange items in `PATH` (and `MANPATH`) causing inconsistent behavior for tools which require specific ordering. To workaround this, set the `ASDF_FORCE_PREPEND` variable to `yes` before sourcing `asdf`, like so: `ASDF_FORCE_PREPEND=yes . "<path-to-asdf-directory>/asdf.sh"`.
+On macOS, starting a Bash or Zsh shell automatically calls a utility called `path_helper`. `path_helper` can rearrange items in `PATH` (and `MANPATH`), causing inconsistent behavior for tools that require specific ordering. To workaround this, `asdf` on macOS defaults to forcily adding its `PATH`-entries to the front (taking highest priority). This is controllable with the `ASDF_FORCE_PREPEND` variable.`.
 :::
 
 Restart your shell so that `PATH` changes take effect. Opening a new terminal tab will usually do it.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -362,7 +362,7 @@ export ASDF_DIR="/opt/asdf-vm"
 `asdf` scripts need to be sourced **after** you have set your `$PATH` and **after** you have sourced your framework (oh-my-zsh etc).
 
 ::: warning
-On macOS, starting a Bash or Zsh shell automatically calls a utility called `path_helper`. `path_helper` can rearrange items in `PATH` (and `MANPATH`) causing inconsistent behavior for tools which require specific ordering. To workaround this, set the `ASDF_FORCE_PREPEND` variable before sourcing `asdf`, like so: `ASDF_FORCE_PREPEND= . "<path-to-asdf-directory>/asdf.sh"`.
+On macOS, starting a Bash or Zsh shell automatically calls a utility called `path_helper`. `path_helper` can rearrange items in `PATH` (and `MANPATH`) causing inconsistent behavior for tools which require specific ordering. To workaround this, set the `ASDF_FORCE_PREPEND` variable to `yes` before sourcing `asdf`, like so: `ASDF_FORCE_PREPEND=yes . "<path-to-asdf-directory>/asdf.sh"`.
 :::
 
 Restart your shell so that `PATH` changes take effect. Opening a new terminal tab will usually do it.

--- a/docs/manage/configuration.md
+++ b/docs/manage/configuration.md
@@ -183,10 +183,17 @@ The location where `asdf` will install plugins, shims and tool versions. Can be 
 
 ### `ASDF_CONCURRENCY`
 
-Number of cores to use when compiling the source code. If set, this value takes precedence over the asdf config `concurrency` value. 
+Number of cores to use when compiling the source code. If set, this value takes precedence over the asdf config `concurrency` value.
 
 - If Unset: the asdf config `concurrency` value is used.
 - Usage: `export ASDF_CONCURRENCY=32`
+
+### `ASDF_FORCE_PREPEND`
+
+Whether or not to prepend the `asdf` shims and path directories to the front-most (highest-priority) part of the `PATH`.
+
+- If `yes`: Force prepending to the `PATH`.
+- If unset or set to any string _other_ than `yes`: Do not force `asdf` directories to the front-most part of the path.
 
 ## Full Configuration Example
 
@@ -195,7 +202,7 @@ Following a simple asdf setup with:
 - a Bash Shell
 - an installation location of `$HOME/.asdf`
 - installed via Git
-- NO environment variables set 
+- NO environment variables set
 - NO custom `.asdfrc` file
 
 would result in the following outcomes:

--- a/docs/manage/configuration.md
+++ b/docs/manage/configuration.md
@@ -190,7 +190,7 @@ Number of cores to use when compiling the source code. If set, this value takes 
 
 ### `ASDF_FORCE_PREPEND`
 
-Whether or not to prepend the `asdf` shims and path directories to the front-most (highest-priority) part of the `PATH`
+Whether or not to prepend the `asdf` shims and path directories to the front-most (highest-priority) part of the `PATH`.
 
 - If Unset: On macOS, defaults to `yes`; but on other systems, defaults to `no`
 - If `yes`: Force `asdf` directories to the front of the `PATH`

--- a/docs/manage/configuration.md
+++ b/docs/manage/configuration.md
@@ -190,10 +190,12 @@ Number of cores to use when compiling the source code. If set, this value takes 
 
 ### `ASDF_FORCE_PREPEND`
 
-Whether or not to prepend the `asdf` shims and path directories to the front-most (highest-priority) part of the `PATH`.
+Whether or not to prepend the `asdf` shims and path directories to the front-most (highest-priority) part of the `PATH`
 
-- If `yes`: Force prepending to the `PATH`.
-- If unset or set to any string _other_ than `yes`: Do not force `asdf` directories to the front-most part of the path.
+- If Unset: On macOS, defaults to `yes`; but on other systems, defaults to `no`
+- If `yes`: Force `asdf` directories to the front of the `PATH`
+- If set to any string _other_ than `yes`: Do _not_ force `asdf` directories to the front of the `PATH`
+- Usage: `ASDF_FORCE_PREPEND=no . "<path-to-asdf-directory>/asdf.sh"`
 
 ## Full Configuration Example
 

--- a/docs/manage/configuration.md
+++ b/docs/manage/configuration.md
@@ -183,7 +183,7 @@ The location where `asdf` will install plugins, shims and tool versions. Can be 
 
 ### `ASDF_CONCURRENCY`
 
-Number of cores to use when compiling the source code. If set, this value takes precedence over the asdf config `concurrency` value.
+Number of cores to use when compiling the source code. If set, this value takes precedence over the asdf config `concurrency` value. 
 
 - If Unset: the asdf config `concurrency` value is used.
 - Usage: `export ASDF_CONCURRENCY=32`

--- a/docs/manage/configuration.md
+++ b/docs/manage/configuration.md
@@ -204,7 +204,7 @@ Following a simple asdf setup with:
 - a Bash Shell
 - an installation location of `$HOME/.asdf`
 - installed via Git
-- NO environment variables set
+- NO environment variables set 
 - NO custom `.asdfrc` file
 
 would result in the following outcomes:


### PR DESCRIPTION
# Summary

This variable forces the prepending of the asdf directories to the PATH variable. It does this by removing existing asdf entries in PATH, including an optimization for Bash and Zsh shells.

Fixes #1550
