### PR TITLE
fix: Print warning if `.tool-versions` or asdfrc contains carriage returns

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -373,6 +373,8 @@ get_asdf_config_value_from_file() {
     return 1
   fi
 
+  util_validate_no_carriage_returns "$config_path"
+
   local result
   result=$(grep -E "^\s*$key\s*=\s*" "$config_path" | head | sed -e 's/^[^=]*= *//' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
   if [ -n "$result" ]; then
@@ -465,6 +467,8 @@ find_file_upwards() {
   search_path=$PWD
   while [ "$search_path" != "/" ]; do
     if [ -f "$search_path/$name" ]; then
+      util_validate_no_carriage_returns "$search_path/$name"
+
       printf "%s\n" "${search_path}/$name"
       return 0
     fi
@@ -860,6 +864,15 @@ util_resolve_user_path() {
     util_resolve_user_path_reply="${HOME}/${path:2}"
   else
     util_resolve_user_path_reply="$path"
+  fi
+}
+
+# @description Check if a file contains carriage returns. If it does, print a warning.
+util_validate_no_carriage_returns() {
+  local file_path="$1"
+
+  if grep -qr $'\r' "$file_path"; then
+    printf '%s\n' "asdf: Warning: File $file_path contains carriage returns. Please remove them." >&2
   fi
 }
 

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -460,3 +460,16 @@ EOF
   [ "$status" -eq 0 ]
   [ "$output" = "$message" ]
 }
+
+@test "prints warning if .tool-versions file has carriage returns" {
+  ASDF_CONFIG_FILE="$BATS_TEST_TMPDIR/asdfrc"
+  cat >"$ASDF_CONFIG_FILE" <<<$'key2 = value2\r'
+
+  [[ "$(get_asdf_config_value "key1" 2>&1)" = *"contains carriage returns"* ]]
+}
+
+@test "prints if asdfrc config file has carriage returns" {
+  cat >".tool-versions" <<<$'nodejs 19.6.0\r'
+
+  [[ "$(find_tool_versions 2>&1)" = *"contains carriage returns"* ]]
+}


### PR DESCRIPTION
# Summary

Title. It was recommended in the linked issue to exit the program as well, but that was not attempted because there are various instances where the code could be ran in subshells (in which case, only the subshell will be exited).

Fixes #1476
