### PR TITLE
fix: Add ShellCheck directives to find sourced files

### DIFF
--- a/bin/asdf
+++ b/bin/asdf
@@ -95,11 +95,13 @@ asdf_cmd() {
     exec "$ASDF_CMD_FILE" "${@:${args_offset}}"
   elif [ -f "$ASDF_CMD_FILE" ]; then
     set -- "${@:${args_offset}}"
+    # shellcheck source=/dev/null
     . "$ASDF_CMD_FILE"
   else
     local asdf_cmd_dir
     asdf_cmd_dir="$(asdf_dir)/lib/commands"
     printf "%s\n" "Unknown command: \`asdf ${*}\`" >&2
+    # shellcheck source=lib/commands/command-help.bash
     . "$asdf_cmd_dir/command-help.bash" >&2
     return 127
   fi


### PR DESCRIPTION
# Summary

Looking at [CI runs](https://github.com/asdf-vm/asdf/actions/runs/5130651562/jobs/9229710004?pr=1566), it looks like the lack of these directives is causing linting to fail. ~~This suggests that on newer versions, ShellCheck bumped errors like [SC1091](https://www.shellcheck.net/wiki/SC1091) from info to error.~~

