### PR TITLE
fix(fish)!: don't resolve symlinks for ASDF_DIR

### DIFF
--- a/asdf.fish
+++ b/asdf.fish
@@ -1,5 +1,5 @@
 if test -z $ASDF_DIR
-    set ASDF_DIR (realpath (dirname (status filename)))
+    set ASDF_DIR (realpath --no-symlinks (dirname (status filename)))
 end
 set --export ASDF_DIR $ASDF_DIR
 


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

In the fish entry point, only make the ASDF_DIR path absolute, and don't resolve symlinks.

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->

Without this change, a `brew upgrade` causes all the shims to be broken.

When asdf is installed by homebrew, it is placed in a versioned directory and then symlinked to `/usr/local/opt/asdf`. If the symlink is resolved, ASDF_DIR contains the versioned directory. This is a problem because shims use the value of ASDF_DIR to get an absolute path to the asdf executable.

Not resolving symlinks is in line with the `asdf.sh` entry point.
