### PR TITLE
fix!: `plugin list` exit code 0 when no plugins are installed

### DIFF
--- a/lib/functions/plugins.bash
+++ b/lib/functions/plugins.bash
@@ -42,7 +42,7 @@ plugin_list_command() {
     ) | awk '{ if (NF > 1) { printf("%-28s", $1) ; $1="" }; print $0}'
   else
     display_error 'No plugins installed'
-    exit 1
+    exit 0
   fi
 }
 


### PR DESCRIPTION
# Summary

Closes #903

I do not consider this a breaking change because the fixed behavior falls into line with existing package managers. If one needs to test if no packages are installed, the better option is to parse standard output.