### PR TITLE
fix!: exit success when adding an already-added plugin

### DIFF
--- a/lib/functions/plugins.bash
+++ b/lib/functions/plugins.bash
@@ -79,8 +79,8 @@ plugin_add_command() {
   mkdir -p "$(asdf_data_dir)/plugins"
 
   if [ -d "$plugin_path" ]; then
-    display_error "Plugin named $plugin_name already added"
-    exit 2
+    printf '%s\n' "Plugin named $plugin_name already added"
+    exit 0
   else
     asdf_run_hook "pre_asdf_plugin_add" "$plugin_name"
     asdf_run_hook "pre_asdf_plugin_add_${plugin_name}"

--- a/test/plugin_add_command.bats
+++ b/test/plugin_add_command.bats
@@ -97,12 +97,12 @@ teardown() {
   [ "$output" = "dummy" ]
 }
 
-@test "plugin_add command with URL specified run twice returns error second time" {
+@test "plugin_add command with URL specified twice returns success on second time" {
   install_mock_plugin_repo "dummy"
 
   run asdf plugin add "dummy" "${BASE_DIR}/repo-dummy"
   run asdf plugin add "dummy" "${BASE_DIR}/repo-dummy"
-  [ "$status" -eq 2 ]
+  [ "$status" -eq 0 ]
   [ "$output" = "Plugin named dummy already added" ]
 }
 


### PR DESCRIPTION
# Summary

Closes #841 

I do not consider this a breaking change because the fixed behavior does not break currently existing scripts that have the workaround (ie `(exit 2) || :` has the same affect as `(exit 0) || :`)
