### PR TITLE
fix: Pass filter expression to `asdf local` command

### DIFF
--- a/lib/functions/versions.bash
+++ b/lib/functions/versions.bash
@@ -34,6 +34,11 @@ version_command() {
 
   check_if_plugin_exists "$plugin_name"
 
+  if ((${#versions[@]} == 2)); then
+    versions[0]="${versions[0]}:${versions[1]}"
+    unset "versions[$((${#versions[@]} - 1))]" # Remove last element in array
+  fi
+
   declare -a resolved_versions
   local item
   for item in "${!versions[@]}"; do


### PR DESCRIPTION
# Summary

Closes #1410

I tested `asdf global ...`, and that that worked fine. Only `asdf local` needed updating.

```sh
[edwin@nullptr ~/Docs/Programming/Repositories/git/asdf]$ asdf local nodejs latest 16 # before
version 16 is not installed for nodejs
[edwin@nullptr ~/Docs/Programming/Repositories/git/asdf]$ asdf local nodejs latest 16 # after
version 16.20.1 is not installed for nodejs
```
