### PR TITLE
fix: improve lint and test scripts

### DIFF
--- a/scripts/install_dependencies.bash
+++ b/scripts/install_dependencies.bash
@@ -18,7 +18,7 @@ if [ -z "$RUNNER_OS" ]; then
   exit 1
 fi
 
-### Set environment variables for tracking versions
+### Set variables for tracking versions
 # Elvish
 elvish_semver="v0.19.2"
 # Fish
@@ -73,5 +73,6 @@ fi
 
 ### Install bats-core
 printf "%s\n" "Installing bats-core"
-git clone --depth 1 --branch "v$(grep -Eo "^\\s*bats\\s*.*$" ".tool-versions" | cut -d ' ' -f2-)" https://github.com/bats-core/bats-core.git "$HOME/bats-core"
+bats_version=$(grep -Eo "^\\s*bats\\s*.*$" ".tool-versions" | cut -d ' ' -f2-)
+git clone --depth 1 --branch "v$bats_version" https://github.com/bats-core/bats-core.git "$HOME/bats-core"
 echo "$HOME/bats-core/bin" >>"$GITHUB_PATH"

--- a/scripts/test.bash
+++ b/scripts/test.bash
@@ -3,26 +3,37 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-repo_root=$(git rev-parse --show-toplevel)
-if [ "$repo_root" != "$PWD" ]; then
-  printf "%s\n" "[ERROR] This scripts requires execution from the repository root directory."
-  printf "\t%s\t%s\n" "Repo root dir:" "$repo_root"
-  printf "\t%s\t%s\n\n" "Current dir:" "$PWD"
-  exit 1
-fi
+print.info() {
+  printf '[INFO] %s\n' "$1"
+}
 
-test_directory="test"
+print.error() {
+  printf '[ERROR] %s\n' "$1" >&2
+}
+
+{
+  repo_dir=$(git rev-parse --show-toplevel)
+  current_dir=$(pwd -P)
+  if [ "$repo_dir" != "$current_dir" ]; then
+    print.error "This scripts requires execution from the repository root directory."
+    printf "\t%s\t%s\n" "Repo root dir:" "$repo_dir"
+    printf "\t%s\t%s\n\n" "Current dir:" "$current_dir"
+    exit 1
+  fi
+}
+
+test_directory="./test"
 bats_options=(--timing --print-output-on-failure)
 
 if command -v parallel >/dev/null; then
-  # enable parallel jobs
-  bats_options=("${bats_options[@]}" --jobs 2 --no-parallelize-within-files)
+  # Enable parallel jobs
+  bats_options+=(--jobs 2 --no-parallelize-within-files)
 elif [[ -n "${CI-}" ]]; then
-  printf "* %s\n" "GNU parallel should be installed in the CI environment. Please install and rerun the test suite."
+  print.error "GNU parallel should be installed in the CI environment. Please install and rerun the test suite."
   exit 1
 else
-  printf "* %s\n" "For faster test execution, install GNU parallel."
+  print.info "For faster test execution, install GNU parallel."
 fi
 
-printf "* %s\n" "Running Bats in directory '${test_directory}' with options:" "${bats_options[@]}"
+print.info "Running Bats in directory '${test_directory}' with options:" "${bats_options[@]}"
 bats "${bats_options[@]}" "${test_directory}"


### PR DESCRIPTION
# Summary

- Makes prints semantically dry
- Use physical directory when comparing to see if script is running in `asdf` repository. (Unfortunately `set -o physical` does not work with `$PWD`)
- Other small fixes