### PR TITLE
fix: nushell integration after nushell language change

### DIFF
--- a/asdf.nu
+++ b/asdf.nu
@@ -1,15 +1,13 @@
 def-env configure-asdf [] {
+    let ASDF_DIR  = ($env.HOME | path join ".asdf")
 
-    let-env ASDF_DIR = ( if ( $env | get --ignore-errors ASDF_DIR | is-empty ) { $env.ASDF_NU_DIR } else { $env.ASDF_DIR } )
+    ## Binary
+    let BIN_DIR = ($ASDF_DIR | path join "bin")
+    $env.PATH = ($env.PATH | where { |p| $p != $BIN_DIR } | append $BIN_DIR)
 
-    let shims_dir = ( if ( $env | get --ignore-errors ASDF_DATA_DIR | is-empty ) { $env.HOME | path join '.asdf' } else { $env.ASDF_DIR } | path join 'shims' )
-
-    let asdf_bin_dir = ( $env.ASDF_DIR | path join 'bin' )
-
-
-    let-env PATH = ( $env.PATH | split row (char esep) | where { |p| $p != $shims_dir } | prepend $shims_dir )
-    let-env PATH = ( $env.PATH | split row (char esep) | where { |p| $p != $asdf_bin_dir } | prepend $asdf_bin_dir )
-
+    ## Shims
+    let SHIMS_DIR = ($ASDF_DIR | path join "shims")
+    $env.PATH = ($env.PATH | where { |p| $p != $SHIMS_DIR } | append $SHIMS_DIR)
 }
 
 configure-asdf

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -301,7 +301,6 @@ Add `asdf.nu` to your `~/.config/nushell/config.nu` with:
 
 ```shell
 source "/home/$HOME/.asdf/asdf.nu"
-use asdf *
 ```
 
 Remember to change `$HOME` to your username. Completions are automatically configured.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -300,10 +300,11 @@ Add the following to `~/.config/powershell/profile.ps1`:
 Add `asdf.nu` to your `~/.config/nushell/config.nu` with:
 
 ```shell
-"\nlet-env ASDF_NU_DIR = ($env.HOME | path join '.asdf')\n source " + ($env.HOME | path join '.asdf/asdf.nu') | save --append $nu.config-path
+source "/home/$HOME/.asdf/asdf.nu"
+use asdf *
 ```
 
-Completions are automatically configured
+Remember to change `$HOME` to your username. Completions are automatically configured.
 :::
 
 ::: details Nushell & Homebrew

--- a/docs/pt-br/guide/getting-started.md
+++ b/docs/pt-br/guide/getting-started.md
@@ -298,7 +298,6 @@ Adicione `asdf.nu` ao seu `~/.config/nushell/config.nu` através do comando:
 
 ```shell
 source "/home/$HOME/.asdf/asdf.nu"
-use asdf *
 ```
 
 Lembre-se de modificiar `$HOME` para seu nome de usuário. O autocomplete já vem configurado.

--- a/docs/pt-br/guide/getting-started.md
+++ b/docs/pt-br/guide/getting-started.md
@@ -297,10 +297,11 @@ Adicione a seguinte linha ao seu `~/.config/powershell/profile.ps1`:
 Adicione `asdf.nu` ao seu `~/.config/nushell/config.nu` através do comando:
 
 ```shell
-"\nlet-env ASDF_NU_DIR = ($env.HOME | path join '.asdf')\n source " + ($env.HOME | path join '.asdf/asdf.nu') | save --append $nu.config-path
+source "/home/$HOME/.asdf/asdf.nu"
+use asdf *
 ```
 
-Ao concluir atualizará automaticamente
+Lembre-se de modificiar `$HOME` para seu nome de usuário. O autocomplete já vem configurado.
 :::
 
 ::: details Nushell & Homebrew


### PR DESCRIPTION
# Summary

I encountered an issue while setting up asdf in my Nushell. The error message stated that the `let-env` call is deprecated and should be replaced with `$env.<environment variable>`. I noticed that the Nushell [documentation](https://www.nushell.sh/cookbook/setup.html) has not been updated to reflect this change. To resolve this issue, I made the necessary changes and improvements to the `Nushell & Git` documentation in the getting started section for both English and Brazilian users.

This pull request addresses the following:

1. Replaces all instances of `let-env` with `$env.PATH` to fix the deprecation issue.
2. Improved the Nushell & Git documentation to reflect the correct usage for setting environment variables. I don't have macOS or Arch, so I didn't change the respective documentation.

Fixes: #1609

## Changes Made

- Replaced all `let-env` calls with `$env.PATH` to comply with the deprecation.
![Captura de tela 2023-07-31 012713](https://github.com/asdf-vm/asdf/assets/107213601/e2df9ec6-7589-4d07-811d-1ff1ea263ace)
- Updated the `Nushell & Git` documentation in the getting started section for both English and Brazilian users.

Thank you for considering this pull request. I'm looking forward to your feedback!
