### PR TITLE
fix: nushell language syntax update

### DIFF
--- a/asdf.nu
+++ b/asdf.nu
@@ -1,11 +1,12 @@
 def-env configure-asdf [] {
 
+    $env.ASDF_NU_DIR = (brew --prefix asdf | str trim | into string | path join 'libexec')
+
     $env.ASDF_DIR = ( if ( $env | get --ignore-errors ASDF_DIR | is-empty ) { $env.ASDF_NU_DIR } else { $env.ASDF_DIR } )
 
     let shims_dir = ( if ( $env | get --ignore-errors ASDF_DATA_DIR | is-empty ) { $env.HOME | path join '.asdf' } else { $env.ASDF_DIR } | path join 'shims' )
 
     let asdf_bin_dir = ( $env.ASDF_DIR | path join 'bin' )
-
 
     $env.PATH = ( $env.PATH | split row (char esep) | where { |p| $p != $shims_dir } | prepend $shims_dir )
     $env.PATH = ( $env.PATH | split row (char esep) | where { |p| $p != $asdf_bin_dir } | prepend $asdf_bin_dir )

--- a/asdf.nu
+++ b/asdf.nu
@@ -1,14 +1,14 @@
 def-env configure-asdf [] {
 
-    let-env ASDF_DIR = ( if ( $env | get --ignore-errors ASDF_DIR | is-empty ) { $env.ASDF_NU_DIR } else { $env.ASDF_DIR } )
+    $env.ASDF_DIR = ( if ( $env | get --ignore-errors ASDF_DIR | is-empty ) { $env.ASDF_NU_DIR } else { $env.ASDF_DIR } )
 
     let shims_dir = ( if ( $env | get --ignore-errors ASDF_DATA_DIR | is-empty ) { $env.HOME | path join '.asdf' } else { $env.ASDF_DIR } | path join 'shims' )
 
     let asdf_bin_dir = ( $env.ASDF_DIR | path join 'bin' )
 
 
-    let-env PATH = ( $env.PATH | split row (char esep) | where { |p| $p != $shims_dir } | prepend $shims_dir )
-    let-env PATH = ( $env.PATH | split row (char esep) | where { |p| $p != $asdf_bin_dir } | prepend $asdf_bin_dir )
+    $env.PATH = ( $env.PATH | split row (char esep) | where { |p| $p != $shims_dir } | prepend $shims_dir )
+    $env.PATH = ( $env.PATH | split row (char esep) | where { |p| $p != $asdf_bin_dir } | prepend $asdf_bin_dir )
 
 }
 

--- a/asdf.nu
+++ b/asdf.nu
@@ -1,6 +1,6 @@
 def-env configure-asdf [] {
 
-    $env.ASDF_NU_DIR = (brew --prefix asdf | str trim | into string | path join 'libexec')
+    ## $env.ASDF_NU_DIR = (brew --prefix asdf | str trim | into string | path join 'libexec')
 
     $env.ASDF_DIR = ( if ( $env | get --ignore-errors ASDF_DIR | is-empty ) { $env.ASDF_NU_DIR } else { $env.ASDF_DIR } )
 

--- a/asdf.nu
+++ b/asdf.nu
@@ -1,7 +1,5 @@
 def-env configure-asdf [] {
 
-    ## $env.ASDF_NU_DIR = (brew --prefix asdf | str trim | into string | path join 'libexec')
-
     $env.ASDF_DIR = ( if ( $env | get --ignore-errors ASDF_DIR | is-empty ) { $env.ASDF_NU_DIR } else { $env.ASDF_DIR } )
 
     let shims_dir = ( if ( $env | get --ignore-errors ASDF_DATA_DIR | is-empty ) { $env.HOME | path join '.asdf' } else { $env.ASDF_DIR } | path join 'shims' )

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -300,7 +300,7 @@ Add the following to `~/.config/powershell/profile.ps1`:
 Add `asdf.nu` to your `~/.config/nushell/config.nu` with:
 
 ```shell
-"\nlet-env ASDF_NU_DIR = ($env.HOME | path join '.asdf')\n source " + ($env.HOME | path join '.asdf/asdf.nu') | save --append $nu.config-path
+"\n$env.ASDF_NU_DIR = ($env.HOME | path join '.asdf')\n source " + ($env.HOME | path join '.asdf/asdf.nu') | save --append $nu.config-path
 ```
 
 Completions are automatically configured
@@ -311,7 +311,7 @@ Completions are automatically configured
 Add `asdf.nu` to your `~/.config/nushell/config.nu` with:
 
 ```shell
-"\nlet-env ASDF_NU_DIR = (brew --prefix asdf | str trim | into string | path join 'libexec')\n source " +  (brew --prefix asdf | into string | path join 'libexec/asdf.nu') | save --append $nu.config-path
+"\n$env.ASDF_NU_DIR = (brew --prefix asdf | str trim | into string | path join 'libexec')\n source " +  (brew --prefix asdf | into string | path join 'libexec/asdf.nu') | save --append $nu.config-path
 ```
 
 Completions are automatically configured
@@ -322,7 +322,7 @@ Completions are automatically configured
 Add `asdf.nu` to your `~/.config/nushell/config.nu` with:
 
 ```shell
-"\nlet-env ASDF_NU_DIR = '/opt/asdf-vm/'\n source /opt/asdf-vm/asdf.nu" | save --append $nu.config-path
+"\n$env.ASDF_NU_DIR = '/opt/asdf-vm/'\n source /opt/asdf-vm/asdf.nu" | save --append $nu.config-path
 ```
 
 Completions are automatically configured.

--- a/docs/pt-br/guide/getting-started.md
+++ b/docs/pt-br/guide/getting-started.md
@@ -297,7 +297,7 @@ Adicione a seguinte linha ao seu `~/.config/powershell/profile.ps1`:
 Adicione `asdf.nu` ao seu `~/.config/nushell/config.nu` através do comando:
 
 ```shell
-"\nlet-env ASDF_NU_DIR = ($env.HOME | path join '.asdf')\n source " + ($env.HOME | path join '.asdf/asdf.nu') | save --append $nu.config-path
+"\n$env.ASDF_NU_DIR = ($env.HOME | path join '.asdf')\n source " + ($env.HOME | path join '.asdf/asdf.nu') | save --append $nu.config-path
 ```
 
 Ao concluir atualizará automaticamente
@@ -308,7 +308,7 @@ Ao concluir atualizará automaticamente
 Adicione `asdf.nu` ao seu `~/.config/nushell/config.nu` através do comando:
 
 ```shell
-"\nlet-env ASDF_NU_DIR = (brew --prefix asdf | str trim | into string | path join 'libexec')\n source " +  (brew --prefix asdf | into string | path join 'libexec/asdf.nu') | save --append $nu.config-path
+"\n$env.ASDF_NU_DIR = (brew --prefix asdf | str trim | into string | path join 'libexec')\n source " +  (brew --prefix asdf | into string | path join 'libexec/asdf.nu') | save --append $nu.config-path
 ```
 
 Ao concluir atualizará automaticamente
@@ -319,7 +319,7 @@ Ao concluir atualizará automaticamente
 Adicione `asdf.nu` ao seu `~/.config/nushell/config.nu` através do comando:
 
 ```shell
-"\nlet-env ASDF_NU_DIR = '/opt/asdf-vm/'\n source /opt/asdf-vm/asdf.nu" | save --append $nu.config-path
+"\n$env.ASDF_NU_DIR = '/opt/asdf-vm/'\n source /opt/asdf-vm/asdf.nu" | save --append $nu.config-path
 ```
 
 Ao concluir atualizará automaticamente

--- a/docs/zh-hans/guide/getting-started.md
+++ b/docs/zh-hans/guide/getting-started.md
@@ -298,7 +298,7 @@ echo -e "\n. \"$(brew --prefix asdf)/libexec/asdf.ps1\"" >> ~/.config/powershell
 使用以下命令将 `asdf.nu` 加入到 `~/.config/nushell/config.nu` 文件中：
 
 ```shell
-"\nlet-env ASDF_NU_DIR = ($env.HOME | path join '.asdf')\n source " + ($env.HOME | path join '.asdf/asdf.nu') | save --append $nu.config-path
+"\n$env.ASDF_NU_DIR = ($env.HOME | path join '.asdf')\n source " + ($env.HOME | path join '.asdf/asdf.nu') | save --append $nu.config-path
 ```
 
 补全功能将会自动配置。
@@ -309,7 +309,7 @@ echo -e "\n. \"$(brew --prefix asdf)/libexec/asdf.ps1\"" >> ~/.config/powershell
 使用以下命令将 `asdf.nu` 加入到 `~/.config/nushell/config.nu` 文件中:
 
 ```shell
-"\nlet-env ASDF_NU_DIR = (brew --prefix asdf | str trim | into string | path join 'libexec')\n source " +  (brew --prefix asdf | into string | path join 'libexec/asdf.nu') | save --append $nu.config-path
+"\n$env.ASDF_NU_DIR = (brew --prefix asdf | str trim | into string | path join 'libexec')\n source " +  (brew --prefix asdf | into string | path join 'libexec/asdf.nu') | save --append $nu.config-path
 ```
 
 补全功能将会自动配置。
@@ -320,7 +320,7 @@ echo -e "\n. \"$(brew --prefix asdf)/libexec/asdf.ps1\"" >> ~/.config/powershell
 使用以下命令将 `asdf.nu` 加入到 `~/.config/nushell/config.nu` 文件中:
 
 ```shell
-"\nlet-env ASDF_NU_DIR = '/opt/asdf-vm/'\n source /opt/asdf-vm/asdf.nu" | save --append $nu.config-path
+"\n$env.ASDF_NU_DIR = '/opt/asdf-vm/'\n source /opt/asdf-vm/asdf.nu" | save --append $nu.config-path
 ```
 
 补全功能将会自动配置。

--- a/scripts/install_dependencies.bash
+++ b/scripts/install_dependencies.bash
@@ -25,7 +25,7 @@ elvish_semver="v0.19.2"
 fish_semver="3.6.1"
 fish_apt_semver="${fish_semver}-1~jammy"
 # Nushell
-nushell_semver="0.78.0"
+nushell_semver="0.84.0"
 # Powershell
 powershell_semver="7.3.3"
 powershell_apt_semver="${powershell_semver}-1.deb"

--- a/test/asdf_nu.bats
+++ b/test/asdf_nu.bats
@@ -25,8 +25,8 @@ run_nushell() {
   run nu -c "
     hide-env -i asdf
     hide-env -i ASDF_DIR
-    let-env PATH = ( '$(cleaned_path)' | split row ':' )
-    let-env ASDF_NU_DIR = '$PWD'
+    \$env.PATH = ( '$(cleaned_path)' | split row ':' )
+    \$env.ASDF_NU_DIR = '$PWD'
 
     source asdf.nu
     $1"
@@ -63,9 +63,9 @@ run_nushell() {
 @test "retains ASDF_DIR" {
   run nu -c "
     hide-env -i asdf
-    let-env ASDF_DIR = ( pwd )
-    let-env PATH = ( '$(cleaned_path)' | split row ':' )
-    let-env ASDF_NU_DIR = '$PWD'
+    \$env.ASDF_DIR = ( pwd )
+    \$env.PATH = ( '$(cleaned_path)' | split row ':' )
+    \$env.ASDF_NU_DIR = '$PWD'
 
     source asdf.nu
 


### PR DESCRIPTION
# Summary

Nushell integration is broken because of the deprecated `let-env`, see https://www.nushell.sh/commands/docs/let-env.html#frontmatter-title-for-removed for details.

Fixes: #1609 

## Other Information

There is already pull request #1610 that does not seem to be worked on at the moment.

Manual testing on my MacBook M1 worked. I tried running the automated test suite, but there were too many unrelated errors. I hope your CI will tell us whether I did everything right.

Linting worked.