### PR TITLE
ci: use dependabot groups for `docs/` dependency PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,7 @@ updates:
       interval: "monthly"
     reviewers:
       - "jthegedus"
+    groups:
+      docs:
+        patterns:
+          - "*"


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

This will group Dependabot updates for all changes to the `docs/` `npm` dependencies into a single PR per month.

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->
