### PR TITLE
fix(fish): use builtin realpath over system one

### DIFF
--- a/asdf.fish
+++ b/asdf.fish
@@ -1,5 +1,5 @@
 if test -z $ASDF_DIR
-    set ASDF_DIR (realpath --no-symlinks (dirname (status filename)))
+    set ASDF_DIR (builtin realpath --no-symlinks (dirname (status filename)))
 end
 set --export ASDF_DIR $ASDF_DIR
 


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

Fixes the issue raised in a PR comment here: https://github.com/asdf-vm/asdf/pull/1583#issuecomment-1714212545

Fish treats their `realpath` builtin as a fallback in case a system version doesn't exist. Not all versions of `realpath` support the `--no-symlinks` flag, which `asdf.fish` uses. This PR ensures that the builtin version of `realpath` is always used.

## Other Information

Just as a note for posterity, the `--no-symlinks` flag for the builtin `realpath` was added in fish 3.2.0, released in March 1, 2021. 2 years old is good, but some slower Linux distros may lack support. If that proves to be a problem, then perhaps a different solution can be found. I think long term though the builtin will offer the best support across different systems.

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->
