### PR TITLE
fix: plugin extension commands to not require `bin/` directory

### DIFF
--- a/bin/asdf
+++ b/bin/asdf
@@ -48,15 +48,13 @@ find_asdf_cmd() {
 
 find_plugin_cmd() {
   local ASDF_CMD_FILE args_offset
-  if [ -d "$(get_plugin_path "$1")/bin" ]; then
-    local result=
-    result="$(find_cmd "$(get_plugin_path "$1")/lib/commands" "${@:2}")"
-    ASDF_CMD_FILE=${result% *}
-    args_offset=${result##* }
-    if [ -n "$ASDF_CMD_FILE" ]; then
-      args_offset=$((args_offset + 1)) # since the first argument is the plugin name
-      printf "%s %s\n" "$ASDF_CMD_FILE" "$args_offset"
-    fi
+  local result=
+  result="$(find_cmd "$(get_plugin_path "$1")/lib/commands" "${@:2}")"
+  ASDF_CMD_FILE=${result% *}
+  args_offset=${result##* }
+  if [ -n "$ASDF_CMD_FILE" ]; then
+    args_offset=$((args_offset + 1)) # since the first argument is the plugin name
+    printf "%s %s\n" "$ASDF_CMD_FILE" "$args_offset"
   fi
 }
 


### PR DESCRIPTION
# Summary

This is a bug.

Closes #726
Closes #1365 (duplicate)
Closes #729 (duplicate, solved, stale)