### PR TITLE
refactor: Prefer grep's `--quiet` over standard output redirection

### DIFF
--- a/lib/commands/command-plugin-test.bash
+++ b/lib/commands/command-plugin-test.bash
@@ -79,7 +79,7 @@ plugin_test_command() {
     fi
 
     # shellcheck disable=SC2119
-    if ! (plugin_list_command | grep "^$plugin_name$" >/dev/null); then
+    if ! (plugin_list_command | grep -q "^$plugin_name$"); then
       fail_test "$plugin_name was not properly installed"
     fi
 
@@ -90,8 +90,8 @@ plugin_test_command() {
     local plugin_path
     plugin_path=$(get_plugin_path "$plugin_name")
     local list_all="$plugin_path/bin/list-all"
-    if grep api.github.com "$list_all" >/dev/null; then
-      if ! grep Authorization "$list_all" >/dev/null; then
+    if grep -q api.github.com "$list_all"; then
+      if ! grep -q Authorization "$list_all"; then
         printf "\nLooks like %s/bin/list-all relies on GitHub releases\n" "$plugin_name"
         printf "but it does not properly sets an Authorization header to prevent\n"
         printf "GitHub API rate limiting.\n\n"

--- a/lib/commands/reshim.bash
+++ b/lib/commands/reshim.bash
@@ -18,7 +18,7 @@ remove_shim_for_version() {
   sed -i.bak -e "/# asdf-plugin: $plugin_name $version"'$/d' "$shim_path"
   rm "$shim_path".bak
 
-  if ! grep "# asdf-plugin:" "$shim_path" >/dev/null ||
+  if ! grep -q "# asdf-plugin:" "$shim_path" ||
     [ "$count_installed" -eq 0 ]; then
     rm -f "$shim_path"
   fi

--- a/lib/functions/versions.bash
+++ b/lib/functions/versions.bash
@@ -60,7 +60,7 @@ version_command() {
     resolved_versions+=("$version")
   done
 
-  if [ -f "$file" ] && grep "^$plugin_name " "$file" >/dev/null; then
+  if [ -f "$file" ] && grep -q "^$plugin_name " "$file"; then
     local temp_dir
     temp_dir=${TMPDIR:-/tmp}
 


### PR DESCRIPTION
# Summary

`--quiet` is an improvement over `>/dev/null` when checking the exit code to check for a string's existence. Using the former better ensures grep does not return an exit code that is unrelated to condition that a substring or regex is contained within a target string (which is the actual semantics of these particular command executions).

## Other

- Closes #1584 (personal configuration issue)
- Closes #1651 should be moved to `asdf-python`