### PR TITLE
fix: asdf not working when bin is symlinked

### DIFF
--- a/bin/asdf
+++ b/bin/asdf
@@ -1,8 +1,47 @@
 #!/usr/bin/env bash
 set -o pipefail
 
+if type -p realpath > /dev/null; then
+  absdir() {
+    local path
+    path="$(realpath "$1")"
+    printf "%s\n" "${path%/*}"
+  }
+elif test -n "$(type -p greadlink readlink | head -1)"; then
+  absdir() {
+    local name path readlink
+    path="$1"
+    readlink="$(type -p greadlink readlink | head -1)"
+    (
+      while [ -n "${path}" ]; do
+        pathdir="${path%/*}"
+        if [ "${pathdir}" != "${path}" ]; then
+          cd "${pathdir}" || exit 1
+        fi
+        name="${path##*/}"
+        path="$($readlink "${name}")"
+      done
+      printf "%s\n" "${PWD}"
+    )
+  }
+else
+  printf "Unable to find readlink or realpath" >&2
+  exit 1
+fi
+
+asdf_dir() {
+  if [ -z "$ASDF_DIR" ]; then
+    local bin_dir root_dir
+    bin_dir="$(absdir "${BASH_SOURCE[0]}")"
+    root_dir="${bin_dir%/*}"
+    printf '%s\n' "$root_dir"
+  else
+    printf '%s\n' "$ASDF_DIR"
+  fi
+}
+
 # shellcheck source=lib/utils.bash
-. "$(dirname "$(dirname "$0")")/lib/utils.bash"
+. "$(asdf_dir)/lib/utils.bash"
 
 find_cmd() {
   local cmd_dir="$1"

--- a/lib/commands/command-current.bash
+++ b/lib/commands/command-current.bash
@@ -1,6 +1,6 @@
 # -*- sh -*-
 # shellcheck source=lib/functions/plugins.bash
-. "$(dirname "$(dirname "$0")")/lib/functions/plugins.bash"
+. "$(asdf_dir)/lib/functions/plugins.bash"
 
 # shellcheck disable=SC2059
 plugin_current_command() {

--- a/lib/commands/command-export-shell-version.bash
+++ b/lib/commands/command-export-shell-version.bash
@@ -1,6 +1,6 @@
 # -*- sh -*-
 # shellcheck source=lib/functions/versions.bash
-. "$(dirname "$(dirname "$0")")/lib/functions/versions.bash"
+. "$(asdf_dir)/lib/functions/versions.bash"
 
 # Output from this command must be executable shell code
 shell_command() {

--- a/lib/commands/command-help.bash
+++ b/lib/commands/command-help.bash
@@ -1,6 +1,6 @@
 # -*- sh -*-
 # shellcheck source=lib/functions/versions.bash
-. "$(dirname "$(dirname "$0")")/lib/functions/versions.bash"
+. "$(asdf_dir)/lib/functions/versions.bash"
 
 asdf_help() {
   printf "version: %s\n\n" "$(asdf_version)"

--- a/lib/commands/command-info.bash
+++ b/lib/commands/command-info.bash
@@ -1,6 +1,6 @@
 # -*- sh -*-
 # shellcheck source=lib/functions/plugins.bash
-. "$(dirname "$(dirname "$0")")/lib/functions/plugins.bash"
+. "$(asdf_dir)/lib/functions/plugins.bash"
 
 info_command() {
   printf "%s:\n%s\n\n" "OS" "$(uname -a)"

--- a/lib/commands/command-install.bash
+++ b/lib/commands/command-install.bash
@@ -1,9 +1,9 @@
 # -*- sh -*-
 # shellcheck source=lib/functions/versions.bash
-. "$(dirname "$(dirname "$0")")/lib/functions/versions.bash"
+. "$(asdf_dir)/lib/functions/versions.bash"
 # shellcheck source=lib/commands/reshim.bash
 . "$(dirname "$ASDF_CMD_FILE")/reshim.bash"
 # shellcheck source=lib/functions/installs.bash
-. "$(dirname "$(dirname "$0")")/lib/functions/installs.bash"
+. "$(asdf_dir)/lib/functions/installs.bash"
 
 install_command "$@"

--- a/lib/commands/command-latest.bash
+++ b/lib/commands/command-latest.bash
@@ -1,5 +1,5 @@
 # -*- sh -*-
 # shellcheck source=lib/functions/versions.bash
-. "$(dirname "$(dirname "$0")")/lib/functions/versions.bash"
+. "$(asdf_dir)/lib/functions/versions.bash"
 
 latest_command "$@"

--- a/lib/commands/command-list-all.bash
+++ b/lib/commands/command-list-all.bash
@@ -1,5 +1,5 @@
 # -*- sh -*-
 # shellcheck source=lib/functions/versions.bash
-. "$(dirname "$(dirname "$0")")/lib/functions/versions.bash"
+. "$(asdf_dir)/lib/functions/versions.bash"
 
 list_all_command "$@"

--- a/lib/commands/command-plugin-add.bash
+++ b/lib/commands/command-plugin-add.bash
@@ -1,5 +1,5 @@
 # -*- sh -*-
 # shellcheck source=lib/functions/plugins.bash
-. "$(dirname "$(dirname "$0")")/lib/functions/plugins.bash"
+. "$(asdf_dir)/lib/functions/plugins.bash"
 
 plugin_add_command "$@"

--- a/lib/commands/command-plugin-list.bash
+++ b/lib/commands/command-plugin-list.bash
@@ -1,5 +1,5 @@
 # -*- sh -*-
 # shellcheck source=lib/functions/plugins.bash
-. "$(dirname "$(dirname "$0")")/lib/functions/plugins.bash"
+. "$(asdf_dir)/lib/functions/plugins.bash"
 
 plugin_list_command "$@"

--- a/lib/commands/command-plugin-test.bash
+++ b/lib/commands/command-plugin-test.bash
@@ -1,12 +1,12 @@
 # -*- sh -*-
 # shellcheck source=lib/functions/versions.bash
-. "$(dirname "$(dirname "$0")")/lib/functions/versions.bash"
+. "$(asdf_dir)/lib/functions/versions.bash"
 # shellcheck source=lib/functions/plugins.bash
-. "$(dirname "$(dirname "$0")")/lib/functions/plugins.bash"
+. "$(asdf_dir)/lib/functions/plugins.bash"
 # shellcheck source=lib/commands/reshim.bash
 . "$(dirname "$ASDF_CMD_FILE")/reshim.bash"
 # shellcheck source=lib/functions/installs.bash
-. "$(dirname "$(dirname "$0")")/lib/functions/installs.bash"
+. "$(asdf_dir)/lib/functions/installs.bash"
 
 plugin_test_command() {
 

--- a/lib/commands/command-plugin-update.bash
+++ b/lib/commands/command-plugin-update.bash
@@ -1,5 +1,5 @@
 # -*- sh -*-
 # shellcheck source=lib/functions/plugins.bash
-. "$(dirname "$(dirname "$0")")/lib/functions/plugins.bash"
+. "$(asdf_dir)/lib/functions/plugins.bash"
 
 plugin_update_command "$@"

--- a/lib/commands/version_commands.bash
+++ b/lib/commands/version_commands.bash
@@ -1,3 +1,3 @@
 # -*- sh -*-
 # shellcheck source=lib/functions/versions.bash
-. "$(dirname "$(dirname "$0")")/lib/functions/versions.bash"
+. "$(asdf_dir)/lib/functions/versions.bash"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -38,18 +38,6 @@ asdf_data_dir() {
   printf "%s\n" "$data_dir"
 }
 
-asdf_dir() {
-  if [ -z "$ASDF_DIR" ]; then
-    local current_script_path=${BASH_SOURCE[0]}
-    printf '%s\n' "$(
-      cd -- "$(dirname "$(dirname "$current_script_path")")" || exit
-      printf '%s\n' "$PWD"
-    )"
-  else
-    printf '%s\n' "$ASDF_DIR"
-  fi
-}
-
 asdf_plugin_repository_url() {
   printf "https://github.com/asdf-vm/asdf-plugins.git\n"
 }


### PR DESCRIPTION
# Summary

This PR seeks to add support for resolving `asdf_dir` when `bin/asdf` is symlinked to a non-standard location.

Fixes: #1657

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->
