### PR TITLE
fix: Avoid mention of `ASDF_NU_DIR`

### DIFF
--- a/asdf.nu
+++ b/asdf.nu
@@ -1,14 +1,27 @@
 def-env configure-asdf [] {
+    $env.ASDF_DIR = (
+      if ($env | get --ignore-errors ASDF_NU_DIR | is-empty) == false {
+        $env.ASDF_NU_DIR
+      }
+      else if ($env | get --ignore-errors ASDF_DIR | is-empty) == false {
+        $env.ASDF_DIR
+      } else {
+        print --stderr "asdf: Either ASDF_NU_DIR or ASDF_DIR must not be empty"
+        return
+      }
+    )
 
-    $env.ASDF_DIR = ( if ( $env | get --ignore-errors ASDF_DIR | is-empty ) { $env.ASDF_NU_DIR } else { $env.ASDF_DIR } )
-
-    let shims_dir = ( if ( $env | get --ignore-errors ASDF_DATA_DIR | is-empty ) { $env.HOME | path join '.asdf' } else { $env.ASDF_DIR } | path join 'shims' )
-
+    let shims_dir = (
+      if ( $env | get --ignore-errors ASDF_DATA_DIR | is-empty ) {
+        $env.HOME | path join '.asdf'
+      } else {
+        $env.ASDF_DIR
+      } | path join 'shims'
+    )
     let asdf_bin_dir = ( $env.ASDF_DIR | path join 'bin' )
 
     $env.PATH = ( $env.PATH | split row (char esep) | where { |p| $p != $shims_dir } | prepend $shims_dir )
     $env.PATH = ( $env.PATH | split row (char esep) | where { |p| $p != $asdf_bin_dir } | prepend $asdf_bin_dir )
-
 }
 
 configure-asdf

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -300,7 +300,7 @@ Add the following to `~/.config/powershell/profile.ps1`:
 Add `asdf.nu` to your `~/.config/nushell/config.nu` with:
 
 ```shell
-"\n$env.ASDF_NU_DIR = ($env.HOME | path join '.asdf')\n source " + ($env.HOME | path join '.asdf/asdf.nu') | save --append $nu.config-path
+"\n$env.ASDF_DIR = ($env.HOME | path join '.asdf')\n source " + ($env.HOME | path join '.asdf/asdf.nu') | save --append $nu.config-path
 ```
 
 Completions are automatically configured
@@ -311,7 +311,7 @@ Completions are automatically configured
 Add `asdf.nu` to your `~/.config/nushell/config.nu` with:
 
 ```shell
-"\n$env.ASDF_NU_DIR = (brew --prefix asdf | str trim | into string | path join 'libexec')\n source " +  (brew --prefix asdf | into string | path join 'libexec/asdf.nu') | save --append $nu.config-path
+"\n$env.ASDF_DIR = (brew --prefix asdf | str trim | into string | path join 'libexec')\n source " +  (brew --prefix asdf | into string | path join 'libexec/asdf.nu') | save --append $nu.config-path
 ```
 
 Completions are automatically configured
@@ -322,7 +322,7 @@ Completions are automatically configured
 Add `asdf.nu` to your `~/.config/nushell/config.nu` with:
 
 ```shell
-"\n$env.ASDF_NU_DIR = '/opt/asdf-vm/'\n source /opt/asdf-vm/asdf.nu" | save --append $nu.config-path
+"\n$env.ASDF_DIR = '/opt/asdf-vm/'\n source /opt/asdf-vm/asdf.nu" | save --append $nu.config-path
 ```
 
 Completions are automatically configured.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -311,7 +311,7 @@ Completions are automatically configured
 Add `asdf.nu` to your `~/.config/nushell/config.nu` with:
 
 ```shell
-"\n$env.ASDF_DIR = (brew --prefix asdf | str trim | into string | path join 'libexec')\n source " +  (brew --prefix asdf | into string | path join 'libexec/asdf.nu') | save --append $nu.config-path
+"\n$env.ASDF_DIR = (brew --prefix asdf | str trim | into string | path join 'libexec')\n source " +  (brew --prefix asdf | str trim | into string | path join 'libexec/asdf.nu') | save --append $nu.config-path
 ```
 
 Completions are automatically configured

--- a/docs/pt-br/guide/getting-started.md
+++ b/docs/pt-br/guide/getting-started.md
@@ -308,7 +308,7 @@ Ao concluir atualizará automaticamente
 Adicione `asdf.nu` ao seu `~/.config/nushell/config.nu` através do comando:
 
 ```shell
-"\n$env.ASDF_DIR = (brew --prefix asdf | str trim | into string | path join 'libexec')\n source " +  (brew --prefix asdf | into string | path join 'libexec/asdf.nu') | save --append $nu.config-path
+"\n$env.ASDF_DIR = (brew --prefix asdf | str trim | into string | path join 'libexec')\n source " +  (brew --prefix asdf | str trim | into string | path join 'libexec/asdf.nu') | save --append $nu.config-path
 ```
 
 Ao concluir atualizará automaticamente

--- a/docs/pt-br/guide/getting-started.md
+++ b/docs/pt-br/guide/getting-started.md
@@ -297,7 +297,7 @@ Adicione a seguinte linha ao seu `~/.config/powershell/profile.ps1`:
 Adicione `asdf.nu` ao seu `~/.config/nushell/config.nu` através do comando:
 
 ```shell
-"\n$env.ASDF_NU_DIR = ($env.HOME | path join '.asdf')\n source " + ($env.HOME | path join '.asdf/asdf.nu') | save --append $nu.config-path
+"\n$env.ASDF_DIR = ($env.HOME | path join '.asdf')\n source " + ($env.HOME | path join '.asdf/asdf.nu') | save --append $nu.config-path
 ```
 
 Ao concluir atualizará automaticamente
@@ -308,7 +308,7 @@ Ao concluir atualizará automaticamente
 Adicione `asdf.nu` ao seu `~/.config/nushell/config.nu` através do comando:
 
 ```shell
-"\n$env.ASDF_NU_DIR = (brew --prefix asdf | str trim | into string | path join 'libexec')\n source " +  (brew --prefix asdf | into string | path join 'libexec/asdf.nu') | save --append $nu.config-path
+"\n$env.ASDF_DIR = (brew --prefix asdf | str trim | into string | path join 'libexec')\n source " +  (brew --prefix asdf | into string | path join 'libexec/asdf.nu') | save --append $nu.config-path
 ```
 
 Ao concluir atualizará automaticamente
@@ -319,7 +319,7 @@ Ao concluir atualizará automaticamente
 Adicione `asdf.nu` ao seu `~/.config/nushell/config.nu` através do comando:
 
 ```shell
-"\n$env.ASDF_NU_DIR = '/opt/asdf-vm/'\n source /opt/asdf-vm/asdf.nu" | save --append $nu.config-path
+"\n$env.ASDF_DIR = '/opt/asdf-vm/'\n source /opt/asdf-vm/asdf.nu" | save --append $nu.config-path
 ```
 
 Ao concluir atualizará automaticamente

--- a/docs/zh-hans/guide/getting-started.md
+++ b/docs/zh-hans/guide/getting-started.md
@@ -309,7 +309,7 @@ echo -e "\n. \"$(brew --prefix asdf)/libexec/asdf.ps1\"" >> ~/.config/powershell
 使用以下命令将 `asdf.nu` 加入到 `~/.config/nushell/config.nu` 文件中:
 
 ```shell
-"\n$env.ASDF_DIR = (brew --prefix asdf | str trim | into string | path join 'libexec')\n source " +  (brew --prefix asdf | into string | path join 'libexec/asdf.nu') | save --append $nu.config-path
+"\n$env.ASDF_DIR = (brew --prefix asdf | str trim | into string | path join 'libexec')\n source " +  (brew --prefix asdf | str trim | into string | path join 'libexec/asdf.nu') | save --append $nu.config-path
 ```
 
 补全功能将会自动配置。

--- a/docs/zh-hans/guide/getting-started.md
+++ b/docs/zh-hans/guide/getting-started.md
@@ -298,7 +298,7 @@ echo -e "\n. \"$(brew --prefix asdf)/libexec/asdf.ps1\"" >> ~/.config/powershell
 使用以下命令将 `asdf.nu` 加入到 `~/.config/nushell/config.nu` 文件中：
 
 ```shell
-"\n$env.ASDF_NU_DIR = ($env.HOME | path join '.asdf')\n source " + ($env.HOME | path join '.asdf/asdf.nu') | save --append $nu.config-path
+"\n$env.ASDF_DIR = ($env.HOME | path join '.asdf')\n source " + ($env.HOME | path join '.asdf/asdf.nu') | save --append $nu.config-path
 ```
 
 补全功能将会自动配置。
@@ -309,7 +309,7 @@ echo -e "\n. \"$(brew --prefix asdf)/libexec/asdf.ps1\"" >> ~/.config/powershell
 使用以下命令将 `asdf.nu` 加入到 `~/.config/nushell/config.nu` 文件中:
 
 ```shell
-"\n$env.ASDF_NU_DIR = (brew --prefix asdf | str trim | into string | path join 'libexec')\n source " +  (brew --prefix asdf | into string | path join 'libexec/asdf.nu') | save --append $nu.config-path
+"\n$env.ASDF_DIR = (brew --prefix asdf | str trim | into string | path join 'libexec')\n source " +  (brew --prefix asdf | into string | path join 'libexec/asdf.nu') | save --append $nu.config-path
 ```
 
 补全功能将会自动配置。
@@ -320,7 +320,7 @@ echo -e "\n. \"$(brew --prefix asdf)/libexec/asdf.ps1\"" >> ~/.config/powershell
 使用以下命令将 `asdf.nu` 加入到 `~/.config/nushell/config.nu` 文件中:
 
 ```shell
-"\n$env.ASDF_NU_DIR = '/opt/asdf-vm/'\n source /opt/asdf-vm/asdf.nu" | save --append $nu.config-path
+"\n$env.ASDF_DIR = '/opt/asdf-vm/'\n source /opt/asdf-vm/asdf.nu" | save --append $nu.config-path
 ```
 
 补全功能将会自动配置。

--- a/test/asdf_nu.bats
+++ b/test/asdf_nu.bats
@@ -26,7 +26,7 @@ run_nushell() {
     hide-env -i asdf
     hide-env -i ASDF_DIR
     \$env.PATH = ( '$(cleaned_path)' | split row ':' )
-    \$env.ASDF_NU_DIR = '$PWD'
+    \$env.ASDF_DIR = '$PWD'
 
     source asdf.nu
     $1"
@@ -60,12 +60,27 @@ run_nushell() {
   [ "$result" = "" ]
 }
 
-@test "retains ASDF_DIR" {
+@test "retains ASDF_DIR (from ASDF_NU_DIR)" {
   run nu -c "
     hide-env -i asdf
     \$env.ASDF_DIR = ( pwd )
     \$env.PATH = ( '$(cleaned_path)' | split row ':' )
     \$env.ASDF_NU_DIR = '$PWD'
+
+    source asdf.nu
+
+    echo \$env.ASDF_DIR"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "$PWD" ]
+}
+
+@test "retains ASDF_DIR (from ASDF_DIR)" {
+  run nu -c "
+    hide-env -i asdf
+    \$env.ASDF_DIR = ( pwd )
+    \$env.PATH = ( '$(cleaned_path)' | split row ':' )
+    \$env.ASDF_DIR = '$PWD'
 
     source asdf.nu
 


### PR DESCRIPTION
# Summary

It was [a mistake](https://github.com/asdf-vm/asdf/pull/1624#discussion_r1319269045) to read the `ASDF_NU_DIR` environment variable (it looks like use of it snuck through the CR). Since it serves the exact same purpose as `ASDF_DIR`, it is redundant. Remove mention of this variable, but keep reading it for backwards-compatability.

Closes #1623
Closes #1630

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->
