### PR TITLE
docs: Improve `.asdfrc` plugin hook docuentation

### DIFF
--- a/docs/manage/configuration.md
+++ b/docs/manage/configuration.md
@@ -152,6 +152,31 @@ The default number of cores to use during compilation.
 
 Note: the environment variable `ASDF_CONCURRENCY` take precedence if set.
 
+### Plugin Hooks
+
+It is possible to execute custom code:
+
+- Before or after a plugin is installed, reshimed, updated, or uninstalled
+- Before or after a plugin command is executed
+
+For example, if a plugin called `foo` is installed and provides a `bar` executable, then the following hooks can be used to execute custom code first:
+
+```text
+pre_foo_bar = echo Executing with args: $@
+```
+
+The following patterns are supported:
+
+- `pre_<plugin_name>_<command>`
+- `pre_asdf_download_<plugin_name>`
+- `{pre,post}_asdf_{install,reshim,uninstall}_<plugin_name>`
+  - `$1`: full version
+- `{pre,post}_asdf_plugin_{add,update,remove,reshim}`
+  - `$1`: plugin name
+- `{pre,post}_asdf_plugin_{add,update,remove}_<plugin_name>`
+
+See [Create a Plugin](../plugins/create.md) for specifics on what command hooks are ran before or after what commands.
+
 ## Environment Variables
 
 Setting environment variables varies depending on your system and Shell. Default locations depend upon your installation location and method (Git clone, Homebrew, AUR).

--- a/docs/plugins/create.md
+++ b/docs/plugins/create.md
@@ -685,14 +685,14 @@ No parameters provided.
 
 **Description**
 
-Execute this callback script **after** asdf has downloaded the _updated_ plugin with `asdf plugin update <tool> [<git-ref>]`.
+Execute this callback script **after** asdf has downloaded the _update_ plugin with `asdf plugin update <tool> [<git-ref>]`.
 
 See also the related command hooks:
 
-- `pre_asdf_plugin_updated`
-- `pre_asdf_plugin_updated_${plugin_name}`
-- `post_asdf_plugin_updated`
-- `post_asdf_plugin_updated_${plugin_name}`
+- `pre_asdf_plugin_update`
+- `pre_asdf_plugin_update_${plugin_name}`
+- `post_asdf_plugin_update`
+- `post_asdf_plugin_update_${plugin_name}`
 
 **Environment Variables available to script**
 

--- a/docs/zh-hans/plugins/create.md
+++ b/docs/zh-hans/plugins/create.md
@@ -150,10 +150,10 @@ bin tools veggies
 
 其他请参考相关钩子：
 
-- `pre_asdf_plugin_updated`
-- `pre_asdf_plugin_updated_${plugin_name}`
-- `post_asdf_plugin_updated`
-- `post_asdf_plugin_updated_${plugin_name}`
+- `pre_asdf_plugin_update`
+- `pre_asdf_plugin_update_${plugin_name}`
+- `post_asdf_plugin_update`
+- `post_asdf_plugin_update_${plugin_name}`
 
 #### bin/pre-plugin-remove
 


### PR DESCRIPTION
# Summary

- Document plugin hooks in `.asdfrc` section
- Fix typo when referencing [{pre,post}_asdf_plugin_update](https://github.com/asdf-vm/asdf/blob/4085e5542bac824ea124610ad247c2f90d1b8d93/lib/functions/plugins.bash#L164) hooks

Closes #1529
Closes #1466

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->
