### PR TITLE
fix: `plugin test` git-ref default to the default branch of the plugin's repository

### DIFF
--- a/docs/plugins/create.md
+++ b/docs/plugins/create.md
@@ -814,7 +814,7 @@ asdf plugin test <plugin_name> <plugin_url> [--asdf-tool-version <version>] [--a
   installed with that specific version. Defaults to `asdf latest <plugin-name>`
 - If optional `[--asdf-plugin-gitref <git_ref>]` is specified, the plugin itself
   is checked out at that commit/branch/tag. This is useful for testing a
-  pull-request on your plugin's CI.
+  pull-request on your plugin's CI. Defaults to the default branch of the plugin's repository.
 - Optional parameter `[test_command...]` is the command to execute to validate
   the installed tool works correctly. Typically `<tool> --version` or
   `<tool> --help`. For example, to test the NodeJS plugin, we could run

--- a/docs/pt-br/plugins/create.md
+++ b/docs/pt-br/plugins/create.md
@@ -209,8 +209,8 @@ asdf plugin test <plugin-name> <plugin-url> [--asdf-tool-version <version>] [--a
 ```
 
 Apenas os dois primeiros argumentos são necessários.
-Se \__version_ for especificado, a ferramenta será instalada com essa versão específica. O padrão é o que retorna `asdf mais recente <plugin-name>`.
-Se _git-ref_ for especificado, o plug-in em si é verificado nesse commit/branch/tag, útil para testar um pull-request no CI do seu plug-in.
+Se \__version_ for especificado, a ferramenta será instalada com essa versão específica. O padrão é o que retorna `asdf latest <plugin-name>`.
+Se _git-ref_ for especificado, o plug-in em si é verificado nesse commit/branch/tag, útil para testar um pull-request no CI do seu plug-in. O padrão é o branch _default_ do repositório do plugin.
 
 Os argumentos Rest são considerados o comando a ser executado para garantir que a ferramenta instalada funcione corretamente.
 Normalmente seria algo que leva `--version` ou `--help`.

--- a/docs/zh-hans/plugins/create.md
+++ b/docs/zh-hans/plugins/create.md
@@ -222,7 +222,7 @@ asdf plugin test <plugin-name> <plugin-url> [--asdf-tool-version <version>] [--a
 
 只有前两个参数是必须的。
 如果指定了 \__version_，则该工具将随指定版本一起安装。默认返回为 `asdf latest <plugin-name>`。
-如果指定了 _git-ref_，则插件将检查提交/分支/标签。这对于在该插件的 CI 上测试拉取请求非常有用。
+如果指定了 _git-ref_，则插件将检查提交/分支/标签。这对于在该插件的 CI 上测试拉取请求非常有用。默认值是插件仓库的默认分支。
 
 剩下的参数被视为要执行的命令，以确保安装的工具正常工作。通常情况下，它需要带 `--version` 或者 `--help`。例如，要测试 NodeJS 插件，我们可以运行：
 

--- a/lib/commands/command-plugin-test.bash
+++ b/lib/commands/command-plugin-test.bash
@@ -14,7 +14,8 @@ plugin_test_command() {
   local plugin_url="$2"
   shift 2
 
-  local plugin_gitref="master"
+  plugin_remote_default_branch=$(git ls-remote --symref $plugin_url HEAD | awk '{ sub(/refs\/heads\//, ""); print $2; exit }')
+  local plugin_gitref=${3:-${plugin_remote_default_branch}}
   local tool_version
   local interpret_args_literally
   local skip_next_arg

--- a/lib/commands/command-plugin-test.bash
+++ b/lib/commands/command-plugin-test.bash
@@ -14,8 +14,20 @@ plugin_test_command() {
   local plugin_url="$2"
   shift 2
 
-  plugin_remote_default_branch=$(git ls-remote --symref $plugin_url HEAD | awk '{ sub(/refs\/heads\//, ""); print $2; exit }')
-  local plugin_gitref=${3:-${plugin_remote_default_branch}}
+  local exit_code
+  local TEST_DIR
+
+  fail_test() {
+    printf "FAILED: %s\n" "$1"
+    rm -rf "$TEST_DIR"
+    exit 1
+  }
+
+  if [ -z "$plugin_name" ] || [ -z "$plugin_url" ]; then
+    fail_test "please provide a plugin name and url"
+  fi
+
+  local plugin_gitref
   local tool_version
   local interpret_args_literally
   local skip_next_arg
@@ -46,21 +58,13 @@ plugin_test_command() {
     fi
   done
 
-  if [ "$#" -eq 1 ]; then
-    set -- "${SHELL:-sh}" -c "$1"
+  if [ -z "$plugin_gitref" ]; then
+    plugin_remote_default_branch=$(git ls-remote --symref "$plugin_url" HEAD | awk '{ sub(/refs\/heads\//, ""); print $2; exit }')
+    plugin_gitref=${3:-${plugin_remote_default_branch}}
   fi
 
-  local exit_code
-  local TEST_DIR
-
-  fail_test() {
-    printf "FAILED: %s\n" "$1"
-    rm -rf "$TEST_DIR"
-    exit 1
-  }
-
-  if [ -z "$plugin_name" ] || [ -z "$plugin_url" ]; then
-    fail_test "please provide a plugin name and url"
+  if [ "$#" -eq 1 ]; then
+    set -- "${SHELL:-sh}" -c "$1"
   fi
 
   TEST_DIR=$(mktemp -dt asdf.XXXX)


### PR DESCRIPTION
# Summary

It implements the strategy followed by #800 to retrieve the plugin's default branch instead of relying on master.

Fixes: #974
