### PR TITLE
fix: use universal scope for fish_user_paths in fish shell integration

### DIFF
--- a/asdf.fish
+++ b/asdf.fish
@@ -13,10 +13,10 @@ end
 # Do not use fish_add_path (added in Fish 3.2) because it
 # potentially changes the order of items in fish_user_paths
 if not contains $_asdf_bin $fish_user_paths
-    set --global --prepend fish_user_paths $_asdf_bin
+    set --universal --prepend fish_user_paths $_asdf_bin
 end
 if not contains $_asdf_shims $fish_user_paths
-    set --global --prepend fish_user_paths $_asdf_shims
+    set --universal --prepend fish_user_paths $_asdf_shims
 end
 set --erase _asdf_bin
 set --erase _asdf_shims


### PR DESCRIPTION
# Summary

This PR addresses issue described in #1629. Currently the Fish shell setup script sets fish_user_paths as a global variable.  This conflicts with the expected universal nature of fish_user_paths, leading to path assignments not persisting across sessions when using fish_add_path.

Fixes:
- fish-shell/fish-shell#9819
- #1629

## Other Information

This ensures that any paths added via fish_add_path are retained across all Fish shell sessions, aligning with the standard behavior of fish_add_path as outlined in its [documentation](https://fishshell.com/docs/current/tutorial.html).