### PR TITLE
ci: Update Fish dependencies

### DIFF
--- a/scripts/install_dependencies.bash
+++ b/scripts/install_dependencies.bash
@@ -22,7 +22,7 @@ fi
 # Elvish
 elvish_semver="v0.19.2"
 # Fish
-fish_semver="3.6.1"
+fish_semver="3.7.0"
 fish_apt_semver="${fish_semver}-1~jammy"
 # Nushell
 nushell_semver="0.84.0"


### PR DESCRIPTION
# Summary

Recently, there have been errors in CI as packages from the Fish PPA (https://launchpad.net/~fish-shell/+archive/ubuntu/release-3) have been removed.

Unfortunately, it seems that `3.6` is no longer installable so the version was bumped
