### PR TITLE
fix: use PATH instead of fish_user_paths + tests

### DIFF
--- a/asdf.fish
+++ b/asdf.fish
@@ -11,12 +11,12 @@ else
 end
 
 # Do not use fish_add_path (added in Fish 3.2) because it
-# potentially changes the order of items in fish_user_paths
-if not contains $_asdf_bin $fish_user_paths
-    set --universal --prepend fish_user_paths $_asdf_bin
+# potentially changes the order of items in PATH
+if not contains $_asdf_bin $PATH
+    set -gx --prepend PATH $_asdf_bin
 end
-if not contains $_asdf_shims $fish_user_paths
-    set --universal --prepend fish_user_paths $_asdf_shims
+if not contains $_asdf_shims $PATH
+    set -gx --prepend PATH $_asdf_shims
 end
 set --erase _asdf_bin
 set --erase _asdf_shims


### PR DESCRIPTION
# Summary

Update `asdf.fish` to modify `$PATH` directly, rather than using `$fish_user_paths`. This respects the user's choice between a universal or global `$fish_user_paths`, addressing an issue where the previous `asdf.fish` made this decision on behalf of the user.

Modifying `$PATH` directly was recommended by @faho (long time Fish shell contributor) and avoids assumptions about `$fish_user_paths` being global or universal, which should be the shell users decision. Note that in fish `$PATH` cannot be a universal variable (it's simply inherited from the parent process), so it does not have this issue.

This approach also aligns with initialisation scripts from other projects, such as those from [brew](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/cmd/shellenv.sh#L35) and [pyenv](https://github.com/pyenv/pyenv/blob/46d3954bffb70a78adaba2c4d4a2601313483878/libexec/pyenv-init#L227) that also set PATH directly, ensuring simplicity.

A side effect is that this also fixes tests and resolves test interdependencies caused by the persistence of the universal variable across runs.

Fixes:
- tests :upside_down_face:
- fish-shell/fish-shell#9819
- #1629
- #1699