### PR TITLE
feat: Auto-install missing versions in asdf local.

### DIFF
--- a/docs/manage/configuration.md
+++ b/docs/manage/configuration.md
@@ -65,6 +65,7 @@ always_keep_download = no
 plugin_repository_last_check_duration = 60
 disable_plugin_short_name_repository = no
 concurrency = auto
+local_command_auto_install_missing_version = no
 ```
 
 ### `legacy_version_file`
@@ -151,6 +152,17 @@ The default number of cores to use during compilation.
 | `auto`  | Calculate the number of cores using `nproc`, then `sysctl hw.ncpu`, then `/proc/cpuinfo` or else `1` |
 
 Note: the environment variable `ASDF_CONCURRENCY` take precedence if set.
+
+### `local_command_auto_install_missing_version`
+
+Configure the `asdf local` command with the ability to auto-install missing versions.
+
+For example, if you want your `.tool-versions` file to reflect `ruby 2.7.8`, you can invoke `asdf local ruby 2.7.8`.  By default, if Ruby 2.7.8 is not yet installed, this command will exit with an error. However, if you set `local_command_auto_install_missing_version = yes` in `~/.asdfrc`, Ruby 2.7.8 will be downloaded & installed if necessary, and then `.tool-versions` will be updated.
+
+| Options                                                    | Description                                                |
+| :--------------------------------------------------------- | :--------------------------------------------------------- |
+| `no` <Badge type="tip" text="default" vertical="middle" /> | Only update .tool-versions if version is already available |
+| `yes`                                                      | Install version if missing, then update .tool-versions     |
 
 ### Plugin Hooks
 

--- a/lib/commands/command-local.bash
+++ b/lib/commands/command-local.bash
@@ -2,5 +2,9 @@
 
 # shellcheck source=lib/commands/version_commands.bash
 . "$(dirname "$ASDF_CMD_FILE")/version_commands.bash"
+# shellcheck source=lib/commands/reshim.bash
+. "$(dirname "$ASDF_CMD_FILE")/reshim.bash"
+# shellcheck source=lib/functions/installs.bash
+. "$(dirname "$(dirname "$0")")/lib/functions/installs.bash"
 
 local_command "$@"

--- a/lib/functions/versions.bash
+++ b/lib/functions/versions.bash
@@ -53,8 +53,14 @@ version_command() {
     fi
 
     if ! (check_if_version_exists "$plugin_name" "$version"); then
-      version_not_installed_text "$plugin_name" "$version" 1>&2
-      exit 1
+      auto_install=$(get_asdf_config_value "local_command_auto_install_missing_version")
+      if [[ "$auto_install" == "yes" ]]; then
+        echo "install_tool_version $plugin_name $version"
+        install_tool_version "$plugin_name" "$version"
+      else
+        version_not_installed_text "$plugin_name" "$version" 1>&2
+        exit 1
+      fi
     fi
 
     resolved_versions+=("$version")

--- a/lib/functions/versions.bash
+++ b/lib/functions/versions.bash
@@ -55,7 +55,6 @@ version_command() {
     if ! (check_if_version_exists "$plugin_name" "$version"); then
       auto_install=$(get_asdf_config_value "local_command_auto_install_missing_version")
       if [[ "$auto_install" == "yes" ]]; then
-        echo "install_tool_version $plugin_name $version"
         install_tool_version "$plugin_name" "$version"
       else
         version_not_installed_text "$plugin_name" "$version" 1>&2


### PR DESCRIPTION
# Summary

I frequently want to be able to upgrade my `.tool-versions` straight to the newest version of a plugin with the `asdf local` command.  At the moment, the first repository i perform this on, i'll get an error that the latest version isn't installed:

```shellsession
$ asdf local ruby latest
version 3.3.0 is not installed for ruby ❌
```

Instead of having to read the latest version from the error output, then type, e.g., `asdf install ruby 3.3.0`, then redo my command, i'd like to be able to have `asdf local` do the installation automatically.  This will save me a tedious manual step.

With this change, i can do it all in one go:

```shellsession
$ echo "local_command_auto_install_missing_version = yes" >> .asdfrc
$ asdf local ruby latest
...installs Ruby 3.3.0...
$ cat .tool-versions
ruby 3.3.0 🎉
```

## Other Information

Apologies for the PR spam.  Hopefully this one will be acceptable.  I previously misunderstood a few things about how asdf works under the hood – i think this is a better way to address what i actually wanted, namely less manual version swizzling 😁 

Also, i'm happy to find a better name for the config option.