### PR TITLE
fix: keep_download condition

### DIFF
--- a/lib/functions/installs.bash
+++ b/lib/functions/installs.bash
@@ -237,11 +237,11 @@ install_tool_version() {
       # Remove download directory if --keep-download flag or always_keep_download config setting are not set
       if [ -d "$download_path" ]; then
         always_keep_download=$(get_asdf_config_value "always_keep_download")
-        if [ "$keep_download" != "true" ] && [ "$always_keep_download" != "yes" ]; then
-          rm -r "$download_path"
-        else
+        if [ "$keep_download" = "true" ] || [ "$always_keep_download" = "yes" ]; then
           printf '%s\n' "asdf: Warn: You have configured asdf to preserve downloaded files (with always_keep_download=yes or --keep-download). But" >&2
           printf '%s\n' "asdf: Warn: the current plugin ($plugin_name) does not support that. Downloaded files will not be preserved." >&2
+        else
+          rm -r "$download_path"
         fi
       fi
 

--- a/lib/functions/installs.bash
+++ b/lib/functions/installs.bash
@@ -235,9 +235,9 @@ install_tool_version() {
     local install_exit_code=$?
     if [ $install_exit_code -eq 0 ] && [ $download_exit_code -eq 0 ]; then
       # Remove download directory if --keep-download flag or always_keep_download config setting are not set
-      always_keep_download=$(get_asdf_config_value "always_keep_download")
-      if [ ! "$keep_download" = "true" ] && [ ! "$always_keep_download" = "yes" ]; then
-        if [ -d "$download_path" ]; then
+      if [ -d "$download_path" ]; then
+        always_keep_download=$(get_asdf_config_value "always_keep_download")
+        if [ "$keep_download" != "true" ] && [ "$always_keep_download" != "yes" ]; then
           rm -r "$download_path"
         else
           printf '%s\n' "asdf: Warn: You have configured asdf to preserve downloaded files (with always_keep_download=yes or --keep-download). But" >&2


### PR DESCRIPTION
# Summary

Swap directory and argument checks so it won't result in misleading warning.

Fixes: #1711

## Other Information

~~Also replaced `[ ! a = b ]` with `[ a != b ]` as it's more readable.~~ Inverted condition for better readability.
