### PR TITLE
fix: shim and preset plugin mismatch message

### DIFF
--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -129,6 +129,36 @@ teardown() {
   echo "$output" | grep -q "dummy 1.0" 2>/dev/null
 }
 
+@test "issue #928" {
+  # Install 1.0, with fake "dummyman" command, shimmed for 1.0
+  run asdf install dummy 1.0
+  echo "echo Dummy Manager" >"$ASDF_DIR/installs/dummy/1.0/bin/dummyman"
+  chmod +x "$ASDF_DIR/installs/dummy/1.0/bin/dummyman"
+  run asdf reshim dummy 1.0
+
+  # Install 1.3
+  run asdf install dummy 1.3
+
+  echo "dummy 1.3" >"$PROJECT_DIR/.tool-versions"
+
+  # reshim doesn't help
+  run asdf reshim dummy
+  run asdf shim-versions dummyman
+  [ "$status" -eq 0 ]
+  [ "$output" = "dummy 1.0" ]
+
+  run "$ASDF_DIR/shims/dummyman"
+  [ "$status" -eq 126 ]
+  echo ">> $output" >&3
+
+  # Below is current (misleading) message
+  echo "$output" | grep -q "No preset version installed for command dummyman" 2>/dev/null
+  echo "$output" | grep -q "Please install a version by running one of the following:" 2>/dev/null
+  echo "$output" | grep -q "asdf install dummy 1.3" 2>/dev/null
+  echo "$output" | grep -q "or add one of the following versions in your config file at $PROJECT_DIR/.tool-versions" 2>/dev/null
+  echo "$output" | grep -q "dummy 1.0" 2>/dev/null
+}
+
 @test "shim exec should execute first plugin that is installed and set" {
   run asdf install dummy 2.0.0
   run asdf install dummy 3.0

--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -129,7 +129,7 @@ teardown() {
   echo "$output" | grep -q "dummy 1.0" 2>/dev/null
 }
 
-@test "issue #928" {
+@test "shim exec should suggest to check obsolete shim" {
   # Install 1.0, with fake "dummyman" command, shimmed for 1.0
   run asdf install dummy 1.0
   echo "echo Dummy Manager" >"$ASDF_DIR/installs/dummy/1.0/bin/dummyman"
@@ -138,7 +138,6 @@ teardown() {
 
   # Install 1.3
   run asdf install dummy 1.3
-
   echo "dummy 1.3" >"$PROJECT_DIR/.tool-versions"
 
   # reshim doesn't help
@@ -146,17 +145,11 @@ teardown() {
   run asdf shim-versions dummyman
   [ "$status" -eq 0 ]
   [ "$output" = "dummy 1.0" ]
-
   run "$ASDF_DIR/shims/dummyman"
   [ "$status" -eq 126 ]
-  echo ">> $output" >&3
 
-  # Below is current (misleading) message
-  echo "$output" | grep -q "No preset version installed for command dummyman" 2>/dev/null
-  echo "$output" | grep -q "Please install a version by running one of the following:" 2>/dev/null
-  echo "$output" | grep -q "asdf install dummy 1.3" 2>/dev/null
-  echo "$output" | grep -q "or add one of the following versions in your config file at $PROJECT_DIR/.tool-versions" 2>/dev/null
-  echo "$output" | grep -q "dummy 1.0" 2>/dev/null
+  echo "$output" | grep -q "Shimmed command 'dummyman' has no matched plugin version" 2>/dev/null
+  echo "$output" | grep -q "Check the executable or try install dummyman for your preset plugin version" 2>/dev/null
 }
 
 @test "shim exec should execute first plugin that is installed and set" {


### PR DESCRIPTION
# Summary

Detect the case "missing preset plugin" is in fact installed, print different message instead of the misleading one.

Fixes: #928 

## Other Information

Example output:
![sample-output](https://github.com/asdf-vm/asdf/assets/156608/fd6e907f-589a-416e-890a-a427561299f7)