### PR TITLE
fix: correct list usage in asdf.nu

### DIFF
--- a/asdf.nu
+++ b/asdf.nu
@@ -107,7 +107,7 @@ module asdf {
 
         let flags = ($params | where enabled | get --ignore-errors flag | default '' )
 
-        ^asdf plugin list $flags | lines | parse -r $template | str trim
+        ^asdf plugin list ...$flags | lines | parse -r $template | str trim
     }
 
     # list all available plugins


### PR DESCRIPTION
After installing asdf.nu in my nushell config, running `asdf plugin list` gives me the following error:

    ❯ asdf plugin list
    Error: nu::shell::cannot_pass_list_to_external
    
      × Lists are not automatically spread when calling external commands
         ╭─[/opt/asdf-vm/asdf.nu:110:27]
     109 │ 
     110 │         ^asdf plugin list $flags | lines | parse -r $template | str trim
         ·                           ───┬──
         ·                              ╰── Spread operator (...) is necessary to spread lists
     111 │     }
         ╰────
      help: Either convert the list to a string or use the spread operator, like so: ...$flags

This change fixes the error.

# Summary

Uses the spread operator when passing a list into the `asdf` command

Fixes: No issue created, just the fix (would you like me to create an issue?)

## Other Information

- asdf version: `v0.13.1-0586b37`, installed via `asdf-vim` AUR package
- nu version: `0.92.1`, installed via `nushell` Arch package