### PR TITLE
fix: Avoid false warning on clean up.

### DIFF
--- a/lib/functions/installs.bash
+++ b/lib/functions/installs.bash
@@ -237,12 +237,10 @@ install_tool_version() {
       # Remove download directory if --keep-download flag or always_keep_download config setting are not set
       always_keep_download=$(get_asdf_config_value "always_keep_download")
       if [ ! "$keep_download" = "true" ] && [ ! "$always_keep_download" = "yes" ]; then
-        if [ -d "$download_path" ]; then
-          rm -r "$download_path"
-        else
-          printf '%s\n' "asdf: Warn: You have configured asdf to preserve downloaded files (with always_keep_download=yes or --keep-download). But" >&2
-          printf '%s\n' "asdf: Warn: the current plugin ($plugin_name) does not support that. Downloaded files will not be preserved." >&2
-        fi
+        rm -rf "$download_path"
+      elif [ ! -d "$download_path" ]; then
+        printf '%s\n' "asdf: Warn: You have configured asdf to preserve downloaded files (with always_keep_download=yes or --keep-download). But" >&2
+        printf '%s\n' "asdf: Warn: the current plugin ($plugin_name) does not support that. Downloaded files will not be preserved." >&2
       fi
 
       reshim_command "$plugin_name" "$full_version"


### PR DESCRIPTION
# Summary

This is an alternative to #1721, and may be closer to the original intent: if `asdf` is configured to preserve downloads, but the download_path directory is missing, then give warning.

Fixes: Removes false warning on clean up.

