### PR TITLE
fix: Only display the "can't keep downloads" warning when asked to keep downloads

### DIFF
--- a/lib/functions/installs.bash
+++ b/lib/functions/installs.bash
@@ -234,15 +234,16 @@ install_tool_version() {
 
     local install_exit_code=$?
     if [ $install_exit_code -eq 0 ] && [ $download_exit_code -eq 0 ]; then
-      # Remove download directory if --keep-download flag or always_keep_download config setting are not set
+      # If the download directory should be kept, but isn't available, warn the user
       always_keep_download=$(get_asdf_config_value "always_keep_download")
-      if [ ! "$keep_download" = "true" ] && [ ! "$always_keep_download" = "yes" ]; then
-        if [ -d "$download_path" ]; then
-          rm -r "$download_path"
-        else
+      if [ "$keep_download" = "true" ] || [ "$always_keep_download" = "yes" ]; then
+        if [ ! -d "$download_path" ]; then
           printf '%s\n' "asdf: Warn: You have configured asdf to preserve downloaded files (with always_keep_download=yes or --keep-download). But" >&2
           printf '%s\n' "asdf: Warn: the current plugin ($plugin_name) does not support that. Downloaded files will not be preserved." >&2
         fi
+      # Otherwise, remove the download directory if it exists
+      elif [ -d "$download_path" ]; then
+        rm -r "$download_path"
       fi
 
       reshim_command "$plugin_name" "$full_version"

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -7,6 +7,7 @@ setup() {
   install_dummy_legacy_plugin
   install_dummy_plugin
   install_dummy_broken_plugin
+  install_dummy_plugin_no_download
 
   PROJECT_DIR="$HOME/project"
   mkdir -p "$PROJECT_DIR"
@@ -302,11 +303,24 @@ EOM
   [ "$output" = "Download failed!" ]
 }
 
-@test "install_command prints info message if plugin does not support preserving download data if configured" {
-  install_dummy_plugin_no_download
+@test "install_command prints info message if plugin does not support preserving download data if --keep-download flag is provided" {
+  run asdf install dummy-no-download 1.0.0 --keep-download
+  [ "$status" -eq 0 ]
 
+  [[ "$output" == *'asdf: Warn:'*'not be preserved'* ]]
+}
+
+@test "install_command prints info message if plugin does not support preserving download data if always_keep_download setting is true" {
+  echo 'always_keep_download = yes' >"$HOME/.asdfrc"
   run asdf install dummy-no-download 1.0.0
   [ "$status" -eq 0 ]
 
   [[ "$output" == *'asdf: Warn:'*'not be preserved'* ]]
+}
+
+@test "install_command does not print info message if --keep-download flag is not provided and always_keep_download setting is false" {
+  run asdf install dummy-no-download 1.0.0
+  [ "$status" -eq 0 ]
+
+  [[ "$output" != *'asdf: Warn:'*'not be preserved'* ]]
 }


### PR DESCRIPTION
# Summary

Currently, the warning which is intended to alert users that the download directory can't be kept only appears if they haven't asked for it to be. This fix just rearranges the logic a bit so that the warning instead only appears if the download directory *should* be kept, but *can't* be (because it doesn't exist).

Fixes: #1711