### PR TITLE
Fix Bash completions

### DIFF
--- a/completions/asdf.bash
+++ b/completions/asdf.bash
@@ -39,7 +39,7 @@ _asdf() {
     COMPREPLY=($(compgen -W "$available_plugins" -- "$cur"))
     ;;
   install | list | list-all | help)
-    if [[ "$plugins" == *"$prev"* ]]; then
+    if [[ " $plugins " == *" $prev "* ]]; then
       local versions
       versions=$(asdf list-all "$prev" 2>/dev/null)
       # shellcheck disable=SC2207
@@ -54,7 +54,7 @@ _asdf() {
     COMPREPLY=($(compgen -W "--head" -- "$cur"))
     ;;
   uninstall | where | reshim)
-    if [[ "$plugins" == *"$prev"* ]]; then
+    if [[ " $plugins " == *" $prev "* ]]; then
       local versions
       versions=$(asdf list "$prev" 2>/dev/null)
       # shellcheck disable=SC2207
@@ -65,7 +65,7 @@ _asdf() {
     fi
     ;;
   local | global | shell)
-    if [[ "$plugins" == *"$prev"* ]]; then
+    if [[ " $plugins " == *" $prev "* ]]; then
       local versions
       versions=$(asdf list "$prev" 2>/dev/null)
       versions+=" system"

--- a/completions/asdf.bash
+++ b/completions/asdf.bash
@@ -56,7 +56,8 @@ _asdf() {
   uninstall | where | reshim)
     if [[ " $plugins " == *" $prev "* ]]; then
       local versions
-      versions=$(asdf list "$prev" 2>/dev/null)
+      # The first two columns are either blank or contain the "current" marker.
+      versions=$(asdf list "$prev" 2>/dev/null | colrm 1 2)
       # shellcheck disable=SC2207
       COMPREPLY=($(compgen -W "$versions" -- "$cur"))
     else
@@ -67,7 +68,8 @@ _asdf() {
   local | global | shell)
     if [[ " $plugins " == *" $prev "* ]]; then
       local versions
-      versions=$(asdf list "$prev" 2>/dev/null)
+      # The first two columns are either blank or contain the "current" marker.
+      versions=$(asdf list "$prev" 2>/dev/null | colrm 1 2)
       versions+=" system"
       # shellcheck disable=SC2207
       COMPREPLY=($(compgen -W "$versions" -- "$cur"))


### PR DESCRIPTION
## Summary

This PR fixes two bugs I discovered in the Bash completions for version 0.14.0. I briefly tested the Fish completions as well, but did not see either issue there.

Fixes: (I did not find existing issues for these bugs.)

### Problem distinguishing between plugin names and commands

The first issue occurs when attempting to complete a command which is a substring of an installed plugin; for example, trying to complete `asdf shell ` while the `shellcheck` plugin is installed.

Currently, the Bash completions perform a simple substring match to determine whether the previous token is the name of a plugin: `[[ "$plugins" == *"$prev"* ]]`. The string `"shell"` is present in `"shellcheck"` and therefore the list of plugins, so it is interpreted as a plugin name and the completion tries to get the list of installed versions. The resulting list is empty, but because `" system"` is added, pressing <kbd>Tab</kbd> after `asdf shell ` completes with `system `.

The change I've made is to wrap both the list of plugins and the previous word in spaces (the delimiters used in the plugin list) — `[[ " $plugins " == *" $prev "* ]]`. This effectively forces a full-token match, as `" shell "` is *not* present in `" shellcheck "`.

### Asterisk present in installed-version completions

The other issue is that the version currently in use retains its asterisk in Bash completions of installed versions. This comes from the use of `asdf list $plugin` to get the list of versions without removing the asterisk which indicates the current version. The fix simply uses `colrm` to remove the first two columns of that command's output, which are always a space followed by either a space or an asterisk.

## Other Information

I didn't see any existing testing for command completions (I'm not sure how that would work), so no new tests cover these changes.