### PR TITLE
fix: nushell spread operator

### DIFF
--- a/asdf.nu
+++ b/asdf.nu
@@ -107,7 +107,7 @@ module asdf {
 
         let flags = ($params | where enabled | get --ignore-errors flag | default '' )
 
-        ^asdf plugin list $flags | lines | parse -r $template | str trim
+        ^asdf plugin list ...$flags | lines | parse -r $template | str trim
     }
 
     # list all available plugins


### PR DESCRIPTION
# Summary

With nushell 0.94.2 I get the following error:
```
$ asdf plugin list
Error: nu::shell::cannot_pass_list_to_external

  × Lists are not automatically spread when calling external commands
     ╭─[/home/deas/.asdf/asdf.nu:110:27]
 109 │ 
 110 │         ^asdf plugin list $flags | lines | parse -r $template | str trim
     ·                           ───┬──
     ·                              ╰── Spread operator (...) is necessary to spread lists
 111 │     }
     ╰────
  help: Either convert the list to a string or use the spread operator, like so: ...$flags

```
This change fixes that for me.
