### PR TITLE
fix: make plugin-test work on alpine linux

### DIFF
--- a/lib/commands/command-plugin-test.bash
+++ b/lib/commands/command-plugin-test.bash
@@ -67,7 +67,7 @@ plugin_test_command() {
     set -- "${SHELL:-sh}" -c "$1"
   fi
 
-  TEST_DIR=$(mktemp -dt asdf.XXXX)
+  TEST_DIR=$(mktemp -dt asdf.XXXXXX)
   cp -R "$(asdf_dir)/bin" "$TEST_DIR"
   cp -R "$(asdf_dir)/lib" "$TEST_DIR"
   cp "$(asdf_dir)/asdf.sh" "$TEST_DIR"


### PR DESCRIPTION

# Summary

the alpine (busbox) version of `mktemp` expects templates to end with exactly 6 Xs whereas GNU want at least 3.

Bumping to 6 Xs allows alpine users to run the plugin-test command without installing the `coreutils` package first

## Other Information

On alpine anything with less than 6 Xs is an error
<img width="461" alt="image" src="https://github.com/user-attachments/assets/7eb3c78b-eb40-4be3-893a-8c5d275d8cdc">

On ubuntu it doesn't matter if its 4 or 6
<img width="461" alt="image" src="https://github.com/user-attachments/assets/41007646-2010-4691-9d11-d700209027b6">

It will also fix running the `asdf-vm/actions/plugin-test` actions on an alpine container (for now an `apk add coreutils` is required)
![image](https://github.com/user-attachments/assets/eb5b19c1-e1e3-4af7-a32d-33c74a1e2da2)
