### PR TITLE
feat: Enable use of `latest:` in `.tool-versions` files

### DIFF
--- a/lib/commands/command-current.bash
+++ b/lib/commands/command-current.bash
@@ -1,6 +1,8 @@
 # -*- sh -*-
 # shellcheck source=lib/functions/plugins.bash
 . "$(dirname "$(dirname "$0")")/lib/functions/plugins.bash"
+# shellcheck source=lib/functions/versions.bash
+. "$(dirname "$(dirname "$0")")/lib/functions/versions.bash"
 
 # shellcheck disable=SC2059
 plugin_current_command() {
@@ -21,7 +23,8 @@ plugin_current_command() {
   local description=""
 
   IFS=' ' read -r -a versions <<<"$full_version"
-  for version in "${versions[@]}"; do
+  for version_spec in "${versions[@]}"; do
+    version="$(resolve_version_spec "$version_spec")"
     if ! (check_if_version_exists "$plugin_name" "$version"); then
       version_not_installed="$version"
     fi

--- a/lib/commands/command-env.bash
+++ b/lib/commands/command-env.bash
@@ -1,4 +1,6 @@
 # -*- sh -*-
+# shellcheck source=lib/functions/versions.bash
+. "$(dirname "$(dirname "$0")")/lib/functions/versions.bash"
 
 shim_env_command() {
   local shim_name="$1"

--- a/lib/commands/command-exec.bash
+++ b/lib/commands/command-exec.bash
@@ -1,4 +1,6 @@
 # -*- sh -*-
+# shellcheck source=lib/functions/versions.bash
+. "$(dirname "$(dirname "$0")")/lib/functions/versions.bash"
 
 shim_exec_command() {
   local shim_name

--- a/lib/commands/command-which.bash
+++ b/lib/commands/command-which.bash
@@ -1,4 +1,6 @@
 # -*- sh -*-
+# shellcheck source=lib/functions/versions.bash
+. "$(dirname "$(dirname "$0")")/lib/functions/versions.bash"
 
 which_command() {
   local shim_name

--- a/lib/functions/versions.bash
+++ b/lib/functions/versions.bash
@@ -37,15 +37,7 @@ version_command() {
   declare -a resolved_versions
   local item
   for item in "${!versions[@]}"; do
-    IFS=':' read -r -a version_info <<<"${versions[$item]}"
-    if [ "${version_info[0]}" = "latest" ] && [ -n "${version_info[1]}" ]; then
-      version=$(latest_command "$plugin_name" "${version_info[1]}")
-    elif [ "${version_info[0]}" = "latest" ] && [ -z "${version_info[1]}" ]; then
-      version=$(latest_command "$plugin_name")
-    else
-      # if branch handles ref: || path: || normal versions
-      version="${versions[$item]}"
-    fi
+    version="$(resolve_version_spec "${versions[$item]}")"
 
     # check_if_version_exists should probably handle if either param is empty string
     if [ -z "$version" ]; then
@@ -77,6 +69,22 @@ version_command() {
     # Add a new version line to the end of the file
     printf "%s %s\n" "$plugin_name" "${resolved_versions[*]}" >>"$file"
   fi
+}
+
+resolve_version_spec() {
+  local version_spec=$1
+
+  IFS=':' read -r -a version_info <<<"$version_spec"
+  if [ "${version_info[0]}" = "latest" ] && [ -n "${version_info[1]}" ]; then
+    version=$(latest_command "$plugin_name" "${version_info[1]}")
+  elif [ "${version_info[0]}" = "latest" ] && [ -z "${version_info[1]}" ]; then
+    version=$(latest_command "$plugin_name")
+  else
+    # if branch handles ref: || path: || normal versions
+    version="$version_spec"
+  fi
+
+  printf "%s\n" "$version"
 }
 
 list_all_command() {

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -736,7 +736,8 @@ select_version() {
     version_and_path=$(find_versions "$plugin_name" "$search_path")
     IFS='|' read -r version_string _path <<<"$version_and_path"
     IFS=' ' read -r -a usable_plugin_versions <<<"$version_string"
-    for plugin_version in "${usable_plugin_versions[@]}"; do
+    for version_spec in "${usable_plugin_versions[@]}"; do
+      plugin_version="$(resolve_version_spec "$version_spec")"
       for plugin_and_version in "${shim_versions[@]}"; do
         local plugin_shim_name
         local plugin_shim_version

--- a/test/current_command.bats
+++ b/test/current_command.bats
@@ -47,6 +47,16 @@ teardown() {
   [ "$output" = "$expected" ]
 }
 
+@test "current should not error on version specifications like 'latest:'" {
+  cd "$PROJECT_DIR"
+  echo "dummy 1.2.0 latest:1.1" >>"$PROJECT_DIR/.tool-versions"
+  expected="dummy           1.2.0 latest:1.1 $PROJECT_DIR/.tool-versions"
+
+  run asdf current "dummy"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
+}
+
 @test "current should derive from the legacy file if enabled" {
   cd "$PROJECT_DIR"
   echo 'legacy_version_file = yes' >"$HOME/.asdfrc"

--- a/test/install_command.bats
+++ b/test/install_command.bats
@@ -45,6 +45,14 @@ teardown() {
   [ "$(cat "$ASDF_DIR/installs/dummy/1.2.0/version")" = "1.2.0" ]
 }
 
+@test "install_command installs the 'latest:' version in .tool-versions" {
+  cd "$PROJECT_DIR"
+  echo -n 'dummy latest:1.1' >".tool-versions"
+  run asdf install dummy
+  [ "$status" -eq 0 ]
+  [ "$(cat "$ASDF_DIR/installs/dummy/1.1.0/version")" = "1.1.0" ]
+}
+
 @test "install_command set ASDF_CONCURRENCY" {
   run asdf install dummy 1.0.0
   [ "$status" -eq 0 ]

--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -141,6 +141,19 @@ teardown() {
   echo "$output" | grep -q "This is Dummy 3.0! hello world" 2>/dev/null
 }
 
+@test "shim exec should respect 'latest:' in .tool-versions" {
+  run asdf install dummy 1.0.0
+  run asdf install dummy 1.1.0
+  run asdf install dummy 2.0.0
+
+  echo "dummy latest:1.1" >"$PROJECT_DIR/.tool-versions"
+
+  run "$ASDF_DIR/shims/dummy" world hello
+  [ "$status" -eq 0 ]
+
+  echo "$output" | grep -q "This is Dummy 1.1.0! hello world" 2>/dev/null
+}
+
 @test "shim exec should only use the first version found for a plugin" {
   run asdf install dummy 3.0
 

--- a/test/test_helpers.bash
+++ b/test/test_helpers.bash
@@ -4,6 +4,8 @@ bats_require_minimum_version 1.7.0
 
 # shellcheck source=lib/utils.bash
 . "$(dirname "$BATS_TEST_DIRNAME")"/lib/utils.bash
+# shellcheck source=lib/functions/versions.bash
+. "$(dirname "$BATS_TEST_DIRNAME")"/lib/functions/versions.bash
 
 setup_asdf_dir() {
   if [ "$BATS_TEST_NAME" = 'test_shim_exec_should_use_path_executable_when_specified_version_path-3a-3cpath-3e' ]; then


### PR DESCRIPTION
# Summary

_Implements https://github.com/asdf-vm/asdf/issues/1012 , and addresses some of the underlying needs in https://github.com/asdf-vm/asdf/issues/1235, https://github.com/asdf-vm/asdf/issues/1342, https://github.com/asdf-vm/asdf/issues/1736, etc_

This change enables `asdf`'s existing latest-version-resolution functionality within the `.tool-versions` file itself. Rather than having to specify a full version number in the file:

```
java corretto-21.0.5.11.1
```

...you can now use the same `latest:` syntax that is already available in the `local` & `global` commands, ie:

```
java latest:corretto-21
```

### Use case

For many tool/runtime ecosystems (eg Java), if a program runs correctly under a specific version of that runtime, it can generally be relied on to run correctly under any _later_ version of that runtime with the same major version number (eg if a project runs under Corretto Java 21.0.5.11.1, it will run on any _later_ version of Corretto Java 21).

This means that for projects in those ecosystems, there is little incentive to pin to fully-specified versions like `21.0.5.11.1`, and in fact there are downsides - over time, developers will default to using older, unpatched versions of Java, unless they are assiduous in continually updating the contents of the `.tool-versions` file, or have tooling devoted to doing so.

At the Guardian we have [several hundred projects](https://github.com/orgs/guardian/repositories?q=visibility%3Apublic+language%3AScala+) that run on the Java platform, and due to our security obligations we generally want to be running under the _latest_ security-patched version of the Java runtime that matches our major-version requirement. We love `asdf` as a tool, and like that the `.tool-versions` file can become a source-of-truth documenting which version of Java a project uses, but we don't want to have to commit fully-specified version numbers like `21.0.5.11.1` to source control, or set up tooling to increment those version numbers across those hundreds of repositories.

Allowing the use of `latest:` in the `.tool-versions` file means that we don't need to continually update those `.tool-versions` files. It also partially addresses some of the needs raised by https://github.com/asdf-vm/asdf/issues/1736, though this solution uses the existing `asdf` version-resolution functionality, rather than adopting nodejs version syntax (`^1.1.0`, etc).

### Determinism & variability of version - could we let the user decide?

In the past, the maintainers of `asdf` have argued [against](https://github.com/asdf-vm/asdf-nodejs/issues/235#issuecomment-885809776) this kind of change:

> Special versions like `latest` are resolved at the time the asdf command specifying them is run and are not permitted to in `.tool-versions` because of the nondeterminism they would introduce. We don't want to allow any variability in versions specified in any of the version files that asdf supports because we want asdf to be **deterministic**. We don't want a new version release to accidentally pull the rug out from under someone because they had specified a shorthand version or version range.

...and [also](https://github.com/asdf-vm/asdf/issues/1342#issuecomment-1368572137):

> `asdf` is designed to ensure everyone on a team is using the **exact** same version. If I am using `nodejs@16.0.0` and you are using `nodejs@16.19.0` those two versions are not anywhere close to being the same. They have different V8 engines, many different features and numerous bug fixes etc. How can we determine the root cause with this variability? Solution, remove the variability. Yes, this makes `asdf` slightly less convenient to use, but the purpose of locking a team to a version is to lock them to a version. Version ranges introduce variability.

I think there are at least _some_ users who would accept some variability in exchange for staying up-to-date, and it's worth considering whether it's reasonable to allow them to select that. In terms of the existing `latest:` syntax already used by `asdf`, the constraint can be made quite tight (eg. `java latest:corretto-21.0.5`) or looser (eg. `java latest:corretto-21`) - so the choice of how much variation they want to accept can be expressed by the user.

In some ecosystems - like Java - if the version number is constrained to particular LTS major version, the only expected updates are security updates. At the Guardian, we _do_ want to be using those latest security updates, and so would use a constraint like `latest:corretto-21`.

### Implementation

A new `resolve_version_spec()` function has been extracted from the existing `version_command()` function. This takes a version-spec string, like `latest:corretto-11` or `corretto-21.0.5.11.1`, and resolves it to a precise version number.

To support `latest:` syntax in `.tool-versions`, the new `resolve_version_spec()` function is now called in `select_version()`, used by `with_shim_executable()`, meaning that any execution of the `asdf` shim (eg, executing `java`) will now resolve any version specifications found in the `.tool-versions` file - if `.tool-versions` contains `java latest:corretto-21`, this will be resolved and the latest version of Java 21 used.

## Testing

Tests have been added for these `asdf` commands to ensure they can handle version resolution in the `.tool-versions` file:

* `exec`
* `install`
* `current` 

## Other Information

Previous `asdf` PRs relating to `latest`:

* https://github.com/asdf-vm/asdf/pull/575 in November 2019: added the `latest` command, eg `asdf latest python 3.6` reports the latest version of Python 3.6.
* https://github.com/asdf-vm/asdf/pull/633 in July 2021: made it possible to specify `latest` when using the `local` & `global` commands, eg: `asdf local python latest:3.7` - this would save a precise version number to `.tools-versions`, which is undesired behaviour for us at the Guardian.

Previous `asdf` issues relating to keeping up with latest-and-greatest versions:

* https://github.com/asdf-vm/asdf-nodejs/issues/235
* https://github.com/asdf-vm/asdf/issues/1012 - _"I propose adding support for the special value "latest" within `.tool-versions` files"_
* https://github.com/asdf-vm/asdf/issues/1342 - _"Is there a way to automatically switch to another runtime version using only the major version"_
* https://github.com/asdf-vm/asdf/issues/1736 - _"specify version in style of package.json (e.g. "^1.1.0")"_
* https://github.com/asdf-vm/asdf/issues/1235 - _"to use latest-and-greatest, updating .tool-versions files with the right versions of individual tools can get pretty tedious"_


A couple of Guardian systems attempting to standardise on using `.tool-versions` as a source of truth:

* https://github.com/guardian/gha-scala-library-release-workflow/pull/36
* https://github.com/guardian/setup-scala

cc @adamnfish @akash1810 @tjsilver
