### PR TITLE
fix: Removed $HOME/ prefix from global filename path

### DIFF
--- a/lib/functions/versions.bash
+++ b/lib/functions/versions.bash
@@ -20,7 +20,7 @@ version_command() {
   file_name="$(asdf_tool_versions_filename)"
 
   if [ "$cmd" = "global" ]; then
-    file="$HOME/$file_name"
+    file="$file_name"
   elif [ "$cmd" = "local-tree" ]; then
     file=$(find_tool_versions)
   else # cmd = local


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

Fixes:

1. Fixes issue for  ASDF_DEFAULT_TOOL_VERSIONS_FILENAME when location defined outside /home/user folder

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->
