### PR TITLE
fix: Support for Windows with Git-Bash or MSYS2 Bash

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -618,6 +618,9 @@ plugin_executables() {
   for bin_path in "${all_bin_paths[@]}"; do
     for executable_file in "$bin_path"/*; do
       if is_executable "$executable_file"; then
+        if [[ "$executable_file" == *".exe" ]]; then
+          executable_file=${executable_file::-4}
+        fi
         printf "%s\n" "$executable_file"
       fi
     done


### PR DESCRIPTION
# Summary
Support Windows through Git-Bash or MSYS2 Bash (Not WSL2) for Use vscode-elixir-ls on Windows

## Other Information
* On *NIX
   * It works as it used to.
* On Windows
   * When executing the `asdf reshim` command, create a `*.bat` file, and when executing the file, execute the command through bash.
   * `asdf reshim` remove `.exe` extension. (ex: erl.exe -> erl)