### PR TITLE
docs: Remove warning about oh-my-zsh-plugin

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -236,9 +236,6 @@ autoload -Uz compinit && compinit
 - if you are using a custom `compinit` setup, ensure `compinit` is below your sourcing of `asdf.sh`
 - if you are using a custom `compinit` setup with a ZSH Framework, ensure `compinit` is below your sourcing of the framework
 
-**Warning**
-
-If you are using a ZSH Framework the associated `asdf` plugin may need to be updated to use the new ZSH completions properly via `fpath`. The Oh-My-ZSH asdf plugin is yet to be updated, see [ohmyzsh/ohmyzsh#8837](https://github.com/ohmyzsh/ohmyzsh/pull/8837).
 :::
 
 ::: details ZSH & Homebrew


### PR DESCRIPTION
# Summary

This was fixed over a year ago in oh-my-zsh commit 278bcfc

https://github.com/ohmyzsh/ohmyzsh/commit/278bcfc