### PR TITLE
fix(golang-rewrite): Fix new lines from `asdf set` command

### DIFF
--- a/internal/cli/set/set_test.go
+++ b/internal/cli/set/set_test.go
@@ -95,6 +95,24 @@ func TestAll(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, "lua 5.2.3\n", string(bytes))
 	})
+
+	t.Run("sets version in current directory only once", func(t *testing.T) {
+		stdout, stderr := buildOutputs()
+		dir := t.TempDir()
+		assert.Nil(t, os.Chdir(dir))
+
+		_ = Main(&stdout, &stderr, []string{"lua", "5.2.3"}, false, false, homeFunc)
+		err := Main(&stdout, &stderr, []string{"lua", "5.2.3"}, false, false, homeFunc)
+
+		assert.Nil(t, err)
+		assert.Equal(t, stdout.String(), "")
+		assert.Equal(t, stderr.String(), "")
+
+		path := filepath.Join(dir, ".tool-versions")
+		bytes, err := os.ReadFile(path)
+		assert.Nil(t, err)
+		assert.Equal(t, "lua 5.2.3\n", string(bytes))
+	})
 }
 
 func buildOutputs() (strings.Builder, strings.Builder) {

--- a/internal/toolversions/toolversions.go
+++ b/internal/toolversions/toolversions.go
@@ -52,14 +52,14 @@ func updateContentWithToolVersions(content string, toolVersions []ToolVersions) 
 					// write updated version
 					newTv := toolVersions[indexMatching]
 					newTokens := toolVersionsToTokens(newTv)
-					fmt.Fprintf(&output, "%s\n", encodeLine(newTokens, comment))
+					writeLine(&output, encodeLine(newTokens, comment))
 					toolVersions = slices.Delete(toolVersions, indexMatching, indexMatching+1)
 					continue
 				}
 			}
 
 			// write back original line
-			fmt.Fprintf(&output, "%s\n", line)
+			writeLine(&output, line)
 		}
 	}
 
@@ -67,7 +67,7 @@ func updateContentWithToolVersions(content string, toolVersions []ToolVersions) 
 	if len(toolVersions) > 0 {
 		for _, toolVersion := range toolVersions {
 			newTokens := toolVersionsToTokens(toolVersion)
-			fmt.Fprintf(&output, "%s\n", encodeLine(newTokens, ""))
+			writeLine(&output, encodeLine(newTokens, ""))
 		}
 	}
 
@@ -260,4 +260,10 @@ func encodeLine(tokens []string, comment string) string {
 		return tokensStr
 	}
 	return fmt.Sprintf("%s #%s", tokensStr, comment)
+}
+
+func writeLine(output *strings.Builder, line string) {
+	if strings.TrimSpace(line) != "" {
+		output.WriteString(line + "\n")
+	}
 }


### PR DESCRIPTION
# Summary

Ensures that there is only a single trailing new line in the `.tool-versions` file.

Fixes #1840
