### PR TITLE
fix: bash command set end of line LF

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,7 @@ root = true
 [*]
 indent_style = space
 indent_size = 2
+end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
@@ -12,3 +13,6 @@ indent_size = 4
 
 [*.fish]
 indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
# Summary

line ending for shell scripts should be LF

Fixes: #1846, #1799

## Other Information

