### PR TITLE
fix(golang-rewrite): plugin list print messsage to stderr when no plugins installed

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -774,6 +774,11 @@ func pluginListCommand(cCtx *cli.Context, logger *log.Logger) error {
 		return err
 	}
 
+	if len(plugins) == 0 {
+		logger.Println("No plugins installed")
+		return nil
+	}
+
 	// TODO: Add some sort of presenter logic in another file so we
 	// don't clutter up this cmd code with conditional presentation
 	// logic


### PR DESCRIPTION
The Homebrew tests expect this.