### PR TITLE
docs: Fix go install command in getting-started.md

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -33,7 +33,7 @@ asdf can be installed in several different ways:
 
 <!-- x-release-please-start-version -->
 1. [Install Go](https://go.dev/doc/install)
-2. Run `go install github.com/asdf-vm/asdf@v0.16.0`
+2. Run `go install github.com/asdf-vm/asdf/cmd/asdf@v0.16.0`
 <!-- x-release-please-end -->
 
 ::::


### PR DESCRIPTION
# Summary

Advertised go install command does not work...
~~~
> go install github.com/asdf-vm/asdf@v0.16.0
package github.com/asdf-vm/asdf: build constraints exclude all Go files in /home/isi/.cache/go/pkg/mod/github.com/asdf-vm/asdf@v0.16.0
~~~

because entrypoint is under `cmd/asdf`. This works:
~~~
> go install github.com/asdf-vm/asdf/cmd/asdf@v0.16.0
go: downloading github.com/sethvargo/go-envconfig v1.0.0
go: downloading github.com/go-git/go-git/v5 v5.13.0
go: downloading github.com/urfave/cli/v2 v2.27.1
go: downloading dario.cat/mergo v1.0.0
go: downloading github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376
go: downloading github.com/pjbgf/sha1cd v0.3.0
go: downloading github.com/ProtonMail/go-crypto v1.1.3
go: downloading github.com/go-git/go-billy/v5 v5.6.0
go: downloading github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99
go: downloading github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3
go: downloading github.com/kevinburke/ssh_config v1.2.0
go: downloading github.com/skeema/knownhosts v1.3.0
go: downloading github.com/xanzy/ssh-agent v0.3.3
go: downloading gopkg.in/warnings.v0 v0.1.2
go: downloading github.com/cyphar/filepath-securejoin v0.2.5
go: downloading github.com/cloudflare/circl v1.3.7
~~~