### PR TITLE
docs: update path from `~/.bashprofile` -> `~/.zshrc` for zsh

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -190,7 +190,7 @@ export PATH="${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
 
 ###### Custom data directory (optional)
 
-Add the following to `~/.bash_profile` above the line you added above:
+Add the following to `~/.zshrc` above the line you added above:
 
 ```shell
 export ASDF_DATA_DIR="/your/custom/data/dir"


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

The ZSH Configuration section was saying to add path in bashprofile file instead of zshrc

