### PR TITLE
fix: correct SliceToMap environment variable parsing function

### DIFF
--- a/internal/execenv/execenv.go
+++ b/internal/execenv/execenv.go
@@ -69,8 +69,8 @@ func SliceToMap(env []string) map[string]string {
 
 	for _, envVar := range env {
 		varValue := strings.Split(envVar, "=")
-		if len(varValue) == 2 {
-			envMap[varValue[0]] = varValue[1]
+		if len(varValue) >= 2 {
+			envMap[varValue[0]] = strings.Join(varValue[1:], "=")
 		}
 	}
 

--- a/internal/execenv/execenv_test.go
+++ b/internal/execenv/execenv_test.go
@@ -1,6 +1,7 @@
 package execenv
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/asdf-vm/asdf/internal/config"
@@ -72,4 +73,30 @@ func TestGenerate(t *testing.T) {
 		_, found := env["FOO"]
 		assert.False(t, found)
 	})
+}
+
+func TestSliceToMap(t *testing.T) {
+	tests := []struct {
+		input  []string
+		output map[string]string
+	}{
+		{
+			input:  []string{"VAR=value"},
+			output: map[string]string{"VAR": "value"},
+		},
+		{
+			input:  []string{"BASH_FUNC_bats_readlinkf%%=() {  readlink -f \"$1\"\n}"},
+			output: map[string]string{"BASH_FUNC_bats_readlinkf%%": "() {  readlink -f \"$1\"\n}"},
+		},
+		{
+			input:  []string{"MYVAR=some things = with = in it"},
+			output: map[string]string{"MYVAR": "some things = with = in it"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("input: %s, output: %s", tt.input, tt.output), func(t *testing.T) {
+			assert.Equal(t, tt.output, SliceToMap(tt.input))
+		})
+	}
 }


### PR DESCRIPTION
The old code did not allow the equals sign in the environment variable value. But the equals sign is a valid character in value.

Fixes https://github.com/asdf-vm/asdf/issues/1876