### PR TITLE
fix: use version in home dir when no version found in root dir

### DIFF
--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -36,7 +36,17 @@ func Version(conf config.Config, plugin plugins.Plugin, directory string) (versi
 		}
 
 		nextDir := path.Dir(directory)
+		// If current dir and next dir are the same it means we've reached `/` and
+		// have no more parent directories to search.
 		if nextDir == directory {
+			// If no version found, try current users home directory. I'd like to
+			// eventually remove this feature.
+			homeDir, osErr := os.UserHomeDir()
+			if osErr != nil {
+				break
+			}
+
+			versions, found, err = findVersionsInDir(conf, plugin, homeDir)
 			break
 		}
 		directory = nextDir

--- a/internal/shims/shims.go
+++ b/internal/shims/shims.go
@@ -93,7 +93,9 @@ func FindExecutable(conf config.Config, shimName, currentDirectory string) (stri
 				}
 
 				versions.Versions = tempVersions
-				existingPluginToolVersions[plugin] = versions
+				if len(versions.Versions) > 0 {
+					existingPluginToolVersions[plugin] = versions
+				}
 			}
 		}
 	}
@@ -131,9 +133,9 @@ func FindExecutable(conf config.Config, shimName, currentDirectory string) (stri
 
 	tools := []string{}
 	versions := []string{}
-	for plugin := range existingPluginToolVersions {
+	for plugin, toolVersions := range existingPluginToolVersions {
 		tools = append(tools, plugin.Name)
-		versions = append(versions, existingPluginToolVersions[plugin].Versions...)
+		versions = append(versions, toolVersions.Versions...)
 	}
 
 	return "", plugins.Plugin{}, "", false, NoExecutableForPluginError{shim: shimName, tools: tools, versions: versions}

--- a/internal/versions/testdata/asdfrc
+++ b/internal/versions/testdata/asdfrc
@@ -1,4 +1,4 @@
-pre_asdf_download_lua = echo pre_asdf_download_lua $@
-pre_asdf_install_lua = echo pre_asdf_install_lua $@
-post_asdf_install_lua = echo post_asdf_install_lua $@
+pre_asdf_download_testlua = echo pre_asdf_download_lua $@
+pre_asdf_install_testlua = echo pre_asdf_install_lua $@
+post_asdf_install_testlua = echo post_asdf_install_lua $@
 always_keep_download = yes

--- a/internal/versions/versions_test.go
+++ b/internal/versions/versions_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const testPluginName = "lua"
+const testPluginName = "testlua"
 
 func TestInstallAll(t *testing.T) {
 	t.Run("installs multiple tools when multiple tool versions are specified", func(t *testing.T) {


### PR DESCRIPTION
* Use version in home dir when no version found in root dir
* Correct `FindExecutable` function so returns `NoVersionSetError` even when `.tool-version` file located
* Update `resolve` and `versions` package tests to use test plugin name

Fixes #1860