### PR TITLE
docs: Remove old hyphenated command from help

### DIFF
--- a/docs/ja-jp/manage/core.md
+++ b/docs/ja-jp/manage/core.md
@@ -43,22 +43,22 @@ asdf reshim <name> <version>
 ## Shimのバージョン
 
 ```shell
-asdf shim-versions <command>
+asdf shimversions <command>
 ```
 
 `<command>`のShimを提供するプラグインおよびバージョンを一覧で表示します。
 
-例えば、[Node.js](https://nodejs.org/)には`node`と`npm`という2つの実行ファイルが提供されています。[`asdf-nodejs`](https://github.com/asdf-vm/asdf-nodejs/)プラグインで、複数のバージョンのツールがインストールされている場合、`shim-versions`は下記のような一覧を返します:
+例えば、[Node.js](https://nodejs.org/)には`node`と`npm`という2つの実行ファイルが提供されています。[`asdf-nodejs`](https://github.com/asdf-vm/asdf-nodejs/)プラグインで、複数のバージョンのツールがインストールされている場合、`shimversions`は下記のような一覧を返します:
 
 ```shell
-➜ asdf shim-versions node
+➜ asdf shimversions node
 nodejs 14.8.0
 nodejs 14.17.3
 nodejs 16.5.0
 ```
 
 ```shell
-➜ asdf shim-versions npm
+➜ asdf shimversions npm
 nodejs 14.8.0
 nodejs 14.17.3
 nodejs 16.5.0

--- a/docs/ko-kr/manage/core.md
+++ b/docs/ko-kr/manage/core.md
@@ -43,22 +43,22 @@ asdf reshim <name> <version>
 ## Shim 버전
 
 ```shell
-asdf shim-versions <command>
+asdf shimversions <command>
 ```
 
 shim을 제공하는 플러그인 및 버전들을 나열합니다.
 
-예를 들면, [Node.js](https://nodejs.org/)에는 `node`와 `npm`이라고 하는 2개의 실행파일이 제공되고 있습니다. [`asdf-nodejs`](https://github.com/asdf-vm/asdf-nodejs/)을 통해 여러 버전의 툴이 설치되어 있는 경우, `shim-versions`는 아래와 같은 내용을 출력할 수 있습니다:
+예를 들면, [Node.js](https://nodejs.org/)에는 `node`와 `npm`이라고 하는 2개의 실행파일이 제공되고 있습니다. [`asdf-nodejs`](https://github.com/asdf-vm/asdf-nodejs/)을 통해 여러 버전의 툴이 설치되어 있는 경우, `shimversions`는 아래와 같은 내용을 출력할 수 있습니다:
 
 ```shell
-➜ asdf shim-versions node
+➜ asdf shimversions node
 nodejs 14.8.0
 nodejs 14.17.3
 nodejs 16.5.0
 ```
 
 ```shell
-➜ asdf shim-versions npm
+➜ asdf shimversions npm
 nodejs 14.8.0
 nodejs 14.17.3
 nodejs 16.5.0

--- a/docs/manage/core.md
+++ b/docs/manage/core.md
@@ -43,22 +43,22 @@ This recreates the shims for the current version of a package. By default, shims
 ## Shim-versions
 
 ```shell
-asdf shim-versions <command>
+asdf shimversions <command>
 ```
 
 Lists the plugins and versions that provide shims for a command.
 
-As an example, [Node.js](https://nodejs.org/) ships with two executables, `node` and `npm`. When many versions of the tools are installed with [`asdf-nodejs`](https://github.com/asdf-vm/asdf-nodejs/) `shim-versions` can return:
+As an example, [Node.js](https://nodejs.org/) ships with two executables, `node` and `npm`. When many versions of the tools are installed with [`asdf-nodejs`](https://github.com/asdf-vm/asdf-nodejs/) `shimversions` can return:
 
 ```shell
-➜ asdf shim-versions node
+➜ asdf shimversions node
 nodejs 14.8.0
 nodejs 14.17.3
 nodejs 16.5.0
 ```
 
 ```shell
-➜ asdf shim-versions npm
+➜ asdf shimversions npm
 nodejs 14.8.0
 nodejs 14.17.3
 nodejs 16.5.0

--- a/docs/pt-br/manage/core.md
+++ b/docs/pt-br/manage/core.md
@@ -45,22 +45,22 @@ Isso recria os shims para a versão atual de um pacote. Por padrão, os calços 
 ## Versionamento do Shim
 
 ```shell
-asdf shim-versions <command>
+asdf shimversions <command>
 ```
 
 Lista os plugins e versões que fornecem shims para um comando.
 
-Como exemplo, o [Node.js](https://nodejs.org/) vem com dois executáveis, `node` e `npm`. Quando muitas versões das ferramentas são instaladas com [`asdf-nodejs`](https://github.com/asdf-vm/asdf-nodejs/) `shim-versions` pode retornar:
+Como exemplo, o [Node.js](https://nodejs.org/) vem com dois executáveis, `node` e `npm`. Quando muitas versões das ferramentas são instaladas com [`asdf-nodejs`](https://github.com/asdf-vm/asdf-nodejs/) `shimversions` pode retornar:
 
 ```shell
-➜ asdf shim-versions node
+➜ asdf shimversions node
 nodejs 14.8.0
 nodejs 14.17.3
 nodejs 16.5.0
 ```
 
 ```shell
-➜ asdf shim-versions npm
+➜ asdf shimversions npm
 nodejs 14.8.0
 nodejs 14.17.3
 nodejs 16.5.0

--- a/docs/zh-hans/manage/core.md
+++ b/docs/zh-hans/manage/core.md
@@ -43,22 +43,22 @@ asdf reshim <name> <version>
 ## Shim-versions
 
 ```shell
-asdf shim-versions <command>
+asdf shimversions <command>
 ```
 
 列举为命令提供垫片的插件和版本。
 
-例如，[Node.js](https://nodejs.org/) 附带了两个可执行程序，`node` 和 `npm`。当使用 [`asdf-nodejs`](https://github.com/asdf-vm/asdf-nodejs/)`插件安装了这些工具的很多版本时，执行`shim-versions` 命令会返回：
+例如，[Node.js](https://nodejs.org/) 附带了两个可执行程序，`node` 和 `npm`。当使用 [`asdf-nodejs`](https://github.com/asdf-vm/asdf-nodejs/)`插件安装了这些工具的很多版本时，执行`shimversions` 命令会返回：
 
 ```shell
-➜ asdf shim-versions node
+➜ asdf shimversions node
 nodejs 14.8.0
 nodejs 14.17.3
 nodejs 16.5.0
 ```
 
 ```shell
-➜ asdf shim-versions npm
+➜ asdf shimversions npm
 nodejs 14.8.0
 nodejs 14.17.3
 nodejs 16.5.0

--- a/help.txt
+++ b/help.txt
@@ -56,7 +56,7 @@ asdf env <command> [util]               Runs util (default: `env`) inside the
 asdf info                               Print OS, Shell and ASDF debug information.
 asdf version                            Print the currently installed version of ASDF
 asdf reshim <name> <version>            Recreate shims for version of a package
-asdf shim-versions <command>            List the plugins and versions that
+asdf shimversions <command>             List the plugins and versions that
                                         provide a command
 asdf update                             Update asdf to the latest stable release
 asdf update --head                      Update asdf to the latest on the master branch

--- a/internal/help/help.txt
+++ b/internal/help/help.txt
@@ -51,7 +51,7 @@ asdf env <command> [util]               Runs util (default: `env`) inside the
 asdf info                               Print OS, Shell and ASDF debug information.
 asdf version                            Print the currently installed version of ASDF
 asdf reshim <name> <version>            Recreate shims for version of a package
-asdf shim-versions <command>            List the plugins and versions that
+asdf shimversions <command>             List the plugins and versions that
                                         provide a command
 
 RESOURCES


### PR DESCRIPTION
Remove old hyphenated command from help

* shim-versions -> shimversions