### PR TITLE
fix: filter version already installed errors on asdf install

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1115,7 +1115,9 @@ func filterInstallErrors(errs []error) []error {
 	var filtered []error
 	for _, err := range errs {
 		if _, ok := err.(versions.NoVersionSetError); !ok {
-			filtered = append(filtered, err)
+			if _, ok := err.(versions.VersionAlreadyInstalledError); !ok {
+				filtered = append(filtered, err)
+			}
 		}
 	}
 	return filtered

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1083,6 +1083,10 @@ func installCommand(logger *log.Logger, toolName, version string, keepDownload b
 		if version == "" {
 			err = versions.Install(conf, plugin, dir, os.Stdout, os.Stderr)
 			if err != nil {
+				if _, ok := err.(versions.VersionAlreadyInstalledError); ok {
+					return nil
+				}
+
 				if _, ok := err.(versions.NoVersionSetError); ok {
 					logger.Printf("No versions specified for %s in config files or environment", toolName)
 					os.Exit(1)
@@ -1104,6 +1108,9 @@ func installCommand(logger *log.Logger, toolName, version string, keepDownload b
 
 			if err != nil {
 				logger.Printf("error installing version: %s", err)
+				if _, ok := err.(versions.VersionAlreadyInstalledError); ok {
+					return nil
+				}
 			}
 		}
 	}

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -51,6 +51,17 @@ func (e NoVersionSetError) Error() string {
 	return "no version set"
 }
 
+// VersionAlreadyInstalledError is returned whenever a version is already
+// installed.
+type VersionAlreadyInstalledError struct {
+	toolName string
+  version toolversions.Version
+}
+
+func (e VersionAlreadyInstalledError) Error() string {
+  return fmt.Sprintf("version %s of %s is already installed", e.version, e.toolName)
+}
+
 // InstallAll installs all specified versions of every tool for the current
 // directory. Typically this will just be a single version, if not already
 // installed, but it may be multiple versions if multiple versions for the tool
@@ -143,7 +154,7 @@ func InstallOneVersion(conf config.Config, plugin plugins.Plugin, versionStr str
 	installDir := installs.InstallPath(conf, plugin, version)
 
 	if installs.IsInstalled(conf, plugin, version) {
-		return fmt.Errorf("version %s of %s is already installed", version, plugin.Name)
+    return VersionAlreadyInstalledError{version: version, toolName: plugin.Name}
 	}
 
 	env := map[string]string{


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->
* Add `VersionAlreadyInstalledError` for version already installed errors
* Update `filterInstallErrors` in `cli.go` to also filter out these errors from returning a non-zero status code

Fixes: https://github.com/asdf-vm/asdf/issues/1893

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->
I couldn't get "bats" running locally so not sure if all tests pass for this, but it fixes the non-zero status code issue which is inconsistent with how `0.15.0` behaved.
