### PR TITLE
feat: update makefile to generate valid semver for dev builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,37 @@ MAIN_PACKAGE_PATH := ./cmd/asdf
 TARGET_DIR := .
 TARGET := asdf
 
-# Because this Makefile isn't used as part of the actual release binary build,
-# It sets FULL_VERSION to a dev version containing the SHA of the current
-# commit. If we ever use this Makefile to generate release binaries this code
-# will need to change.
-FULL_VERSION = "$(shell git rev-parse --short HEAD)-dev"
+# Currently this Makefile isn't used as part of the actual release binary build,
+# It sets FULL_VERSION to a correct dev version including the SHA of the current
+# commit. This Makefile could be used to generate nightly release binaries.
+
+# Set base version for dev build from previous tag
+BASE_VERSION = $(shell git describe --tags --abbrev=0 2>/dev/null || echo "0.1.0")
+
+# Get number of commits since the last tag so that it can be used to generate valid higher semver
+COMMITS_SINCE_TAG = $(shell git rev-list $(BASE_VERSION).. --count 2>/dev/null || echo "0")
+
+# Get the current commit hash (short); add hash as semver build label which is not used for version sorting precedence
+GIT_HASH = $(shell git rev-parse --short HEAD)
+
+# Determine final version:
+ifeq ($(COMMITS_SINCE_TAG),0)
+    # If exactly on a tag, use BASE_VERSION as-is
+    FULL_VERSION = "$(BASE_VERSION)"
+else
+    # Extract major, minor, patch components needed to generate final dev build version
+    MAJOR = $(shell echo $(BASE_VERSION) | awk -F. '{print $$1}')
+    MINOR = $(shell echo $(BASE_VERSION) | awk -F. '{print $$2}')
+    PATCH = $(shell echo $(BASE_VERSION) | awk -F. '{print $$3}')
+
+    # Increment patch version for dev builds so that dev build version is always > than last tag version
+    DEV_PATCH = $(shell echo $$(($(PATCH) + 1)))
+
+    # Construct full version for dev build
+    FULL_VERSION = "$(MAJOR).$(MINOR).$(DEV_PATCH)-dev.$(COMMITS_SINCE_TAG)+$(GIT_HASH)"
+endif
+
+# Linker flags
 LINKER_FLAGS = '-s -X main.version=${FULL_VERSION}'
 
 # Not sure what the default location should be for builds


### PR DESCRIPTION
# Summary

### **Ensure Dev Builds produce valid [SemVer](https://semver.org/) versions**  

This PR updates the `Makefile` to ensure that development builds generate **valid SemVer versions**, making it easier for tools to correctly identify the asdf version in different environments.  

Currently, dev builds produce versions like:

```sh
$ asdf --version
asdf version "fdcd8af-dev"
```

This format is **not** a valid SemVer version and can cause issues for tools that rely on version comparisons.

With this PR, dev builds will now follow **SemVer-compatible** formatting, ensuring they always sort **higher** than the latest tagged release. For example, after **9 commits** past v0.16.1, the output would be:

```sh
$ asdf --version
asdf version "v0.16.2-dev.9+856cc1d"
```

This ensures a consistent versioning scheme while keeping the commit hash for traceability.

## Other Information

This addresses the concern I raised in this comment: https://github.com/asdf-vm/asdf/pull/1901#issuecomment-2642643206
