### PR TITLE
fix: correct help for asdf set command completion bash

### DIFF
--- a/internal/completions/asdf.bash
+++ b/internal/completions/asdf.bash
@@ -111,7 +111,7 @@ _asdf() {
       COMPREPLY=($(compgen -W "$versions" -- "$cur"))
     else
       # shellcheck disable=SC2207
-      COMPREPLY=($(compgen -W "$plugins -h -p" -- "$cur"))
+      COMPREPLY=($(compgen -W "$plugins -u -p" -- "$cur"))
     fi
     ;;
   latest)


### PR DESCRIPTION
# Summary

Update the completion bash with the fix from 554b4ea