### PR TITLE
fix: repair invalid fish shell completion code

### DIFF
--- a/internal/completions/asdf.fish
+++ b/internal/completions/asdf.fish
@@ -50,30 +50,30 @@ function __fish_asdf_list_shims
     path basename $asdf_data_dir/shims/*
 end
 
-# update
-complete -f -c asdf -n __fish_asdf_needs_command -a update -d "Update asdf"
-complete -f -c asdf -n '__fish_asdf_using_command update; and __fish_asdf_arg_number 2' -l head -d "Updates to master HEAD"
-
 # plugin add completion
-complete -f -c asdf -n __fish_asdf_needs_command -a plugin add -d "Add git repo as plugin"
-complete -f -c asdf -n '__fish_asdf_using_command plugin add; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list_all | grep -v \'*\' | awk \'{ print $1 }\')'
-complete -f -c asdf -n '__fish_asdf_using_command plugin add; and __fish_asdf_arg_number 3' -a '(__fish_asdf_plugin_list_all | grep (__fish_asdf_arg_at 3) | awk \'{ print $2 }\')'
-complete -f -c asdf -n '__fish_asdf_using_command plugin add; and __fish_asdf_arg_number 4'
+# suggest `add` after `plugin`
+complete -f -c asdf -n '__fish_asdf_using_command plugin; and __fish_asdf_arg_number 2' -a add -d "Add git repo as plugin"
+# show available plugins after `plugin add`
+complete -f -c asdf -n '__fish_asdf_using_command plugin; and __fish_asdf_arg_at 2 = "add"; and __fish_asdf_arg_number 3' -a '(__fish_asdf_plugin_list_all | grep -v \'*\' | awk \'{ print $1 }\')'
+# show repository urls for selected plugin
+complete -f -c asdf -n '__fish_asdf_using_command plugin; and __fish_asdf_arg_at 2 = "add"; and __fish_asdf_arg_number 4' -a '(__fish_asdf_plugin_list_all | grep (__fish_asdf_arg_at 3) | awk \'{ print $2 }\')'
 
 # plugin list completion
-complete -f -c asdf -n __fish_asdf_needs_command -a plugin list -d "List installed plugins"
-
-# plugin list all completion
-complete -f -c asdf -n __fish_asdf_needs_command -a plugin list all -d "List all existing plugins"
+complete -f -c asdf -n '__fish_asdf_using_command plugin; and __fish_asdf_arg_number 2' -a list -d "List installed plugins"
+complete -f -c asdf -n '__fish_asdf_using_command plugin; and __fish_asdf_arg_at 2 = "list"; and __fish_asdf_arg_number 3' -a all -d "List all available plugins"
 
 # plugin remove completion
-complete -f -c asdf -n __fish_asdf_needs_command -a plugin remove -d "Remove plugin and package versions"
-complete -f -c asdf -n '__fish_asdf_using_command plugin remove; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
+# show `remove` as an option for `plugin`
+complete -f -c asdf -n '__fish_asdf_using_command plugin; and __fish_asdf_arg_number 2' -a remove -d "Remove plugin and package versions"
+# Show list of plugins after `remove`
+complete -f -c asdf -n '__fish_asdf_using_command plugin; and __fish_asdf_arg_at 2 = "remove"; and __fish_asdf_arg_number 3' -a '(__fish_asdf_plugin_list)'
 
 # plugin update completion
-complete -f -c asdf -n __fish_asdf_needs_command -a plugin update -d "Update plugin"
-complete -f -c asdf -n '__fish_asdf_using_command plugin update; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
-complete -f -c asdf -n '__fish_asdf_using_command plugin update; and __fish_asdf_arg_number 2' -a --all
+complete -f -c asdf -n '__fish_asdf_using_command plugin; and __fish_asdf_arg_number 2' -a update -d "Update plugin"
+# suggest the plugin list
+complete -f -c asdf -n '__fish_asdf_using_command plugin; and __fish_asdf_arg_at 2 = "update"; and __fish_asdf_arg_number 3' -a '(__fish_asdf_plugin_list)'
+# suggest '--all'
+complete -f -c asdf -n '__fish_asdf_using_command plugin; and __fish_asdf_arg_at 2 = "update"; and __fish_asdf_arg_number 3' -a --all
 
 # install completion
 complete -f -c asdf -n __fish_asdf_needs_command -a install -d "Install a specific version of a package"
@@ -108,8 +108,8 @@ complete -f -c asdf -n __fish_asdf_needs_command -a list -d "List installed vers
 complete -f -c asdf -n '__fish_asdf_using_command list; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
 
 # list-all completion
-complete -f -c asdf -n __fish_asdf_needs_command -a list all -d "List all versions of a package"
-complete -f -c asdf -n '__fish_asdf_using_command list all; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
+complete -f -c asdf -n '__fish_asdf_using_command list; and __fish_asdf_arg_number 2' -a all -d "List all versions of a package"
+complete -f -c asdf -n '__fish_asdf_using_command list; and __fish_asdf_arg_at 2 = "all"; and __fish_asdf_arg_number 3' -a '(__fish_asdf_plugin_list)'
 
 # reshim completion
 complete -f -c asdf -n __fish_asdf_needs_command -a reshim -d "Recreate shims for version of a package"
@@ -120,20 +120,14 @@ complete -f -c asdf -n '__fish_asdf_using_command reshim; and __fish_asdf_arg_nu
 complete -f -c asdf -n __fish_asdf_needs_command -a shimversions -d "List the plugins and versions that provide a command"
 complete -f -c asdf -n '__fish_asdf_using_command shimversions; and __fish_asdf_arg_number 2' -a '(__fish_asdf_list_shims)'
 
-# local completion
-complete -f -c asdf -n __fish_asdf_needs_command -a local -d "Set local version for a plugin"
-complete -f -c asdf -n '__fish_asdf_using_command local; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
-complete -f -c asdf -n '__fish_asdf_using_command local; and test (count (commandline -opc)) -gt 2' -a '(__fish_asdf_list_versions (__fish_asdf_arg_at 3)) system'
+# set completion
+complete -f -c asdf -n __fish_asdf_needs_command -a set -d "Set version for a plugin"
+complete -f -c asdf -n '__fish_asdf_using_command set; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
+complete -f -c asdf -n '__fish_asdf_using_command set; and test (count (commandline -opc)) -gt 2' -a '(__fish_asdf_list_versions (__fish_asdf_arg_at 3)) system'
 
-# global completion
-complete -f -c asdf -n __fish_asdf_needs_command -a global -d "Set global version for a plugin"
-complete -f -c asdf -n '__fish_asdf_using_command global; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
-complete -f -c asdf -n '__fish_asdf_using_command global; and test (count (commandline -opc)) -gt 2' -a '(__fish_asdf_list_versions (__fish_asdf_arg_at 3)) system'
-
-# shell completion
-complete -f -c asdf -n __fish_asdf_needs_command -a shell -d "Set version for a plugin in current shell session"
-complete -f -c asdf -n '__fish_asdf_using_command shell; and __fish_asdf_arg_number 2' -a '(__fish_asdf_plugin_list)'
-complete -f -c asdf -n '__fish_asdf_using_command shell; and test (count (commandline -opc)) -gt 2' -a '(__fish_asdf_list_versions (__fish_asdf_arg_at 3)) system'
+# set commands
+complete -f -c asdf -n '__fish_asdf_using_command set' -l home -d "Set version in home directory"
+complete -f -c asdf -n '__fish_asdf_using_command set' -l parent -d "Set version in parent directory"
 
 # misc
 complete -f -c asdf -n __fish_asdf_needs_command -l help -d "Displays help"

--- a/internal/completions/asdf.fish
+++ b/internal/completions/asdf.fish
@@ -50,7 +50,8 @@ function __fish_asdf_list_shims
     path basename $asdf_data_dir/shims/*
 end
 
-# plugin add completion
+# plugin completion
+complete -f -c asdf -n __fish_asdf_needs_command -a plugin -d "Plugin management sub-commands"
 # suggest `add` after `plugin`
 complete -f -c asdf -n '__fish_asdf_using_command plugin; and __fish_asdf_arg_number 2' -a add -d "Add git repo as plugin"
 # show available plugins after `plugin add`


### PR DESCRIPTION
Fixes related to #1934 & #1908

Earlier changes introduced in #1912 broke the fish shell completions. The changes were for both `zsh` and `fish`. Though, here we are making changes only for fixing `fish`.

There is room for improvement but the fix right now is focused to make the broken stuff work. 

Below commands are removed
- `global`
- `local`
- `update`