### PR TITLE
fix: correct typo in `Upgrading to 0.16.0` documentation

### DIFF
--- a/docs/guide/upgrading-to-v0-16.md
+++ b/docs/guide/upgrading-to-v0-16.md
@@ -35,7 +35,7 @@ the asdf binary in `$HOME/bin` and then added `$HOME/bin` to the front of my
 
 ```
 # In .zshrc, .bashrc, etc...
-export PATH="$HOME/bin:$PATH"`
+export PATH="$HOME/bin:$PATH"
 ```
 
 #### 2. Set `ASDF_DATA_DIR`


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

This PR fixes typos in the [Upgrading Without Losing Data](https://asdf-vm.com/guide/upgrading-to-v0-16#_1-download-the-appropriate-asdf-binary-for-your-operating-system-architecture) section of the `Upgrading to 0.16.0` documentation. The existing typos caused errors when copying and pasting the provided commands, which this update resolves.

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->
