### PR TITLE
docs: correct typo in asdf configuration guide

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -61,7 +61,7 @@ asdf can be installed in several different ways:
 ::: tip Note
 Most users **DO NOT** need to customize the location that asdf writes plugin,
 install, and shim data to. However, if `$HOME/.asdf` isn't the directory you
-want asdf writing too, you can change it. Specify the directory by exporting
+want asdf writing to, you can change it. Specify the directory by exporting
 a variable named `ASDF_DATA_DIR` in your shell's RC file.
 :::
 


### PR DESCRIPTION
# Summary

This pull request fixes a minor typo in the asdf configuration documentation. The documentation originally stated:

> if $HOME/.asdf isn't the directory you want asdf writing **too**, you can change it.

It has been updated to:

> if $HOME/.asdf isn't the directory you want asdf writing **to**, you can change it.

Fixes: [asdf-vm/asdf#1942](https://github.com/asdf-vm/asdf/issues/1942)

## Other Information

There are no additional changes beyond the documentation fix. Thank you for reviewing this contribution, and thank you for maintaining asdf!
