### PR TITLE
docs: fix command examples in upgrading-to-v0-16 guide

### DIFF
--- a/docs/guide/upgrading-to-v0-16.md
+++ b/docs/guide/upgrading-to-v0-16.md
@@ -194,7 +194,7 @@ Now:
 ```
 $ asdf cmd foo         # same as running `$ASDF_DATA_DIR/plugins/foo/lib/commands/command`
 $ asdf cmd foo bar     # same as running `$ASDF_DATA_DIR/plugins/foo/lib/commands/command-bar`
-$ asdf cmd foo bat man # same as running `$ASDF_DATA_DIR/plugins/foo/lib/commands/command bat man`
+$ asdf cmd foo bat man # same as running `$ASDF_DATA_DIR/plugins/foo/lib/commands/command-bat man`
 ```
 
 ### Executables Shims Resolve to Must Runnable by `syscall.Exec`


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->
Based on the description I believe the `asdf cmd foo bat man` has a typo in the name of the command thats bring run.
This PR changes the example 

