### PR TITLE
fix: install should report missing plugins

### DIFF
--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"regexp"
 	"strings"
 
@@ -26,6 +27,7 @@ const (
 	uninstallableVersionMsg = "uninstallable version: %s"
 	latestFilterRegex       = "(?i)(^Available versions:|-src|-dev|-latest|-stm|[-\\.]rc|-milestone|-alpha|-beta|[-\\.]pre|-next|(a|b|c)[0-9]+|snapshot|master)"
 	noLatestVersionErrMsg   = "no latest version found"
+	missingPluginErrMsg     = "missing plugin for %s"
 )
 
 // UninstallableVersionError is an error returned if someone tries to install the
@@ -42,6 +44,16 @@ func (e UninstallableVersionError) Error() string {
 // is not able to resolve one.
 type NoVersionSetError struct {
 	toolName string
+}
+
+// MissingPluginError is returned whenever an operation expects a plugin,
+// but it is not installed.
+type MissingPluginError struct {
+	toolName string
+}
+
+func (e MissingPluginError) Error() string {
+	return fmt.Sprintf(missingPluginErrMsg, e.toolName)
 }
 
 func (e NoVersionSetError) Error() string {
@@ -61,14 +73,29 @@ func InstallAll(conf config.Config, dir string, stdOut io.Writer, stdErr io.Writ
 		return []error{fmt.Errorf("unable to list plugins: %w", err)}
 	}
 
+	toolNames := map[string]bool{}
+	filepath := path.Join(dir, conf.DefaultToolVersionsFilename)
+	toolVersions, err := toolversions.GetAllToolsAndVersions(filepath)
+	if err == nil {
+		for _, version := range toolVersions {
+			toolNames[version.Name] = true
+		}
+	}
+
 	// Ideally we should install these in the order they are specified in the
 	// closest .tool-versions file, but for now that is too complicated to
 	// implement.
 	for _, plugin := range plugins {
+		delete(toolNames, plugin.Name)
 		err := Install(conf, plugin, dir, stdOut, stdErr)
 		if err != nil {
 			failures = append(failures, err)
 		}
+	}
+
+	for toolName := range toolNames {
+		err = MissingPluginError{toolName: toolName}
+		failures = append(failures, err)
 	}
 
 	return failures

--- a/internal/versions/versions_test.go
+++ b/internal/versions/versions_test.go
@@ -47,6 +47,7 @@ func TestInstallAll(t *testing.T) {
 		writeVersionFile(t, currentDir, content)
 
 		err := InstallAll(conf, currentDir, &stdout, &stderr)
+		assert.Len(t, err, 1, "expected 1 install error")
 		assert.ErrorContains(t, err[0], "no version set")
 
 		assertVersionInstalled(t, conf.DataDir, plugin.Name, version)
@@ -68,6 +69,23 @@ func TestInstallAll(t *testing.T) {
 		assert.Empty(t, err)
 
 		assertNotInstalled(t, conf.DataDir, secondPlugin.Name, version)
+		assertVersionInstalled(t, conf.DataDir, plugin.Name, version)
+	})
+
+	t.Run("reports skipped tools due to missing plugin", func(t *testing.T) {
+		conf, plugin := generateConfig(t)
+		stdout, stderr := buildOutputs()
+		currentDir := t.TempDir()
+		version := "1.0.0"
+
+		// write a version file
+		content := fmt.Sprintf("%s %s\n%s %s", plugin.Name, version, "non-existant-tool", version)
+		writeVersionFile(t, currentDir, content)
+
+		err := InstallAll(conf, currentDir, &stdout, &stderr)
+		assert.Len(t, err, 1, "expected 1 install error")
+		assert.ErrorContains(t, err[0], "missing plugin for")
+
 		assertVersionInstalled(t, conf.DataDir, plugin.Name, version)
 	})
 }


### PR DESCRIPTION
# Summary

Indicates in the "install" output if a requested tool/version could not be installed due to the plugin not being installed. This will cause the application to exit with a non-zero exit code. Prior to this change, install would complete successfully without any indication that some required tool(s) were not successfully configured.

## Other Information

Sample output:
```
andre@Andres-MacBook-Pro asdf % ./asdf install
version {version 1.8.2} of bats is already installed
version {version 1.18.2-otp-27} of elixir is already installed
version {version 27.2.2} of erlang is already installed
version {version 1.23.4} of golang is already installed
version {version 8.12.1} of gradle is already installed
version {version zulu-21.40.17} of java is already installed
version {version 3.6.0} of shfmt is already installed
missing plugin for shellcheck
andre@Andres-MacBook-Pro asdf % echo $?
1
```
