### PR TITLE
fix: return no error from shims.RemoveAll when shims dir missing

### DIFF
--- a/internal/shims/shims.go
+++ b/internal/shims/shims.go
@@ -4,6 +4,7 @@ package shims
 import (
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path"
@@ -226,6 +227,11 @@ func RemoveAll(conf config.Config) error {
 	shimDir := filepath.Join(conf.DataDir, shimDirName)
 	entries, err := os.ReadDir(shimDir)
 	if err != nil {
+		if _, ok := err.(*fs.PathError); ok {
+			// if directory doesn't exist we can just return because no shims can
+			// possibly exist.
+			return nil
+		}
 		return err
 	}
 

--- a/internal/shims/shims_test.go
+++ b/internal/shims/shims_test.go
@@ -161,6 +161,12 @@ func TestRemoveAll(t *testing.T) {
 			assert.True(t, errors.Is(err, os.ErrNotExist))
 		}
 	})
+
+	t.Run("does not return error when shims directory does not exist", func(t *testing.T) {
+		shimDir := Directory(conf)
+		assert.Nil(t, os.RemoveAll(shimDir))
+		assert.Nil(t, RemoveAll(conf))
+	})
 }
 
 func TestGenerateAll(t *testing.T) {

--- a/test/reshim_command.bats
+++ b/test/reshim_command.bats
@@ -15,6 +15,12 @@ teardown() {
   clean_asdf_dir
 }
 
+@test "reshim should print error when plugin with name does not exist" {
+  run asdf reshim non-existent 1.0
+  [ "$status" -eq 1 ]
+  [ "$output" = "No such plugin: non-existent" ]
+}
+
 @test "reshim should allow prefixes of other versions" {
   run asdf install dummy 1.0.1
   run asdf install dummy 1.0


### PR DESCRIPTION
Fixes https://github.com/asdf-vm/asdf/issues/1891

Also update `asdf reshim` so it prints an error when plugin with name is not found.