### PR TITLE
Fix: Add a newline delimiter when suggesting versions to install

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -678,7 +678,7 @@ func getExecutable(logger *log.Logger, conf config.Config, command string) (exec
 
 			for _, toolVersion := range toolVersions {
 				for _, version := range toolVersion.Versions {
-					fmt.Printf("%s %s", toolVersion.Name, version)
+					fmt.Printf("%s %s\n", toolVersion.Name, version)
 				}
 			}
 		}


### PR DESCRIPTION
# Summary

<!-- Provide a general description of the code changes in your pull request. -->

Adds a new line delimiter when suggesting versions for a user to set.

Sample output without this change:
```
andre@Andres-MBP ws % go version
No version is set for command go
Consider adding one of the following versions in your config file at /Users/andre/ws/.tool-versions
golang 1.24.0golang 1.23.4%
```

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->
