### PR TITLE
fix: envMap to work with env var values containing an equal sign.

### DIFF
--- a/internal/execenv/execenv.go
+++ b/internal/execenv/execenv.go
@@ -55,8 +55,8 @@ func envMap(env string) map[string]string {
 
 	for _, envVar := range strings.Split(env, "\n") {
 		varValue := strings.Split(envVar, "=")
-		if len(varValue) == 2 {
-			slice[varValue[0]] = varValue[1]
+		if len(varValue) >= 2 {
+			slice[varValue[0]] = strings.Join(varValue[1:], "=")
 		}
 	}
 


### PR DESCRIPTION


# Summary

Fixes: envMap to work with env var values containing an equal sign.

## Other Information

SliceToMap has been modified to support = in values, but envMap was not updated accordingly.








