### PR TITLE
Fix: Add missing new line to proposed versions.

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -678,7 +678,7 @@ func getExecutable(logger *log.Logger, conf config.Config, command string) (exec
 
 			for _, toolVersion := range toolVersions {
 				for _, version := range toolVersion.Versions {
-					fmt.Printf("%s %s", toolVersion.Name, version)
+					fmt.Printf("%s %s\n", toolVersion.Name, version)
 				}
 			}
 		}


### PR DESCRIPTION
# Summary

The display is wrong when no version is set in .tools-version

```
ylecuyer@hawk:~$ java
No version is set for command java
Consider adding one of the following versions in your config file at /home/ylecuyer/.tool-versions
java openjdk-17java corretto-8.442.06.1ylecuyer@hawk:~$ 
```

Expected output

```
ylecuyer@hawk:~$ java
No version is set for command java
Consider adding one of the following versions in your config file at /home/ylecuyer/.tool-versions
java openjdk-17
java corretto-8.442.06.1
ylecuyer@hawk:~$ 
```

Fixes: N/A afaik

## Other Information

N/A