### PR TITLE
fix: simplify env vars parsing

### DIFF
--- a/internal/execenv/execenv.go
+++ b/internal/execenv/execenv.go
@@ -27,11 +27,11 @@ func Generate(plugin plugins.Plugin, callbackEnv map[string]string) (env map[str
 	// executing the callback isn't enough. We actually need to source it (.) so
 	// the environment variables get set, and then run `env` so they get printed
 	// to STDOUT.
-	expression := execute.NewExpression(fmt.Sprintf(". \"%s\"; env", execEnvPath), []string{})
+	expression := execute.NewExpression(fmt.Sprintf(". \"%s\"; env -0", execEnvPath), []string{})
 	expression.Env = callbackEnv
 	expression.Stdout = &stdout
 	err = expression.Run()
 
 	str := stdout.String()
-	return execute.SliceToMap(strings.Split(str, "\n")), err
+	return execute.SliceToMap(strings.Split(str, "\x00")), err
 }

--- a/internal/execenv/execenv_test.go
+++ b/internal/execenv/execenv_test.go
@@ -74,9 +74,8 @@ func TestGenerate(t *testing.T) {
 		assert.Nil(t, err)
 		plugin := plugins.New(conf, testPluginName)
 		assert.Nil(t, repotest.WritePluginCallback(plugin.Dir, "exec-env", "#!/usr/bin/env bash\nexport BAZ=\""+value+"\""))
-		env, err := Generate(plugin, map[string]string{"EQUALSTEST": "abc\n123"})
+		env, err := Generate(plugin, map[string]string{})
 		assert.Nil(t, err)
 		assert.Equal(t, value, env["BAZ"])
-		assert.Equal(t, "abc\n123", env["EQUALSTEST"])
 	})
 }

--- a/internal/execenv/execenv_test.go
+++ b/internal/execenv/execenv_test.go
@@ -65,4 +65,18 @@ func TestGenerate(t *testing.T) {
 		assert.Equal(t, "bar", env["BAZ"])
 		assert.Equal(t, "abc\n123", env["EQUALSTEST"])
 	})
+
+	t.Run("preserves environment variables that contain equals sign and line breaks in value", func(t *testing.T) {
+		value := "-----BEGIN CERTIFICATE-----\nMANY\\LINES\\THE\nLAST\\ONE\\ENDS\\IN\nAN=\n-----END CERTIFICATE-----"
+		testDataDir := t.TempDir()
+		conf := config.Config{DataDir: testDataDir}
+		_, err := repotest.InstallPlugin("dummy_plugin", testDataDir, testPluginName)
+		assert.Nil(t, err)
+		plugin := plugins.New(conf, testPluginName)
+		assert.Nil(t, repotest.WritePluginCallback(plugin.Dir, "exec-env", "#!/usr/bin/env bash\nexport BAZ=\""+value+"\""))
+		env, err := Generate(plugin, map[string]string{"EQUALSTEST": "abc\n123"})
+		assert.Nil(t, err)
+		assert.Equal(t, value, env["BAZ"])
+		assert.Equal(t, "abc\n123", env["EQUALSTEST"])
+	})
 }

--- a/internal/execute/execute.go
+++ b/internal/execute/execute.go
@@ -95,19 +95,11 @@ func MapToSlice(env map[string]string) (slice []string) {
 func SliceToMap(env []string) map[string]string {
 	envMap := map[string]string{}
 
-	var previousKey string
-
 	for _, envVar := range env {
 		varValue := strings.SplitN(envVar, "=", 2)
 
 		if len(varValue) == 2 {
-			// new var=value line
-			previousKey = varValue[0]
 			envMap[varValue[0]] = varValue[1]
-		} else {
-			// value from variable defined on a previous line, append
-			val := envMap[previousKey]
-			envMap[previousKey] = val + "\n" + varValue[0]
 		}
 	}
 

--- a/internal/execute/execute_test.go
+++ b/internal/execute/execute_test.go
@@ -269,10 +269,6 @@ func TestSliceToMap(t *testing.T) {
 			input:  []string{"MYVAR=value\nwith\nnewlines"},
 			output: map[string]string{"MYVAR": "value\nwith\nnewlines"},
 		},
-		{
-			input:  []string{"MYVAR=value", "with", "newlines"},
-			output: map[string]string{"MYVAR": "value\nwith\nnewlines"},
-		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# Summary

Simplifies the parsing of env vars reported by bash by parsing NULL delimited values rather than new lines.

Fixes: https://github.com/asdf-vm/asdf/issues/1986

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->
