### PR TITLE
fix: set correct env vars on recursive calls

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,9 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[*.go]
+indent_style = tab
+
 [*.py]
 indent_size = 4
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ repository
 .vagrant
 keyrings
 /tmp
+.idea
 
 dist/
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -340,7 +340,12 @@ func Execute(version string) {
 		},
 	}
 
-	err := app.Run(os.Args)
+	err := unsetAsdfReservedEnvVars()
+	if err != nil {
+		os.Exit(1)
+	}
+
+	err = app.Run(os.Args)
 	if err != nil {
 		os.Exit(1)
 	}
@@ -1565,4 +1570,17 @@ func installedStatus(installed bool) string {
 		return "installed"
 	}
 	return "missing"
+}
+
+func unsetAsdfReservedEnvVars() error {
+	// These are environment variables which are passed via env or exec.
+	// We strip these out to avoid any potential issues with recursive calls to asdf.
+	asdfManagedVars := []string{"ASDF_INSTALL_TYPE", "ASDF_INSTALL_VERSION", "ASDF_INSTALL_PATH"}
+	for _, v := range asdfManagedVars {
+		err := os.Unsetenv(v)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/help/help.go
+++ b/internal/help/help.go
@@ -93,9 +93,7 @@ func WriteToolVersionHelp(conf config.Config, toolName, toolVersion string, writ
 func writePluginHelp(conf config.Config, toolName, toolVersion string, writer io.Writer, errWriter io.Writer) error {
 	plugin := plugins.New(conf, toolName)
 	env := map[string]string{
-		"ASDF_INSTALL_PATH":    plugin.Dir,
-		"ASDF_INSTALL_VERSION": "",
-		"ASDF_INSTALL_TYPE":    "",
+		"ASDF_INSTALL_PATH": plugin.Dir,
 	}
 
 	if toolVersion != "" {

--- a/internal/help/help.go
+++ b/internal/help/help.go
@@ -93,7 +93,9 @@ func WriteToolVersionHelp(conf config.Config, toolName, toolVersion string, writ
 func writePluginHelp(conf config.Config, toolName, toolVersion string, writer io.Writer, errWriter io.Writer) error {
 	plugin := plugins.New(conf, toolName)
 	env := map[string]string{
-		"ASDF_INSTALL_PATH": plugin.Dir,
+		"ASDF_INSTALL_PATH":    plugin.Dir,
+		"ASDF_INSTALL_VERSION": "",
+		"ASDF_INSTALL_TYPE":    "",
 	}
 
 	if toolVersion != "" {

--- a/test/plugin_extension_command.bats
+++ b/test/plugin_extension_command.bats
@@ -133,7 +133,5 @@ EOF
 
   run asdf cmd dummy
   [ "$status" -eq 0 ]
-  envs="$output"
-
-  [ "0" -eq "$(echo "$envs" | grep -c "ASDF_INSTALL_")" ]
+  [ "0" -eq "$(echo "$output" | grep -c "ASDF_INSTALL_")" ]
 }

--- a/test/plugin_extension_command.bats
+++ b/test/plugin_extension_command.bats
@@ -116,3 +116,24 @@ EOF
   [ "$status" -eq 0 ]
   [ "$output" = "$expected" ]
 }
+
+@test "asdf execute plugin default command unsets ASDF_INSTALL_TYPE ASDF_INSTALL_VERSION and ASDF_INSTALL_PATH env variables" {
+  export ASDF_INSTALL_VERSION=1.2.3
+  export ASDF_INSTALL_TYPE=version
+  export ASDF_INSTALL_PATH=/somewhere
+
+  plugin_path="$(get_plugin_path dummy)"
+
+  # this plugin defines a new `asdf dummy` command
+  cat <<'EOF' >"$plugin_path/lib/commands/command"
+#!/usr/bin/env bash
+/usr/bin/env
+EOF
+  chmod +x "$plugin_path/lib/commands/command"
+
+  run asdf cmd dummy
+  [ "$status" -eq 0 ]
+  envs="$output"
+
+  [ "0" -eq "$(echo "$envs" | grep "ASDF_INSTALL_" | wc -l)" ]
+}

--- a/test/plugin_extension_command.bats
+++ b/test/plugin_extension_command.bats
@@ -135,5 +135,5 @@ EOF
   [ "$status" -eq 0 ]
   envs="$output"
 
-  [ "0" -eq "$(echo "$envs" | grep "ASDF_INSTALL_" | wc -l)" ]
+  [ "0" -eq "$(echo "$envs" | grep -c "ASDF_INSTALL_")" ]
 }


### PR DESCRIPTION
# Summary

Addresses the feedback mentioned here: https://github.com/asdf-vm/asdf/pull/1982#issuecomment-2682248660

The solution outlined here strips values which should not be passed through asdf on recursive calls. It's done before any other logic is invoked in order to minimize the number of places that need to consider this case. Open to feedback on this approach.

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->
