### PR TITLE
fix: correct exit status when sub-command does not exist

### DIFF
--- a/cmd/asdf/main_test.go
+++ b/cmd/asdf/main_test.go
@@ -106,6 +106,10 @@ func TestBatsTests(t *testing.T) {
 	t.Run("which_command", func(t *testing.T) {
 		runBatsFile(t, dir, "which_command.bats")
 	})
+
+	t.Run("non_existent_command", func(t *testing.T) {
+		runBatsFile(t, dir, "non_existent_command.bats")
+	})
 }
 
 func runBatsFile(t *testing.T, dir, filename string) {

--- a/test/non_existent_command.bats
+++ b/test/non_existent_command.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+
+load test_helpers
+
+setup() {
+  setup_asdf_dir
+  install_dummy_plugin
+  install_dummy_legacy_plugin
+  run asdf install dummy 1.0
+  run asdf install dummy 1.1
+
+  PROJECT_DIR="$HOME/project"
+  mkdir -p "$PROJECT_DIR"
+}
+
+teardown() {
+  clean_asdf_dir
+}
+
+@test "should show help when no valid command is provided" {
+  cd "$PROJECT_DIR"
+
+  run asdf non-existent-command
+
+  [ "$status" -eq 1 ]
+  [[ $output == 'invalid command provided:'* ]]
+  [[ $output == *$'version: v'* ]]
+  [[ $output == *$'MANAGE PLUGINS\n'* ]]
+  [[ $output == *$'MANAGE TOOLS\n'* ]]
+  [[ $output == *$'UTILS\n'* ]]
+  [[ $output == *$'"Late but latest"\n-- Rajinikanth' ]]
+}

--- a/test/non_existent_command.bats
+++ b/test/non_existent_command.bats
@@ -4,17 +4,9 @@ load test_helpers
 
 setup() {
   setup_asdf_dir
-  install_dummy_plugin
-  install_dummy_legacy_plugin
-  run asdf install dummy 1.0
-  run asdf install dummy 1.1
 
   PROJECT_DIR="$HOME/project"
   mkdir -p "$PROJECT_DIR"
-}
-
-teardown() {
-  clean_asdf_dir
 }
 
 @test "should show help when no valid command is provided" {


### PR DESCRIPTION
Change exit status code when command does not exists.

Fixes #1928