### PR TITLE
fix: correct ASDF_INSTALL_* envvar unset test

### DIFF
--- a/test/plugin_extension_command.bats
+++ b/test/plugin_extension_command.bats
@@ -133,5 +133,5 @@ EOF
 
   run asdf cmd dummy
   [ "$status" -eq 0 ]
-  [ "0" -eq "$(echo "$output" | grep -c "ASDF_INSTALL_")" ]
+  [ "0" -eq "$(echo "$output" | grep -c "^ASDF_INSTALL_")" ]
 }


### PR DESCRIPTION
# Summary

Check for existence of environment variables with `ASDF_INSTALL_` prefix rather than `ASDF_INSTALL_` in the value of the variables.

Fixes: 2005

## Other Information

`bats` is setting a variable with the description of the test running causing the test to fail:
```
BATS_TEST_DESCRIPTION=asdf execute plugin default command unsets ASDF_INSTALL_TYPE ASDF_INSTALL_VERSION and ASDF_INSTALL_PATH env variables
```

Related to: https://github.com/asdf-vm/asdf/pull/1982