### PR TITLE
fix: improve handling of unsuccesful tool installations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ repository
 keyrings
 /tmp
 .idea
+.vscode
 
 dist/
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -437,7 +437,7 @@ func getVersionInfo(conf config.Config, plugin plugins.Plugin, currentDir string
 	if found {
 		firstVersion := toolversion.Versions[0]
 		version := toolversions.Parse(firstVersion)
-		installed = installs.IsInstalled(conf, plugin, version)
+		installed = installs.InstallDirExists(conf, plugin, version)
 	}
 	return toolversion, found, installed
 }
@@ -705,7 +705,7 @@ func anyInstalled(conf config.Config, toolVersions []toolversions.ToolVersions) 
 		for _, version := range toolVersion.Versions {
 			version := toolversions.Parse(version)
 			plugin := plugins.New(conf, toolVersion.Name)
-			if installs.IsInstalled(conf, plugin, version) {
+			if installs.InstallDirExists(conf, plugin, version) {
 				return true
 			}
 		}
@@ -1501,7 +1501,7 @@ func whereCommand(logger *log.Logger, tool, versionStr string) error {
 
 		if found && len(versions.Versions) > 0 {
 			versionStruct := toolversions.Version{Type: "version", Value: versions.Versions[0]}
-			if installs.IsInstalled(conf, plugin, versionStruct) {
+			if installs.InstallDirExists(conf, plugin, versionStruct) {
 				installPath := installs.InstallPath(conf, plugin, versionStruct)
 				fmt.Printf("%s", installPath)
 				return nil
@@ -1514,7 +1514,7 @@ func whereCommand(logger *log.Logger, tool, versionStr string) error {
 		return errors.New(msg)
 	}
 
-	if !installs.IsInstalled(conf, plugin, version) {
+	if !installs.InstallDirExists(conf, plugin, version) {
 		logger.Printf("Version not installed")
 		return errors.New("Version not installed")
 	}
@@ -1558,7 +1558,7 @@ func latestForPlugin(conf config.Config, toolName, pattern string, showStatus bo
 	}
 
 	if showStatus {
-		installed := installs.IsInstalled(conf, plugin, toolversions.Version{Type: "version", Value: latest})
+		installed := installs.InstallDirExists(conf, plugin, toolversions.Version{Type: "version", Value: latest})
 		fmt.Printf("%s\t%s\t%s\n", plugin.Name, latest, installedStatus(installed))
 	} else {
 		fmt.Printf("%s\n", latest)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1294,6 +1294,11 @@ func listLocalCommand(logger *log.Logger, conf config.Config, pluginName, filter
 		}
 
 		for _, version := range versions {
+			versionObj := toolversions.Version{Type: "version", Value: version}
+			if !shims.ShimExists(conf, plugin, versionObj) {
+				continue
+			}
+
 			if slices.Contains(currentVersions.Versions, version) {
 				fmt.Printf(" *%s\n", version)
 			} else {
@@ -1319,7 +1324,13 @@ func listLocalCommand(logger *log.Logger, conf config.Config, pluginName, filter
 				cli.OsExiter(1)
 				return err
 			}
+
 			for _, version := range versions {
+				versionObj := toolversions.Version{Type: "version", Value: version}
+				if !shims.ShimExists(conf, plugin, versionObj) {
+					continue
+				}
+
 				if slices.Contains(currentVersions.Versions, version) {
 					fmt.Printf(" *%s\n", version)
 				} else {

--- a/internal/installs/installs.go
+++ b/internal/installs/installs.go
@@ -55,8 +55,8 @@ func DownloadPath(conf config.Config, plugin plugins.Plugin, version toolversion
 	return filepath.Join(data.DownloadDirectory(conf.DataDir, plugin.Name), toolversions.FormatForFS(version))
 }
 
-// IsInstalled checks if a specific version of a tool is installed
-func IsInstalled(conf config.Config, plugin plugins.Plugin, version toolversions.Version) bool {
+// InstallDirExists checks if a specific version of a tool is installed
+func InstallDirExists(conf config.Config, plugin plugins.Plugin, version toolversions.Version) bool {
 	installDir := InstallPath(conf, plugin, version)
 
 	// Check if version already installed

--- a/internal/installs/installs.go
+++ b/internal/installs/installs.go
@@ -59,8 +59,7 @@ func DownloadPath(conf config.Config, plugin plugins.Plugin, version toolversion
 // version of a tool is accessible
 func InstallDirExists(conf config.Config, plugin plugins.Plugin, version toolversions.Version) bool {
 	installDir := InstallPath(conf, plugin, version)
-
-	// Check if version already installed
 	_, err := os.Stat(installDir)
+
 	return !os.IsNotExist(err)
 }

--- a/internal/installs/installs.go
+++ b/internal/installs/installs.go
@@ -55,7 +55,8 @@ func DownloadPath(conf config.Config, plugin plugins.Plugin, version toolversion
 	return filepath.Join(data.DownloadDirectory(conf.DataDir, plugin.Name), toolversions.FormatForFS(version))
 }
 
-// InstallDirExists checks if a specific version of a tool is installed
+// InstallDirExists checks if the installation directory for the specific
+// version of a tool is accessible
 func InstallDirExists(conf config.Config, plugin plugins.Plugin, version toolversions.Version) bool {
 	installDir := InstallPath(conf, plugin, version)
 

--- a/internal/installs/installs_test.go
+++ b/internal/installs/installs_test.go
@@ -65,17 +65,17 @@ func TestInstalled(t *testing.T) {
 	})
 }
 
-func TestIsInstalled(t *testing.T) {
+func TestInstallDirExists(t *testing.T) {
 	conf, plugin := generateConfig(t)
 	installVersion(t, conf, plugin, "1.0.0")
 
 	t.Run("returns false when not installed", func(t *testing.T) {
 		version := toolversions.Version{Type: "version", Value: "4.0.0"}
-		assert.False(t, IsInstalled(conf, plugin, version))
+		assert.False(t, InstallDirExists(conf, plugin, version))
 	})
 	t.Run("returns true when installed", func(t *testing.T) {
 		version := toolversions.Version{Type: "version", Value: "1.0.0"}
-		assert.True(t, IsInstalled(conf, plugin, version))
+		assert.True(t, InstallDirExists(conf, plugin, version))
 	})
 }
 

--- a/internal/shims/shims.go
+++ b/internal/shims/shims.go
@@ -443,3 +443,20 @@ func dirsToPaths(dirs []string, root string) (paths []string) {
 
 	return paths
 }
+
+// ShimExists returns true if a shim exists for a specific version of a tool
+func ShimExists(conf config.Config, plugin plugins.Plugin, version toolversions.Version) bool {
+	shimPath := Path(conf, plugin.Name)
+	toolVersions, err := GetToolsAndVersionsFromShimFile(shimPath)
+	if err != nil {
+		return false
+	}
+
+	for _, toolVersion := range toolVersions {
+		if toolVersion.Name == plugin.Name && slices.Contains(toolVersion.Versions, toolversions.Format(version)) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/shims/shims_test.go
+++ b/internal/shims/shims_test.go
@@ -428,6 +428,30 @@ func TestExecutableDirs(t *testing.T) {
 	})
 }
 
+func TestShimExists(t *testing.T) {
+	conf, plugin := generateConfig(t)
+	version := "1.0.0"
+	v := toolversions.Version{Type: "version", Value: version}
+
+	t.Run("returns false when no shim exist for plugin version", func(t *testing.T) {
+		// don't install any versions, so no shims are generated
+		got := ShimExists(conf, plugin, v)
+		assert.False(t, got, "expected ShimExists to return false if no shim is generated yet")
+	})
+
+	t.Run("returns true when shim exists for plugin version", func(t *testing.T) {
+		// install a version and generate shims
+		installVersion(t, conf, plugin, version)
+
+		var stdout, stderr strings.Builder
+		err := GenerateAll(conf, &stdout, &stderr)
+		assert.NoError(t, err, "expected GenerateAll to succeed")
+
+		got := ShimExists(conf, plugin, v)
+		assert.True(t, got, "expected ShimExists to return true after shims are generated for plugin/version")
+	})
+}
+
 // Helper functions
 func buildOutputs() (strings.Builder, strings.Builder) {
 	var stdout strings.Builder

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -156,7 +156,7 @@ func InstallOneVersion(conf config.Config, plugin plugins.Plugin, versionStr str
 	downloadDir := installs.DownloadPath(conf, plugin, version)
 	installDir := installs.InstallPath(conf, plugin, version)
 
-	if installs.InstallDirExists(conf, plugin, version) {
+	if installs.InstallDirExists(conf, plugin, version) && shims.ShimExists(conf, plugin, version) {
 		return VersionAlreadyInstalledError{version: version, toolName: plugin.Name}
 	}
 

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -156,7 +156,7 @@ func InstallOneVersion(conf config.Config, plugin plugins.Plugin, versionStr str
 	downloadDir := installs.DownloadPath(conf, plugin, version)
 	installDir := installs.InstallPath(conf, plugin, version)
 
-	if installs.IsInstalled(conf, plugin, version) {
+	if installs.InstallDirExists(conf, plugin, version) {
 		return VersionAlreadyInstalledError{version: version, toolName: plugin.Name}
 	}
 
@@ -318,7 +318,7 @@ func Uninstall(conf config.Config, plugin plugins.Plugin, rawVersion string, std
 		return errors.New("'latest' is a special version value that cannot be used for uninstall command")
 	}
 
-	if !installs.IsInstalled(conf, plugin, version) {
+	if !installs.InstallDirExists(conf, plugin, version) {
 		return errors.New("No such version")
 	}
 


### PR DESCRIPTION
# Summary

This PR addresses incorrect displays of incomplete installations when using the `list` command and prevents erroneous ‘version already installed’ errors when attempting to reinstall after a failed or interrupted installation.

The PR refactors the installation verification process by renaming `IsInstalled` to `InstallDirExists`, making it clear that it only checks for the existence of the installation directory. In addition, a new function, `ShimExists`, has been added to verify that a proper shim exists for a given plugin version. The `InstallOneVersion` function now checks both the installation directory and the shim before considering a version already installed, **preventing false positives from partial installations**. The CLI output has also been updated (via `listLocalCommand`) to skip or mark versions that lack a valid shim. Unit tests have been added for `ShimExists` and existing tests have been updated accordingly. Finally, Visual Studio Code settings have been excluded from the repository via `.gitignore`.


Fixes: #1981
Fixes: #1940
Fixes: #1932


