### PR TITLE
fix: remove install directory for version when install fails

### DIFF
--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -196,6 +196,9 @@ func InstallOneVersion(conf config.Config, plugin plugins.Plugin, versionStr str
 
 	err = plugin.RunCallback("install", []string{}, env, stdOut, stdErr)
 	if err != nil {
+		if rmErr := os.RemoveAll(installDir); rmErr != nil {
+			fmt.Fprintf(stdErr, "failed to clean up '%s' due to %s\n", installDir, rmErr)
+		}
 		return fmt.Errorf("failed to run install callback: %w", err)
 	}
 


### PR DESCRIPTION
# Summary

PR based on feedback in https://github.com/asdf-vm/asdf/pull/2008 . This PR will remove the install directory for the given version if it fails to install (install command returns a non-zero exit code).

Fixes: https://github.com/asdf-vm/asdf/issues/1981
Fixes: https://github.com/asdf-vm/asdf/issues/1940

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->
