### PR TITLE
docs: add Zypper to the package managers in which asdf is available

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -9,6 +9,7 @@ asdf can be installed in several different ways:
 | Package Manager   | Command                                                                                                                                                             |
 | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Homebrew | `brew install asdf`                                                                                                                                                 |
+| Zypper   | `zypper install asdf`                                                                                                                                               |
 | Pacman   | `git clone https://aur.archlinux.org/asdf-vm.git && cd asdf-vm && makepkg -si` or use your preferred [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers) |
 
 :::


### PR DESCRIPTION
# Summary

asdf is now available in openSUSE through Zypper! I just added it to the official documentation.