### PR TITLE
fix: remove comment from first line zsh completion output (#2035)

### DIFF
--- a/internal/completions/asdf.zsh
+++ b/internal/completions/asdf.zsh
@@ -1,4 +1,3 @@
-# Define completion for asdf version manager
 #compdef asdf
 #description tool to manage versions of multiple runtimes
 


### PR DESCRIPTION
# Summary

The first line of a completion file must be `#compdef`, removed the comment that was added above it.

Fixes: #2035