### PR TITLE
docs: Document `BASE_DIR` environment variable

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+export BASE_DIR="$PWD"

--- a/docs/contribute/core.md
+++ b/docs/contribute/core.md
@@ -13,6 +13,19 @@ git clone https://github.com/<GITHUB_USER>/asdf.git
 git clone https://github.com/asdf-vm/asdf.git
 ```
 
+Set the `BASE_DIR` environment variable to the full path of your `asdf-vm/asdf` clone:
+
+```
+cd asdf
+export BASE_DIR="$PWD"
+```
+
+[`direnv`](https://github.com/direnv/direnv) can be used to always export `BASE_DIR`:
+
+```
+direnv allow
+```
+
 The tools for core development are in this repo's `.tool-versions`. If you wish to manage with `asdf` itself, add the plugins:
 
 ```shell


### PR DESCRIPTION
New users to `asdf` who wish to contribute will run into the following errors when running `./scripts/test.bash`:

```
 ✗ help should show dummy plugin help specific to version when version is present [7]
   (from function `setup_asdf_dir' in file test/test_helpers.bash, line 16,
    from function `setup' in test file test/help_command.bats, line 6)
     `setup_asdf_dir' failed
   mkdir: cannot create directory ‘/w spacetest_help_should_show_dummy_plugin_help_specific_to_version_when_version_is_present’: Permission denied
```

This is due to paths within the various test suites relying on the `BASE_DIR` environment variable, which is not set by default.

This pull request adds the following:
* Some documentation of the `BASE_DIR` env var.
* A `direnv` `.envrc` file that will set that variable.

Note: I am a long-time asdf user, who would like to contribute to the project and noticed this while setting up my dev environment on an up-to-date Arch Linux system. My intention is to work on this issue:

https://github.com/asdf-vm/asdf/issues/2042