### PR TITLE
fix: support ref installed tool shims

### DIFF
--- a/internal/installs/installs.go
+++ b/internal/installs/installs.go
@@ -31,7 +31,7 @@ func Installed(conf config.Config, plugin plugins.Plugin) (versions []string, er
 			continue
 		}
 
-		versions = append(versions, file.Name())
+		versions = append(versions, toolversions.VersionFromFSFormat(file.Name()))
 	}
 
 	return versions, err

--- a/internal/installs/installs.go
+++ b/internal/installs/installs.go
@@ -31,7 +31,7 @@ func Installed(conf config.Config, plugin plugins.Plugin) (versions []string, er
 			continue
 		}
 
-		versions = append(versions, toolversions.VersionFromFSFormat(file.Name()))
+		versions = append(versions, toolversions.VersionStringFromFSFormat(file.Name()))
 	}
 
 	return versions, err

--- a/internal/installtest/installtest.go
+++ b/internal/installtest/installtest.go
@@ -66,18 +66,18 @@ func InstallOneVersion(conf config.Config, plugin plugins.Plugin, versionType, v
 
 // InstallPath returns the path to a tool installation
 func InstallPath(conf config.Config, plugin plugins.Plugin, version string) string {
-	return filepath.Join(pluginInstallPath(conf, plugin), toolVersion(version))
+	return filepath.Join(pluginInstallPath(conf, plugin), formatVersionStringFromFS(version))
 }
 
 // DownloadPath returns the download path for a particular plugin and version
 func DownloadPath(conf config.Config, plugin plugins.Plugin, version string) string {
-	return filepath.Join(conf.DataDir, dataDirDownloads, plugin.Name, toolVersion(version))
+	return filepath.Join(conf.DataDir, dataDirDownloads, plugin.Name, formatVersionStringFromFS(version))
 }
 
 func pluginInstallPath(conf config.Config, plugin plugins.Plugin) string {
 	return filepath.Join(conf.DataDir, dataDirInstalls, plugin.Name)
 }
 
-func toolVersion(version string) string {
+func formatVersionStringFromFS(version string) string {
 	return toolversions.FormatForFS(toolversions.Parse(version))
 }

--- a/internal/installtest/installtest.go
+++ b/internal/installtest/installtest.go
@@ -66,18 +66,18 @@ func InstallOneVersion(conf config.Config, plugin plugins.Plugin, versionType, v
 
 // InstallPath returns the path to a tool installation
 func InstallPath(conf config.Config, plugin plugins.Plugin, version string) string {
-	return filepath.Join(pluginInstallPath(conf, plugin), formatVersionStringFromFS(version))
+	return filepath.Join(pluginInstallPath(conf, plugin), formatVersionStringForFS(version))
 }
 
 // DownloadPath returns the download path for a particular plugin and version
 func DownloadPath(conf config.Config, plugin plugins.Plugin, version string) string {
-	return filepath.Join(conf.DataDir, dataDirDownloads, plugin.Name, formatVersionStringFromFS(version))
+	return filepath.Join(conf.DataDir, dataDirDownloads, plugin.Name, formatVersionStringForFS(version))
 }
 
 func pluginInstallPath(conf config.Config, plugin plugins.Plugin) string {
 	return filepath.Join(conf.DataDir, dataDirInstalls, plugin.Name)
 }
 
-func formatVersionStringFromFS(version string) string {
+func formatVersionStringForFS(version string) string {
 	return toolversions.FormatForFS(toolversions.Parse(version))
 }

--- a/internal/installtest/installtest.go
+++ b/internal/installtest/installtest.go
@@ -66,18 +66,18 @@ func InstallOneVersion(conf config.Config, plugin plugins.Plugin, versionType, v
 
 // InstallPath returns the path to a tool installation
 func InstallPath(conf config.Config, plugin plugins.Plugin, version string) string {
-	return filepath.Join(pluginInstallPath(conf, plugin), pluginVersion(version))
+	return filepath.Join(pluginInstallPath(conf, plugin), toolVersion(version))
 }
 
 // DownloadPath returns the download path for a particular plugin and version
 func DownloadPath(conf config.Config, plugin plugins.Plugin, version string) string {
-	return filepath.Join(conf.DataDir, dataDirDownloads, plugin.Name, pluginVersion(version))
+	return filepath.Join(conf.DataDir, dataDirDownloads, plugin.Name, toolVersion(version))
 }
 
 func pluginInstallPath(conf config.Config, plugin plugins.Plugin) string {
 	return filepath.Join(conf.DataDir, dataDirInstalls, plugin.Name)
 }
 
-func pluginVersion(version string) string {
+func toolVersion(version string) string {
 	return toolversions.FormatForFS(toolversions.Parse(version))
 }

--- a/internal/installtest/installtest.go
+++ b/internal/installtest/installtest.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/asdf-vm/asdf/internal/config"
 	"github.com/asdf-vm/asdf/internal/plugins"
+	"github.com/asdf-vm/asdf/internal/toolversions"
 )
 
 const (
@@ -65,14 +66,18 @@ func InstallOneVersion(conf config.Config, plugin plugins.Plugin, versionType, v
 
 // InstallPath returns the path to a tool installation
 func InstallPath(conf config.Config, plugin plugins.Plugin, version string) string {
-	return filepath.Join(pluginInstallPath(conf, plugin), version)
+	return filepath.Join(pluginInstallPath(conf, plugin), pluginVersion(version))
 }
 
 // DownloadPath returns the download path for a particular plugin and version
 func DownloadPath(conf config.Config, plugin plugins.Plugin, version string) string {
-	return filepath.Join(conf.DataDir, dataDirDownloads, plugin.Name, version)
+	return filepath.Join(conf.DataDir, dataDirDownloads, plugin.Name, pluginVersion(version))
 }
 
 func pluginInstallPath(conf config.Config, plugin plugins.Plugin) string {
 	return filepath.Join(conf.DataDir, dataDirInstalls, plugin.Name)
+}
+
+func pluginVersion(version string) string {
+	return toolversions.FormatForFS(toolversions.Parse(version))
 }

--- a/internal/shims/shims.go
+++ b/internal/shims/shims.go
@@ -411,12 +411,7 @@ func parse(contents string) (versions []toolversions.ToolVersions) {
 			segments := strings.Split(line, " ")
 			// if doesn't have expected number of elements on line skip
 			if len(segments) >= 4 {
-				versions = append(versions, toolversions.ToolVersions{
-					Name: segments[2],
-					Versions: []string{
-						toolversions.VersionFromFSFormat(segments[3]),
-					},
-				})
+				versions = append(versions, toolversions.ToolVersions{Name: segments[2], Versions: []string{segments[3]}})
 			}
 		}
 	}

--- a/internal/shims/shims.go
+++ b/internal/shims/shims.go
@@ -411,7 +411,12 @@ func parse(contents string) (versions []toolversions.ToolVersions) {
 			segments := strings.Split(line, " ")
 			// if doesn't have expected number of elements on line skip
 			if len(segments) >= 4 {
-				versions = append(versions, toolversions.ToolVersions{Name: segments[2], Versions: []string{segments[3]}})
+				versions = append(versions, toolversions.ToolVersions{
+					Name: segments[2],
+					Versions: []string{
+						toolversions.VersionFromFSFormat(segments[3]),
+					},
+				})
 			}
 		}
 	}

--- a/internal/shims/shims_test.go
+++ b/internal/shims/shims_test.go
@@ -100,6 +100,29 @@ func TestFindExecutable(t *testing.T) {
 	})
 }
 
+func TestFindExecutable_Ref(t *testing.T) {
+	version := "ref:v1.1.0"
+	conf, plugin := generateConfig(t)
+	installVersion(t, conf, plugin, version)
+	stdout, stderr := buildOutputs()
+	assert.Nil(t, GenerateAll(conf, &stdout, &stderr))
+	currentDir := t.TempDir()
+
+	t.Run("returns string containing path to ref installed executable when found", func(t *testing.T) {
+		// write a version file
+		data := []byte("lua ref:v1.1.0")
+		assert.Nil(t, os.WriteFile(filepath.Join(currentDir, ".tool-versions"), data, 0o666))
+
+		executable, gotPlugin, version, found, err := FindExecutable(conf, "dummy", currentDir)
+		assert.Nil(t, err)
+		assert.True(t, found)
+		assert.Equal(t, "ref:v1.1.0", version)
+		assert.Equal(t, plugin, gotPlugin)
+		assert.Equal(t, "dummy", filepath.Base(executable))
+		assert.Equal(t, "ref-v1.1.0", filepath.Base(filepath.Dir(filepath.Dir(executable))))
+	})
+}
+
 func TestGetExecutablePath(t *testing.T) {
 	version := toolversions.Version{Type: "version", Value: "1.1.0"}
 	conf, plugin := generateConfig(t)

--- a/internal/toolversions/toolversions.go
+++ b/internal/toolversions/toolversions.go
@@ -189,6 +189,8 @@ func Format(version Version) string {
 		return "system"
 	case "path":
 		return fmt.Sprintf("path:%s", version.Value)
+	case "ref":
+		return fmt.Sprintf("ref:%s", version.Value)
 	default:
 		return version.Value
 	}

--- a/internal/toolversions/toolversions.go
+++ b/internal/toolversions/toolversions.go
@@ -205,6 +205,13 @@ func FormatForFS(version Version) string {
 	}
 }
 
+func VersionFromFSFormat(version string) string {
+	if strings.HasPrefix(version, "ref-") {
+		return strings.Replace(version, "ref-", "ref:", 1)
+	}
+	return version
+}
+
 func readLines(content string) (lines []string) {
 	return strings.Split(content, "\n")
 }
@@ -224,11 +231,6 @@ func getAllToolsAndVersionsInContent(content string) (toolVersions []ToolVersion
 	for _, line := range readLines(content) {
 		tokens, _ := parseLine(line)
 		if len(tokens) > 1 {
-			for i := 1; i < len(tokens); i++ {
-				if strings.HasPrefix(tokens[i], "ref:") {
-					tokens[i] = strings.Replace(tokens[i], "ref:", "ref-", 1)
-				}
-			}
 			newTool := ToolVersions{Name: tokens[0], Versions: tokens[1:]}
 			toolVersions = append(toolVersions, newTool)
 		}

--- a/internal/toolversions/toolversions.go
+++ b/internal/toolversions/toolversions.go
@@ -207,7 +207,7 @@ func FormatForFS(version Version) string {
 	}
 }
 
-func VersionFromFSFormat(version string) string {
+func VersionStringFromFSFormat(version string) string {
 	if strings.HasPrefix(version, "ref-") {
 		return strings.Replace(version, "ref-", "ref:", 1)
 	}

--- a/internal/toolversions/toolversions.go
+++ b/internal/toolversions/toolversions.go
@@ -224,6 +224,11 @@ func getAllToolsAndVersionsInContent(content string) (toolVersions []ToolVersion
 	for _, line := range readLines(content) {
 		tokens, _ := parseLine(line)
 		if len(tokens) > 1 {
+			for i := 1; i < len(tokens); i++ {
+				if strings.HasPrefix(tokens[i], "ref:") {
+					tokens[i] = strings.Replace(tokens[i], "ref:", "ref-", 1)
+				}
+			}
 			newTool := ToolVersions{Name: tokens[0], Versions: tokens[1:]}
 			toolVersions = append(toolVersions, newTool)
 		}

--- a/internal/toolversions/toolversions_test.go
+++ b/internal/toolversions/toolversions_test.go
@@ -358,7 +358,7 @@ func TestFormat(t *testing.T) {
 		{
 			desc:   "with ref version",
 			input:  Version{Type: "ref", Value: "foobar"},
-			output: "foobar",
+			output: "ref:foobar",
 		},
 		{
 			desc:   "with system version",

--- a/internal/toolversions/toolversions_test.go
+++ b/internal/toolversions/toolversions_test.go
@@ -390,6 +390,29 @@ func TestFormatForFS(t *testing.T) {
 	})
 }
 
+func TestVersionStringFromFSFormat(t *testing.T) {
+	tests := []struct {
+		desc  string
+		input Version
+	}{
+		{
+			desc:  "with regular version",
+			input: Version{Type: "version", Value: "foobar"},
+		},
+		{
+			desc:  "with ref version",
+			input: Version{Type: "ref", Value: "foobar"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got := Parse(VersionStringFromFSFormat(FormatForFS(tt.input)))
+			assert.Equal(t, tt.input, got)
+		})
+	}
+}
+
 func BenchmarkUnique(b *testing.B) {
 	versions := []ToolVersions{
 		{Name: "foo", Versions: []string{"1"}},

--- a/internal/toolversions/toolversions_test.go
+++ b/internal/toolversions/toolversions_test.go
@@ -49,6 +49,19 @@ func TestFindToolVersions(t *testing.T) {
 		assert.True(t, found)
 		assert.Equal(t, []string{"2.0.0"}, versions)
 	})
+
+	t.Run("returns list of versions as hyphenated when installed as <tool> ref:<gitref>", func(t *testing.T) {
+		toolVersionsPath := filepath.Join(t.TempDir(), ".tool-versions")
+		file, err := os.Create(toolVersionsPath)
+		assert.Nil(t, err)
+		defer file.Close()
+		file.WriteString("erlang ref:OTP-27.3.1")
+
+		versions, found, err := FindToolVersions(toolVersionsPath, "erlang")
+		assert.Nil(t, err)
+		assert.True(t, found)
+		assert.Equal(t, []string{"ref-OTP-27.3.1"}, versions)
+	})
 }
 
 func TestWriteToolVersionsToFile(t *testing.T) {

--- a/internal/toolversions/toolversions_test.go
+++ b/internal/toolversions/toolversions_test.go
@@ -49,19 +49,6 @@ func TestFindToolVersions(t *testing.T) {
 		assert.True(t, found)
 		assert.Equal(t, []string{"2.0.0"}, versions)
 	})
-
-	t.Run("returns list of versions as hyphenated when installed as <tool> ref:<gitref>", func(t *testing.T) {
-		toolVersionsPath := filepath.Join(t.TempDir(), ".tool-versions")
-		file, err := os.Create(toolVersionsPath)
-		assert.Nil(t, err)
-		defer file.Close()
-		file.WriteString("erlang ref:OTP-27.3.1")
-
-		versions, found, err := FindToolVersions(toolVersionsPath, "erlang")
-		assert.Nil(t, err)
-		assert.True(t, found)
-		assert.Equal(t, []string{"ref-OTP-27.3.1"}, versions)
-	})
 }
 
 func TestWriteToolVersionsToFile(t *testing.T) {


### PR DESCRIPTION
# Summary

I commonly make use of `ref:` based installs when working in `erlang` and `elixir` repositories, however this appears to be broken in the current builds as the `ref:` prefix is normalized to `ref-` when working with file path rendering the ref based installs unlocatable by the shim.

Fixes: #2001

## Other Information

I do not know if there is a better place to do this, I am happy to make the changes in the correct area if you feel it is needed.
