### PR TITLE
feat: log failure to add plugin in "plugin test"

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -964,7 +964,7 @@ func pluginTestCommand(l *log.Logger, args []string, toolVersion, ref string) {
 	// Install plugin
 	err = plugins.Add(conf, testName, url, ref)
 	if err != nil {
-		failTest(l, fmt.Sprintf("%s was not properly installed", name))
+		failTest(l, fmt.Sprintf("%s was not properly installed reason: %s", name, err))
 	}
 
 	// Remove plugin


### PR DESCRIPTION
# Summary

Display the internal reason why the plugin failed to be installed.

Error are currently returned but unused and there are several reasons why the plugin addition could fail

Current:
```console
$ go run cmd/asdf/main.go plugin test my-plugin some-url install 1.1.1
FAILED: my-plugin was not properly installed
exit status 1
```

With changes:
```console
$ go run cmd/asdf/main.go plugin test my-plugin some-url install 1.1.1
FAILED: my-plugin was not properly installed reason: Plugin named asdf-test-my-plugin already added
exit status 1
```