### PR TITLE
fix: correct intersection logic in `shims.FindExecutable` function so ordering of multiple versions is preserved

### DIFF
--- a/internal/shims/shims.go
+++ b/internal/shims/shims.go
@@ -76,12 +76,14 @@ func FindExecutable(conf config.Config, shimName, currentDirectory string) (stri
 		if plugin.Exists() == nil {
 
 			versions, found, err := resolve.Version(conf, plugin, currentDirectory)
+
 			if err != nil {
 				return "", plugins.Plugin{}, "", false, nil
 			}
 
 			if found {
-				tempVersions := toolversions.Intersect(shimToolVersion.Versions, versions.Versions)
+				tempVersions := toolversions.Intersect(versions.Versions, shimToolVersion.Versions)
+
 				if slices.Contains(versions.Versions, "system") {
 					tempVersions = append(tempVersions, "system")
 				}

--- a/internal/shims/shims_test.go
+++ b/internal/shims/shims_test.go
@@ -24,6 +24,7 @@ func TestFindExecutable(t *testing.T) {
 	version := "1.1.0"
 	conf, plugin := generateConfig(t)
 	installVersion(t, conf, plugin, version)
+	installVersion(t, conf, plugin, "2.0.0")
 	stdout, stderr := buildOutputs()
 	assert.Nil(t, GenerateAll(conf, &stdout, &stderr))
 	currentDir := t.TempDir()
@@ -47,6 +48,20 @@ func TestFindExecutable(t *testing.T) {
 	t.Run("returns string containing path to executable when found", func(t *testing.T) {
 		// write a version file
 		data := []byte("lua 1.1.0")
+		assert.Nil(t, os.WriteFile(filepath.Join(currentDir, ".tool-versions"), data, 0o666))
+
+		executable, gotPlugin, version, found, err := FindExecutable(conf, "dummy", currentDir)
+		assert.Equal(t, filepath.Base(filepath.Dir(filepath.Dir(executable))), "1.1.0")
+		assert.Equal(t, filepath.Base(executable), "dummy")
+		assert.Equal(t, plugin, gotPlugin)
+		assert.Equal(t, version, "1.1.0")
+		assert.True(t, found)
+		assert.Nil(t, err)
+	})
+
+	t.Run("returns path to executable with first version when multiple versions are set", func(t *testing.T) {
+		// write a version file
+		data := []byte("lua 1.1.0 3.0.0 2.0.0")
 		assert.Nil(t, os.WriteFile(filepath.Join(currentDir, ".tool-versions"), data, 0o666))
 
 		executable, gotPlugin, version, found, err := FindExecutable(conf, "dummy", currentDir)

--- a/internal/toolversions/toolversions_test.go
+++ b/internal/toolversions/toolversions_test.go
@@ -153,25 +153,50 @@ func TestUpdateContentWithToolVersions(t *testing.T) {
 }
 
 func TestIntersect(t *testing.T) {
-	t.Run("when provided two empty ToolVersions returns empty ToolVersions", func(t *testing.T) {
-		got := Intersect([]string{}, []string{})
-		want := []string(nil)
+	tests := []struct {
+		desc   string
+		input1 []string
+		input2 []string
+		want   []string
+	}{
+		{
+			desc:   "when provided two empty ToolVersions returns empty ToolVersions",
+			input1: []string{},
+			input2: []string{},
+			want:   []string(nil),
+		},
+		{
+			desc:   "when provided ToolVersions with no matching versions return empty ToolVersions",
+			input1: []string{"1", "2"},
+			input2: []string{"3", "4"},
+			want:   []string(nil),
+		},
+		{
+			desc:   "when provided ToolVersions with different versions return new ToolVersions only containing versions in both",
+			input1: []string{"1", "2"},
+			input2: []string{"2", "3"},
+			want:   []string{"2"},
+		},
+		{
+			desc:   "preserves order of items in first argument",
+			input1: []string{"1", "3", "2"},
+			input2: []string{"2", "3"},
+			want:   []string{"3", "2"},
+		},
+		{
+			desc:   "preserves order of items in first argument (variant 2)",
+			input1: []string{"1", "4", "5", "3", "2"},
+			input2: []string{"2", "3", "4"},
+			want:   []string{"4", "3", "2"},
+		},
+	}
 
-		assert.Equal(t, got, want)
-	})
-
-	t.Run("when provided ToolVersions with no matching versions return empty ToolVersions", func(t *testing.T) {
-		got := Intersect([]string{"1", "2"}, []string{"3", "4"})
-
-		assert.Equal(t, got, []string(nil))
-	})
-
-	t.Run("when provided ToolVersions with different versions return new ToolVersions only containing versions in both", func(t *testing.T) {
-		got := Intersect([]string{"1", "2"}, []string{"2", "3"})
-		want := []string{"2"}
-
-		assert.Equal(t, got, want)
-	})
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got := Intersect(tt.input1, tt.input2)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestUnique(t *testing.T) {


### PR DESCRIPTION
* add more tests for `toolversions.Intersect` function
* add failing test for `shims.FindExecutable` function
* correct intersection logic in `shims.FindExecutable` function

Fixes https://github.com/asdf-vm/asdf/issues/2038