### PR TITLE
feat(golang-rewrite): add support for shim templates resolution

### DIFF
--- a/internal/shims/shims.go
+++ b/internal/shims/shims.go
@@ -56,7 +56,7 @@ func (e NoExecutableForPluginError) Error() string {
 
 // FindExecutable takes a shim name and a current directory and returns the path
 // to the executable that the shim resolves to.
-func FindExecutable(conf config.Config, shimName, currentDirectory string) (string, plugins.Plugin, string, bool, error) {
+func FindExecutable(conf config.Config, shimName, currentDirectory string) (path string, plugin plugins.Plugin, version string, found bool, err error) {
 	shimPath := Path(conf, shimName)
 
 	if _, err := os.Stat(shimPath); err != nil {

--- a/internal/shims/shims.go
+++ b/internal/shims/shims.go
@@ -74,6 +74,11 @@ func FindExecutable(conf config.Config, shimName, currentDirectory string) (stri
 	for _, shimToolVersion := range toolVersions {
 		plugin := plugins.New(conf, shimToolVersion.Name)
 		if plugin.Exists() == nil {
+			// If a shim template is found, we can return it before looping through versions
+			shimTemplate, err := plugin.ShimTemplatePath(shimName)
+			if err == nil {
+				return shimTemplate, plugin, "", true, nil
+			}
 
 			versions, found, err := resolve.Version(conf, plugin, currentDirectory)
 

--- a/internal/shims/shims.go
+++ b/internal/shims/shims.go
@@ -373,18 +373,25 @@ func ToolExecutables(conf config.Config, plugin plugins.Plugin, version toolvers
 
 // ExecutablePaths returns a slice of absolute directory paths that tool
 // executables are contained in.
-func ExecutablePaths(conf config.Config, plugin plugins.Plugin, version toolversions.Version) ([]string, error) {
+func ExecutablePaths(conf config.Config, plugin plugins.Plugin, version toolversions.Version) (paths []string, err error) {
 	dirs, err := ExecutableDirs(plugin)
 	if err != nil {
 		return []string{}, err
 	}
 
+	shimsDir, err := os.Stat(path.Join(plugin.Dir, "shims"))
+	if err == nil && shimsDir.IsDir() {
+		paths = append(paths, path.Join(plugin.Dir, "shims"))
+	}
+
 	installPath := installs.InstallPath(conf, plugin, version)
-	return dirsToPaths(dirs, installPath), nil
+	paths = append(paths, dirsToPaths(dirs, installPath)...)
+
+	return paths, nil
 }
 
-// ExecutableDirs returns a slice of directory names that tool executables are
-// contained in
+// ExecutableDirs returns a slice of relative directory names that tool executables are
+// contained in, *inside installs*
 func ExecutableDirs(plugin plugins.Plugin) ([]string, error) {
 	var stdOut strings.Builder
 	var stdErr strings.Builder

--- a/internal/shims/shims_test.go
+++ b/internal/shims/shims_test.go
@@ -464,6 +464,27 @@ func TestExecutablePaths(t *testing.T) {
 		assert.Equal(t, filepath.Base(path1), "foo")
 		assert.Equal(t, filepath.Base(path2), "bar")
 	})
+
+	t.Run("returns list of executable paths for tool version containing shim templates", func(t *testing.T) {
+		data := []byte("echo 'foo bar'")
+		err := os.WriteFile(filepath.Join(plugin.Dir, "bin", "list-bin-paths"), data, 0o777)
+		assert.Nil(t, err)
+
+		// write a shim template to the plugin shims dir
+		setupShimTemplate(t, plugin, "dummy", "echo 'shim template'")
+
+		executables, err := ExecutablePaths(conf, plugin, toolversions.Version{Type: "version", Value: "1.2.3"})
+		assert.Nil(t, err)
+		path1 := executables[0]
+		path2 := executables[1]
+		path3 := executables[2]
+		assert.Equal(t, "foo", filepath.Base(path2))
+		assert.Equal(t, "bar", filepath.Base(path3))
+
+		relativePath, err := filepath.Rel(conf.DataDir, path1)
+		assert.Nil(t, err)
+		assert.Equal(t, "plugins/lua/shims", relativePath)
+	})
 }
 
 func TestExecutableDirs(t *testing.T) {

--- a/internal/shims/shims_test.go
+++ b/internal/shims/shims_test.go
@@ -113,6 +113,27 @@ func TestFindExecutable(t *testing.T) {
 		assert.Equal(t, filepath.Base(executable), "dummy")
 		assert.True(t, strings.HasPrefix(executable, dir))
 	})
+
+	t.Run("returns string containing path to executable when shim template in plugin is set", func(t *testing.T) {
+		// write a version file
+		data := []byte("lua 1.1.0")
+		assert.Nil(t, os.WriteFile(filepath.Join(currentDir, ".tool-versions"), data, 0o666))
+
+		// write a shim template to the plugin shims dir
+		setupShimTemplate(t, plugin, "dummy", "echo 'shim template'")
+
+		executable, gotPlugin, version, found, err := FindExecutable(conf, "dummy", currentDir)
+		assert.Nil(t, err)
+
+		relativePath, err := filepath.Rel(conf.DataDir, executable)
+		assert.Nil(t, err)
+
+		assert.Equal(t, "plugins/lua/shims/dummy", relativePath)
+		assert.Equal(t, "dummy", filepath.Base(executable))
+		assert.Equal(t, plugin, gotPlugin)
+		assert.Equal(t, "", version)
+		assert.True(t, found)
+	})
 }
 
 func TestFindExecutable_Ref(t *testing.T) {
@@ -510,4 +531,20 @@ func installVersion(t *testing.T, conf config.Config, plugin plugins.Plugin, ver
 	t.Helper()
 	err := installtest.InstallOneVersion(conf, plugin, "version", version)
 	assert.Nil(t, err)
+}
+
+func setupShimTemplate(t *testing.T, plugin plugins.Plugin, shimName string, script string) {
+	t.Helper()
+	shimsDirPath := filepath.Join(plugin.Dir, "shims")
+	os.MkdirAll(shimsDirPath, 0o777)
+
+	shimPath := filepath.Join(shimsDirPath, shimName)
+	contents := fmt.Sprintf("#!/usr/bin/env bash\n%s\n", script)
+	err := os.WriteFile(shimPath, []byte(contents), 0o777)
+	assert.Nil(t, err)
+
+	t.Cleanup(func() {
+		err := os.Remove(shimPath)
+		assert.Nil(t, err)
+	})
 }


### PR DESCRIPTION
# Summary

In this PR I'm adding support for [custom shim templates](https://asdf-vm.com/plugins/create.html#custom-shim-templates) back, since it is missing from the current go implementation.
As of now, the implementation short-circuits very early if it finds an acceptable shim in the first tool available.

Plugins that I know are using shim templates are: [asdf-elixir](https://github.com/asdf-vm/asdf-elixir/tree/master/shims), [asdf-nodejs](https://github.com/asdf-vm/asdf-nodejs/tree/master/shims), and [asdf-python](https://github.com/asdf-community/asdf-python/tree/master/shims).

fixes #2025 asdf-vm/asdf-nodejs#421

