### PR TITLE
test(golang-rewrite): ignore global git config on repotest

### DIFF
--- a/internal/repotest/repotest.go
+++ b/internal/repotest/repotest.go
@@ -206,6 +206,10 @@ func runCmd(cmdName string, args ...string) error {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
+	// Global env vars
+	// GIT_CONFIG_GLOBAL=/dev/null prevents git from looking for user settings like commit.gpgSign and user.name
+	cmd.Env = []string{"GIT_CONFIG_GLOBAL=/dev/null"}
+
 	err := cmd.Run()
 	if err != nil {
 		// If command fails print both stderr and stdout


### PR DESCRIPTION
# Summary

I noticed that while running tests, a dialog asking for my GPG key password was popping up. This is because I sign all my commits, and because repotests is using the `git` command behind the scenes using my global `~/.gitconfig`.

In this PR I'm setting the 

Fixes: List issue numbers here `GIT_CONFIG_GLOBAL` variable to `/dev/null` for all commands run on repotest, so it ignores the [global user config](https://github.com/git/git/commit/4179b4897f2de28858acaebd6382c06c91532e98), which to me seems logical, since we are using git just for a simple test.

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->
