### PR TITLE
fix: set correct version for go install and make builds

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -21,7 +21,8 @@
     "SECURITY.md",
     "docs/guide/getting-started.md",
     "docs/pt-br/guide/getting-started.md",
-    "docs/zh-hans/guide/getting-started.md"
+    "docs/zh-hans/guide/getting-started.md",
+    "cmd/asdf/main.go"
   ],
   ".": "0.16.7"
 }

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,7 @@
 MAIN_PACKAGE_PATH := ./cmd/asdf
 TARGET_DIR := .
 TARGET := asdf
-
-# Because this Makefile isn't used as part of the actual release binary build,
-# It sets FULL_VERSION to a dev version containing the SHA of the current
-# commit. If we ever use this Makefile to generate release binaries this code
-# will need to change.
-FULL_VERSION = "$(shell git rev-parse --short HEAD)-dev"
-LINKER_FLAGS = '-s -X main.version=${FULL_VERSION}'
+LINKER_FLAGS = '-s'
 
 # Not sure what the default location should be for builds
 build: # test lint

--- a/cmd/asdf/main.go
+++ b/cmd/asdf/main.go
@@ -1,12 +1,40 @@
 // Main entrypoint for the CLI app
 package main
 
-import "github.com/asdf-vm/asdf/internal/cli"
+import (
+	"fmt"
+	"runtime/debug"
+	"slices"
 
-// Replaced with the real version during a typical build
-var version = "v-dev"
+	"github.com/asdf-vm/asdf/internal/cli"
+)
+
+// Do not touch this next line
+var version = "0.16.7" // x-release-please-version
 
 // Placeholder for the real code
 func main() {
-	cli.Execute(version)
+	fullVersion := buildFullVersion(version)
+	cli.Execute(fullVersion)
+}
+
+func buildFullVersion(version string) string {
+	var shortRef string
+
+	info, ok := debug.ReadBuildInfo()
+
+	if !ok {
+		panic("can't get build info")
+	}
+	idx := slices.IndexFunc(info.Settings, func(s debug.BuildSetting) bool {
+		return s.Key == "vcs.revision"
+	})
+
+	if idx < 0 {
+		shortRef = "unknown"
+	} else {
+		shortRef = info.Settings[idx].Value[0:7]
+	}
+
+	return fmt.Sprintf("%s (revision %s)", version, shortRef)
 }

--- a/test/help_command.bats
+++ b/test/help_command.bats
@@ -73,7 +73,7 @@ EOF
   run asdf help
 
   [ "$status" -eq 0 ]
-  [[ $output == 'version: v'* ]]
+  [[ $output =~ $'version: '[0-9]* ]]
   [[ $output == *$'MANAGE PLUGINS\n'* ]]
   [[ $output == *$'MANAGE TOOLS\n'* ]]
   [[ $output == *$'UTILS\n'* ]]

--- a/test/non_existent_command.bats
+++ b/test/non_existent_command.bats
@@ -16,7 +16,7 @@ setup() {
 
   [ "$status" -eq 1 ]
   [[ $output == 'invalid command provided:'* ]]
-  [[ $output == *$'version: v'* ]]
+  [[ $output =~ $'version: '[0-9]* ]]
   [[ $output == *$'MANAGE PLUGINS\n'* ]]
   [[ $output == *$'MANAGE TOOLS\n'* ]]
   [[ $output == *$'UTILS\n'* ]]


### PR DESCRIPTION
Intended to address https://github.com/asdf-vm/asdf/issues/2046 and related issues.

With these changes the version will always look something like this:

```
$ ./asdf version
0.16.7 (revision 610d084)
```