### PR TITLE
fix: error message formatting by adding newline in printError

### DIFF
--- a/internal/cli/set/set.go
+++ b/internal/cli/set/set.go
@@ -90,9 +90,13 @@ func Main(_ io.Writer, stderr io.Writer, args []string, home bool, parent bool, 
 }
 
 func printError(stderr io.Writer, msg string) error {
-	fmt.Fprintf(stderr, "%s", msg)
-	return errors.New(msg)
+	if !strings.HasSuffix(msg, "\n") {
+		msg += "\n"
+	}
+	fmt.Fprint(stderr, msg)
+	return errors.New(strings.TrimSuffix(msg, "\n"))
 }
+
 
 func findVersionFileInParentDir(conf config.Config, directory string) (string, bool) {
 	directory = filepath.Dir(directory)


### PR DESCRIPTION
# Summary

- Added a check to append a newline to the error message if it's missing before printing.

- Trimmed the newline when creating the returned error value to keep error messages clean and consistent.

Fixes: #2095 

## Other Information

This prevents error messages from running into the shell prompt, improving readability.
