### PR TITLE
fix: ensures output always ends with a newline when printed

### DIFF
--- a/internal/cli/set/set.go
+++ b/internal/cli/set/set.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/asdf-vm/asdf/internal/config"
 	"github.com/asdf-vm/asdf/internal/plugins"
@@ -90,8 +91,11 @@ func Main(_ io.Writer, stderr io.Writer, args []string, home bool, parent bool, 
 }
 
 func printError(stderr io.Writer, msg string) error {
-	fmt.Fprintf(stderr, "%s", msg)
-	return errors.New(msg)
+	if !strings.HasSuffix(msg, "\n") {
+		msg += "\n"
+	}
+	fmt.Fprint(stderr, msg)
+	return errors.New(strings.TrimSuffix(msg, "\n"))
 }
 
 func findVersionFileInParentDir(conf config.Config, directory string) (string, bool) {

--- a/internal/cli/set/set_test.go
+++ b/internal/cli/set/set_test.go
@@ -20,7 +20,7 @@ func TestAll(t *testing.T) {
 
 		assert.Error(t, err, "tool and version must be provided as arguments")
 		assert.Equal(t, stdout.String(), "")
-		assert.Equal(t, stderr.String(), "tool and version must be provided as arguments")
+		assert.Equal(t, stderr.String(), "tool and version must be provided as arguments\n")
 	})
 
 	t.Run("prints error when no version specified", func(t *testing.T) {
@@ -29,7 +29,7 @@ func TestAll(t *testing.T) {
 
 		assert.Error(t, err, "version must be provided as an argument")
 		assert.Equal(t, stdout.String(), "")
-		assert.Equal(t, stderr.String(), "version must be provided as an argument")
+		assert.Equal(t, stderr.String(), "version must be provided as an argument\n")
 	})
 
 	t.Run("prints error when both --parent and --home flags are set", func(t *testing.T) {
@@ -38,7 +38,7 @@ func TestAll(t *testing.T) {
 
 		assert.Error(t, err, "home and parent flags cannot both be specified; must be one location or the other")
 		assert.Equal(t, stdout.String(), "")
-		assert.Equal(t, stderr.String(), "home and parent flags cannot both be specified; must be one location or the other")
+		assert.Equal(t, stderr.String(), "home and parent flags cannot both be specified; must be one location or the other\n")
 	})
 
 	t.Run("sets version in current directory when no flags provided", func(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/asdf-vm/asdf/issues/2095

This PR corrects code submitted in https://github.com/asdf-vm/asdf/pull/2096