### PR TITLE
fix: only return version starting with number when no filter is supplied

### DIFF
--- a/internal/versions/versions_test.go
+++ b/internal/versions/versions_test.go
@@ -372,6 +372,25 @@ func TestLatest(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, "4.0.0", version)
 	})
+
+	t.Run("when given no query returns latest version of plugin starting with number", func(t *testing.T) {
+		pluginName := "no-latest-non-numeric-versions"
+		pluginDir, err := repotest.InstallPlugin("dummy_plugin", conf.DataDir, pluginName)
+		assert.Nil(t, err)
+		plugin := plugins.New(conf, pluginName)
+
+		// Replace list-all script so it returns some non-numeric versions
+		listAllScript := filepath.Join(pluginDir, "bin", "list-all")
+		err = os.WriteFile(listAllScript, []byte("#!/usr/bin/env bash\necho foobar 3.4.5 1.2.3-dev foobar2"), 0o777)
+		assert.Nil(t, err)
+		latestScript := filepath.Join(pluginDir, "bin", "latest-stable")
+		err = os.Remove(latestScript)
+		assert.Nil(t, err)
+
+		version, err := Latest(plugin, "")
+		assert.Nil(t, err)
+		assert.Equal(t, "3.4.5", version)
+	})
 }
 
 func TestLatestWithSamples(t *testing.T) {


### PR DESCRIPTION
Fixes: https://github.com/asdf-vm/asdf/issues/2073

Previously the code for the latest command would always filter out versions not starting with a number, even when the user provided a filter of their own that specifically looked for a non-numeric version.