### PR TITLE
fix: env variable version resolution to match legacy behavior

### DIFF
--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -131,5 +131,5 @@ func parseVersion(rawVersions string) []string {
 }
 
 func variableVersionName(toolName string) string {
-	return fmt.Sprintf("ASDF_%s_VERSION", strings.ToUpper(toolName))
+	return fmt.Sprintf("ASDF_%s_VERSION", strings.ToUpper(strings.ReplaceAll(toolName, "-", "_")))
 }


### PR DESCRIPTION
# Summary

We still use shell-lived tool session in our workflows, however when migrating to manually setting the behavior using env var, we noticed this issue.

This fix ensures the pattern matches the legacy shell behavior

https://github.com/asdf-vm/asdf/blob/2114f1ebc15b3f1653228c8b416f759898a58dc7/lib/commands/command-export-shell-version.bash#L20
