### PR TITLE
docs: add asdf Dev Container Feature to community projects

### DIFF
--- a/docs/more/community-projects.md
+++ b/docs/more/community-projects.md
@@ -7,6 +7,8 @@ Here are some community projects related to `asdf`:
 - [asdf dev container](https://github.com/iloveitaly/asdf-devcontainer): A
   [GitHub Dev Container](https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/introduction-to-dev-containers)
   supporting asdf managed tools in GitHub Codespaces.
+- [asdf Dev Container Feature](https://github.com/Alegrowin/devcontainer-features/): A Dev Container Feature that installs asdf in any dev container.
+  It works with pre 0.16.0 and 0.16.0+. If user Opt-in auto-install, it will automatically install tools from `.tool-versions.
 
 ::: warning Note
 


### PR DESCRIPTION
Adds information about the asdf Dev Container Feature to the community projects documentation. This feature allows installing asdf in any dev container, works with both pre-0.16.0 and 0.16.0+ versions, and can auto-install tools from .tool-versions file.
