### PR TITLE
fix: nushell completions --ignore-errors deprecation

### DIFF
--- a/internal/completions/asdf.nushell
+++ b/internal/completions/asdf.nushell
@@ -95,12 +95,12 @@ module asdf {
         let template = '(?P<name>.+)' + (
                             $params |
                             where enabled |
-                            get --ignore-errors template |
+                            get --optional template |
                             str join '' |
                             str trim
                         )
 
-        let flags = ($params | where enabled | get --ignore-errors flag | default '' )
+        let flags = ($params | where enabled | get --optional flag | default '' )
 
         ^asdf plugin list ...$flags | lines | parse -r $template | str trim
     }


### PR DESCRIPTION
# Summary

Update nushell completion code to use the new flag.

Fixes: #2156

## Other Information

Thanks for the great tool, I've been using it to earn a living for years.