### PR TITLE
Fix set version completion

### DIFF
--- a/internal/completions/asdf.zsh
+++ b/internal/completions/asdf.zsh
@@ -320,12 +320,7 @@ case "$subcmd" in
         else
           local plugin="${words[3]}"
         fi
-        local versions
-        if versions=$(asdf list all "$plugin" 2>/dev/null); then
-          _wanted "versions-$plugin" \
-            expl "Available versions of $plugin" \
-            compadd -- ${(f)versions}
-        fi
+        _asdf__installed_versions_of_plus_system $plugin
         ;;
     esac
     ;;


### PR DESCRIPTION
# Summary

Currently, zsh completion of the `set` command show list of all available versions.
This fix will only show the installed (and "system") versions.

Fixes #2047, #2134


## Example with `nodejs` plugin

### before

<img width="600" alt="Screenshot 2025-08-28 at 3 53 23 PM" src="https://github.com/user-attachments/assets/7f648eb2-0d0a-4cf9-98fb-1327db04e30f" />

### after

<img width="6060" alt="Screenshot 2025-08-28 at 3 55 00 PM" src="https://github.com/user-attachments/assets/5d7dcf7e-ec22-4946-9f87-b1826063f03e" />

