### PR TITLE
fix: restore backward compatibility of ASDF_{TOOL}_VERSION env vars

### DIFF
--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -131,5 +131,5 @@ func parseVersion(rawVersions string) []string {
 }
 
 func variableVersionName(toolName string) string {
-	return fmt.Sprintf("ASDF_%s_VERSION", strings.ToUpper(toolName))
+	return fmt.Sprintf("ASDF_%s_VERSION", strings.ToUpper(strings.ReplaceAll(s, "-", "_"))
 }

--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -131,5 +131,5 @@ func parseVersion(rawVersions string) []string {
 }
 
 func variableVersionName(toolName string) string {
-	return fmt.Sprintf("ASDF_%s_VERSION", strings.ToUpper(strings.ReplaceAll(s, "-", "_"))
+	return fmt.Sprintf("ASDF_%s_VERSION", strings.ToUpper(strings.ReplaceAll(toolName, "-", "_"))
 }


### PR DESCRIPTION

# Summary

In the bash version it was not only uppercasing, but also replacing `-` with `_` (because `-` is not a valid character for env vars).

See original code for reference:
https://github.com/asdf-vm/asdf/blame/master/lib/commands/command-export-shell-version.bash#L20-L21

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->
