### PR TITLE
docs: fix typos again

### DIFF
--- a/asdf.nu
+++ b/asdf.nu
@@ -190,7 +190,7 @@ module asdf {
         command: string # Name of command
     ]
 
-    # Display install path for an installled package version
+    # Display install path for an installed package version
     export extern "asdf where" [
         name: string@"complete asdf installed" # Name of installed package
         version?: string@"complete asdf plugin versions installed" # Version of installed package

--- a/docs/pt-br/index.md
+++ b/docs/pt-br/index.md
@@ -33,6 +33,6 @@ features:
     details: "Suporta Bash, ZSH, Fish & Elvish com autocomplete."
     icon: 🐚
   - title: "GitHub Actions"
-    details: "Fornece um GitHub Action para instalar e utilizar seu .tool-verions em seu fluxo de trabalho CICD."
+    details: "Fornece um GitHub Action para instalar e utilizar seu .tool-versions em seu fluxo de trabalho CICD."
     icon: 🤖
 ---

--- a/docs/zh-hans/manage/versions.md
+++ b/docs/zh-hans/manage/versions.md
@@ -87,7 +87,7 @@ asdf set <name> latest[:<version>]
 
 #### 通过环境变量
 
-在确定版本时，系统会查询符合模式的环境变量 `ASDF_${TOOL}_VERISON`。该版本格式与 `.tool-versions` 文件中支持的格式一致。如果设置了该环境变量，其值将覆盖任何 `.tool-versions` 文件中为该工具设置的版本。例如：
+在确定版本时，系统会查询符合模式的环境变量 `ASDF_${TOOL}_VERSION`。该版本格式与 `.tool-versions` 文件中支持的格式一致。如果设置了该环境变量，其值将覆盖任何 `.tool-versions` 文件中为该工具设置的版本。例如：
 
 ```shell
 export ASDF_ELIXIR_VERSION=1.18.1

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -105,7 +105,7 @@ func Execute(version string) {
 			{
 				Name: "exec",
 				// We want all arguments to exec to remain unparsed so we can pass them
-				// directly to the command asdf whill exec on behalf of the shim/user.
+				// directly to the command asdf will exec on behalf of the shim/user.
 				// SkipFlagParsing tells urfave/cli to do this.
 				SkipFlagParsing: true,
 				Action: func(_ context.Context, cmd *cli.Command) error {

--- a/internal/completions/asdf.nushell
+++ b/internal/completions/asdf.nushell
@@ -161,7 +161,7 @@ module asdf {
         command: string # Name of command
     ]
 
-    # Display install path for an installled package version
+    # Display install path for an installed package version
     export extern "asdf where" [
         name: string@"complete asdf installed" # Name of installed package
         version?: string@"complete asdf plugin versions installed" # Version of installed package

--- a/test/utils.bats
+++ b/test/utils.bats
@@ -133,7 +133,7 @@ teardown() {
   [ "$output" = "path:/some/dummy path" ]
 }
 
-@test "parse_asdf_version_file should output path version with tilda" {
+@test "parse_asdf_version_file should output path version with tilde" {
   echo "dummy path:~/some/dummy path" >"$PROJECT_DIR/.tool-versions"
   run parse_asdf_version_file "$PROJECT_DIR/.tool-versions" dummy
   [ "$status" -eq 0 ]
@@ -278,7 +278,7 @@ teardown() {
   [ "$output" = "path:/some/place with spaces" ]
 }
 
-@test "get_preset_version_for should return path version with tilda" {
+@test "get_preset_version_for should return path version with tilde" {
   cd "$PROJECT_DIR"
   echo "dummy path:~/some/place with spaces" >"$PROJECT_DIR/.tool-versions"
   run get_preset_version_for "dummy"


### PR DESCRIPTION
# Summary

Fix typos found via `codespell -S pt-br -L devlop` and `typos --hidden --format brief`

## Other Information

None.
