### PR TITLE
fix: use os.PathListSeparator

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -545,7 +545,7 @@ func envCommand(logger *log.Logger, shimmedCommand string, args []string) error 
 }
 
 func setPath(paths []string) string {
-	return strings.Join(paths, ":") + ":" + os.Getenv("PATH")
+	return strings.Join(paths, string(os.PathListSeparator)) + string(os.PathListSeparator) + os.Getenv("PATH")
 }
 
 func execCommand(logger *log.Logger, command string, args []string) error {

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -4,6 +4,7 @@
 package paths
 
 import (
+	"path/filepath"
 	"strings"
 )
 
@@ -11,11 +12,11 @@ import (
 func RemoveFromPath(currentPath, pathToRemove string) string {
 	var newPaths []string
 
-	for _, fspath := range strings.Split(currentPath, ":") {
+	for _, fspath := range filepath.SplitList(currentPath) {
 		if fspath != pathToRemove {
 			newPaths = append(newPaths, fspath)
 		}
 	}
 
-	return strings.Join(newPaths, ":")
+	return strings.Join(newPaths, string(filepath.ListSeparator))
 }


### PR DESCRIPTION
# Summary

Use [`os.PathListSeparator`](https://pkg.go.dev/os#PathListSeparator) instead of `":"`. This removes one blocker for a Windows port (#450) as the path separator on Windows is `";"`.

Also use [`path/filepath.SplitList`](https://pkg.go.dev/path/filepath#SplitList) instead of [`strings.Split`](https://pkg.go.dev/strings#Split) to correctly handle the (very unexpected) case of an empty `PATH` in `internal/shims.RemoveFromPath`.