### PR TITLE
fix: set LANG=C for locale-dependent tests

### DIFF
--- a/internal/execute/execute_test.go
+++ b/internal/execute/execute_test.go
@@ -28,7 +28,8 @@ func TestNewExpression(t *testing.T) {
 
 func TestRun_Command(t *testing.T) {
 	t.Run("command is executed with bash", func(t *testing.T) {
-		cmd := New("echo $(type -a sh);", []string{})
+		// "type" (bash) output is locale sensitive
+		cmd := New("echo $(LANG=C type -a sh);", []string{})
 
 		var stdout strings.Builder
 		cmd.Stdout = &stdout
@@ -130,7 +131,8 @@ func TestRun_Command(t *testing.T) {
 
 func TestRun_Expression(t *testing.T) {
 	t.Run("expression is executed with bash", func(t *testing.T) {
-		cmd := NewExpression("echo $(type -a sh)", []string{})
+		// "type" (bash) output is locale sensitive
+		cmd := NewExpression("echo $(LANG=C type -a sh)", []string{})
 
 		var stdout strings.Builder
 		cmd.Stdout = &stdout

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestRepoClone(t *testing.T) {
+	t.Setenv("LANG", "C") // error messages from git are locale dependent
+
 	t.Run("when repo name is valid but URL is invalid prints an error", func(t *testing.T) {
 		repo := NewRepo(t.TempDir())
 		err := repo.Clone("foobar", "")
@@ -94,6 +96,8 @@ func TestRepoRemoteURL(t *testing.T) {
 }
 
 func TestRepoUpdate(t *testing.T) {
+	t.Setenv("LANG", "C") // error messages from git are locale dependent
+
 	repoDir := generateRepo(t)
 	directory := t.TempDir()
 

--- a/internal/plugins/plugins_test.go
+++ b/internal/plugins/plugins_test.go
@@ -125,6 +125,8 @@ func TestAdd(t *testing.T) {
 	})
 
 	t.Run("when plugin name is valid but URL is invalid prints an error", func(t *testing.T) {
+		t.Setenv("LANG", "C") // git error messages are locale dependent
+
 		conf := config.Config{DataDir: testDataDir}
 
 		err := Add(conf, "foo", "foobar", "")


### PR DESCRIPTION
Set `LANG=C` for tests which call external commands (`bash`, `git`) which have locale-dependent output.

Fixes: #2196

```console
$ LANG=fr_FR.UTF-8 go test -trimpath -count=1 ./...
?   	github.com/asdf-vm/asdf/internal/cli	[no test files]
?   	github.com/asdf-vm/asdf/internal/installtest	[no test files]
?   	github.com/asdf-vm/asdf/internal/repotest	[no test files]
ok  	github.com/asdf-vm/asdf/cmd/asdf	102.088s
ok  	github.com/asdf-vm/asdf/internal/cli/set	0.181s
ok  	github.com/asdf-vm/asdf/internal/completions	1.065s
ok  	github.com/asdf-vm/asdf/internal/config	0.697s
ok  	github.com/asdf-vm/asdf/internal/data	0.357s
ok  	github.com/asdf-vm/asdf/internal/exec	1.584s
ok  	github.com/asdf-vm/asdf/internal/execenv	2.300s
ok  	github.com/asdf-vm/asdf/internal/execute	1.347s
ok  	github.com/asdf-vm/asdf/internal/git	3.107s
ok  	github.com/asdf-vm/asdf/internal/help	2.933s
ok  	github.com/asdf-vm/asdf/internal/hook	1.071s
ok  	github.com/asdf-vm/asdf/internal/info	0.969s
ok  	github.com/asdf-vm/asdf/internal/installs	2.459s
ok  	github.com/asdf-vm/asdf/internal/paths	0.668s
ok  	github.com/asdf-vm/asdf/internal/pluginindex	1.260s
ok  	github.com/asdf-vm/asdf/internal/plugins	9.831s
ok  	github.com/asdf-vm/asdf/internal/resolve	3.537s
ok  	github.com/asdf-vm/asdf/internal/shims	10.938s
ok  	github.com/asdf-vm/asdf/internal/toolversions	0.825s
ok  	github.com/asdf-vm/asdf/internal/versions	18.840s
```
