### PR TITLE
docs: Update getting-started.md to remove macOS warning

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -68,8 +68,6 @@ a variable named `ASDF_DATA_DIR` in your shell's RC file.
 
 There are many different combinations of Shells, OSs & Installation methods all of which affect the configuration here. Expand the selection below that best matches your system.
 
-**macOS users, be sure to read the warning about `path_helper` at the end of this section.**
-
 ::: details Bash
 
 **macOS Catalina or newer**: The default shell has changed to **ZSH**. Unless changing back to Bash, follow the ZSH instructions.


### PR DESCRIPTION
# Summary

In the Getting Started guide, there is a callout for macos users to see a warning about path_helper, but path_helper is not mentioned anywhere on the page.

It used to be mentioned in the Getting Started (legacy) page, but was removed. So this PR also removes the confusing callout.

## Other Information

<!-- If there is anything else that is relevant to your pull request include that information here. Thank you for contributing to asdf! -->
