### PR TITLE
docs: update note on 'asdf global' usage

### DIFF
--- a/docs/guide/getting-started-legacy.md
+++ b/docs/guide/getting-started-legacy.md
@@ -434,6 +434,8 @@ nodejs 16.5.0
 
 Some OSs already have tools installed that are managed by the system and not `asdf`, `python` is a common example. You need to tell `asdf` to pass the management back to the system. The [Versions reference section](/manage/versions.md) will guide you.
 
+Note: `asdf global` has been superceded by `asdf local` in later version
+
 ### Local
 
 Local versions are defined in the `$PWD/.tool-versions` file (your current working directory). Usually, this will be the Git repository for a project. When in your desired directory execute:


### PR DESCRIPTION
# Summary
Clarify the use of 'asdf global' and its replacement.

- Relates to #https://github.com/asdf-vm/asdf/issues/2002

## Other Information

Let me know if you would like to modify the comment/style. I was thinking to say:

> has been superceded by `asdf local` starting in :version:

but I couldn't easily trace it based on the Changelog.md. It looks like there's mention of the command up to version `0.8.1`:

<img width="886" height="631" alt="Screenshot from 2026-01-21 16-53-01" src="https://github.com/user-attachments/assets/b7e64ac4-51c0-4e73-adbd-10e5bd9131cb" />
