### PR TITLE
fix: respect absolute tool versions file path

### DIFF
--- a/internal/resolve/resolve.go
+++ b/internal/resolve/resolve.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/asdf-vm/asdf/internal/config"
@@ -56,10 +57,13 @@ func Version(conf config.Config, plugin plugins.Plugin, directory string) (versi
 }
 
 func findVersionsInDir(conf config.Config, plugin plugins.Plugin, directory string) (versions ToolVersions, found bool, err error) {
-	filepath := path.Join(directory, conf.DefaultToolVersionsFilename)
+	toolVersionsPath := conf.DefaultToolVersionsFilename
+	if !filepath.IsAbs(toolVersionsPath) {
+		toolVersionsPath = path.Join(directory, toolVersionsPath)
+	}
 
-	if _, err = os.Stat(filepath); err == nil {
-		versions, found, err := toolversions.FindToolVersions(filepath, plugin.Name)
+	if _, err = os.Stat(toolVersionsPath); err == nil {
+		versions, found, err := toolversions.FindToolVersions(toolVersionsPath, plugin.Name)
 		if found || err != nil {
 			return ToolVersions{Versions: versions, Source: conf.DefaultToolVersionsFilename, Directory: directory}, found, err
 		}

--- a/internal/resolve/resolve_test.go
+++ b/internal/resolve/resolve_test.go
@@ -70,6 +70,21 @@ func TestVersion(t *testing.T) {
 		assert.True(t, found)
 		assert.Equal(t, toolVersion.Versions, []string{"1.2.3"})
 	})
+
+	t.Run("returns version from absolute DefaultToolVersionsFilename", func(t *testing.T) {
+		currentDir := t.TempDir()
+		customFile := filepath.Join(t.TempDir(), "custom-file")
+		conf := config.Config{DataDir: testDataDir, DefaultToolVersionsFilename: customFile, ConfigFile: "testdata/asdfrc"}
+
+		data := []byte(fmt.Sprintf("%s 1.2.3", testPluginName))
+		err = os.WriteFile(customFile, data, 0o666)
+		assert.Nil(t, err)
+
+		toolVersion, found, err := Version(conf, plugin, currentDir)
+		assert.Nil(t, err)
+		assert.True(t, found)
+		assert.Equal(t, toolVersion.Versions, []string{"1.2.3"})
+	})
 }
 
 func TestFindVersionsInDir(t *testing.T) {
@@ -121,6 +136,22 @@ func TestFindVersionsInDir(t *testing.T) {
 
 		data := []byte(fmt.Sprintf("%s 1.2.3 2.3.4", testPluginName))
 		err = os.WriteFile(filepath.Join(currentDir, "custom-file"), data, 0o666)
+
+		toolVersion, found, err := findVersionsInDir(conf, plugin, currentDir)
+
+		assert.Equal(t, toolVersion.Versions, []string{"1.2.3", "2.3.4"})
+		assert.True(t, found)
+		assert.Nil(t, err)
+	})
+
+	t.Run("when DefaultToolVersionsFilename is an absolute path reads from that path", func(t *testing.T) {
+		currentDir := t.TempDir()
+		customFile := filepath.Join(t.TempDir(), "custom-file")
+
+		conf := config.Config{DataDir: testDataDir, DefaultToolVersionsFilename: customFile}
+
+		data := []byte(fmt.Sprintf("%s 1.2.3 2.3.4", testPluginName))
+		err = os.WriteFile(customFile, data, 0o666)
 
 		toolVersion, found, err := findVersionsInDir(conf, plugin, currentDir)
 


### PR DESCRIPTION
## Summary

Fixes #2201.

When `ASDF_TOOL_VERSIONS_FILENAME` is set to an absolute path, version resolution currently joins that absolute path with the current directory before checking for the file. That turns a valid path like `/home/me/custom-tool-versions` into `<cwd>/home/me/custom-tool-versions`, so asdf fails to find the configured version and falls through to the shim error path.

This change treats `DefaultToolVersionsFilename` as a full path when it is absolute, and only joins it with the current directory when it is a relative filename.

## Testing

Passed:
- `go test ./internal/resolve -run 'TestVersion|TestFindVersionsInDir' -v`
- `go test ./internal/...`
- Temporary in-repo repro harness for `resolve.Version(...)` with an absolute `DefaultToolVersionsFilename`:
  before the fix it returned `found=false`; after the fix it returned `found=true versions=[1.2.3]`.

Environment-limited:
- `go test ./...` fails in `cmd/asdf` because `bats` is not installed in the current environment; the visible failures are all `bats command failed to run test file successfully`.
