### PR TITLE
docs: update nushell setup instructions

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -264,7 +264,7 @@ $env.PATH = $env.PATH | where {$in != $asdf_shims} | prepend $asdf_shims
 
 ###### Custom data directory (required when $asdf_data_dir != '~/.asdf')
 
-Add the following to `~/.config/nushell/config.nu`:
+If you set $asdf_data_dir to something different than the default `~/.asdf` then you must add the following to `~/.config/nushell/config.nu`:
 
 ```shell
 $env.ASDF_DATA_DIR = $asdf_data_dir

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -257,47 +257,30 @@ Shell completions not available for PowerShell
 Add the following to `~/.config/nushell/config.nu`:
 
 ```shell
-let shims_dir = (
-  if ( $env | get --ignore-errors ASDF_DATA_DIR | is-empty ) {
-    $env.HOME | path join '.asdf'
-  } else {
-    $env.ASDF_DATA_DIR
-  } | path join 'shims'
-)
-$env.PATH = ( $env.PATH | split row (char esep) | where { |p| $p != $shims_dir } | prepend $shims_dir )
+const asdf_data_dir = '~/.asdf' | path expand # or wherever you like
+const asdf_shims = [$asdf_data_dir shims] | path join
+$env.PATH = $env.PATH | where {$in != $asdf_shims} | prepend $asdf_shims
 ```
 
-###### Custom data directory (optional)
+###### Custom data directory (required when $asdf_data_dir != '~/.asdf')
 
-Add the following to `~/.config/nushell/config.nu` above the line you added above:
+Add the following to `~/.config/nushell/config.nu`:
 
 ```shell
-$env.ASDF_DATA_DIR = "/your/custom/data/dir"
+$env.ASDF_DATA_DIR = $asdf_data_dir
 ```
 
 ##### Set up shell completions (optional)
 
-```shell
-# If you've not customized the asdf data directory:
-$ mkdir $"($env.HOME)/.asdf/completions"
-$ asdf completion nushell | save $"($env.HOME)/.asdf/completions/nushell.nu"
-
-# If you have customized the data directory by setting ASDF_DATA_DIR:
-$ mkdir $"($env.ASDF_DATA_DIR)/completions"
-$ asdf completion nushell | save $"($env.ASDF_DATA_DIR)/completions/nushell.nu"
-```
-
-Then add the following to `~/.config/nushell/config.nu`:
+Add the following to `~/.config/nushell/config.nu`, after the required setup:
 
 ```shell
-let asdf_data_dir = (
-  if ( $env | get --ignore-errors ASDF_DATA_DIR | is-empty ) {
-    $env.HOME | path join '.asdf'
-  } else {
-    $env.ASDF_DATA_DIR
-  }
-)
-source "$asdf_data_dir/completions/nushell.nu"
+const asdf_cmp = [$asdf_data_dir completions nushell.nu] | path join
+if not ($asdf_cmp | path exists) {
+  mkdir ($asdf_cmp | path dirname)
+  asdf completion nushell | save -f $asdf_cmp
+}
+source $asdf_cmp
 ```
 
 :::

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -276,10 +276,8 @@ Add the following to `~/.config/nushell/config.nu`, after the required setup:
 
 ```shell
 const asdf_cmp = [$asdf_data_dir completions nushell.nu] | path join
-if not ($asdf_cmp | path exists) {
-  mkdir ($asdf_cmp | path dirname)
-  asdf completion nushell | save -f $asdf_cmp
-}
+mkdir ($asdf_cmp | path dirname)
+asdf completion nushell | save -f $asdf_cmp
 source $asdf_cmp
 ```
 


### PR DESCRIPTION
Hi there 👋
Nushell user here.
While reviewing the documentation to refresh my asdf setup, I noticed the Nushell configuration section might benefit from some updates. Most importantly:
  
- let is used where const may be needed — source expects a path known at parse time in modern Nushell
- String interpolation bug in completion setup: `"$asdf_data_dir/completions/nushell.nu"` should be `$"($asdf_data_dir)/completions/nushell.nu"`
- Use of deprecated `get --ignore-errors` (now `get --optional`)
- Split row (char esep) is called on $env.PATH, which is already a list

I've taken a stab at updating the examples based on what works in my own config. I'd welcome any feedback — happy to adjust if there are edge cases or compatibility concerns I might be overlooking.

Love ❤️