### PR TITLE
docs: add missing macOS path_helper warning

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -68,6 +68,8 @@ a variable named `ASDF_DATA_DIR` in your shell's RC file.
 
 There are many different combinations of Shells, OSs & Installation methods all of which affect the configuration here. Expand the selection below that best matches your system.
 
+**macOS users, be sure to read the warning about `path_helper` at the end of this section.**
+
 ::: details Bash
 
 **macOS Catalina or newer**: The default shell has changed to **ZSH**. Unless changing back to Bash, follow the ZSH instructions.
@@ -303,6 +305,10 @@ export ASDF_DATA_DIR="/your/custom/data/dir"
 :::
 
 `asdf` scripts need to be sourced **after** you have set your `$PATH` and **after** you have sourced your framework (oh-my-zsh etc).
+
+::: warning
+On macOS, starting a Bash or Zsh shell automatically calls a utility called `path_helper`. `path_helper` can rearrange items in `PATH` (and `MANPATH`), causing inconsistent behavior for tools that require specific ordering. To workaround this, `asdf` on macOS defaults to forcibly adding its `PATH`-entries to the front (taking highest priority). This is controllable with the `ASDF_FORCE_PREPEND` variable.
+:::
 
 Restart your shell so that `PATH` changes take effect. Opening a new terminal tab will usually do it.
 


### PR DESCRIPTION
## Summary

Restores the missing macOS `path_helper` warning in the Getting Started guide.

- Re-adds the pointer: *"macOS users, be sure to read the warning about `path_helper` at the end of this section."*
- Adds the `path_helper` warning at the end of the **Configure asdf** section, so the pointer now resolves.
- Warning text is taken verbatim from the existing pre-0.16 guide (`docs/guide/getting-started-legacy.md`).

Closes #2141

## Why

The Getting Started guide points macOS users to a `path_helper` warning "at the end of this section", but the warning itself was missing from the page (#2141). This restores it from the legacy guide, which still describes the current behavior: on macOS `asdf` prepends its `PATH` entries by default, controllable via `ASDF_FORCE_PREPEND`.

## Notes

Documentation-only change.