### PR TITLE
fix: prevent incomplete installations from being shown as installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ keyrings
 dist/
 
 # ignore build binary
-asdf
+/asdf

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ keyrings
 dist/
 
 # ignore build binary
-asdf
+./asdf

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,10 @@ Please [open a new Feature Request](https://github.com/asdf-vm/asdf/issues/new/c
 
 See [docs/contribute/core.md](docs/contribute/core.md) or on our [Docs Site](https://asdf-vm.com/contribute/core.html).
 
+### Architectural Decision Records
+
+Architectural Decision Records (ADRs) are stored in `docs/adr/`. These documents capture important architectural decisions made in the project and are useful for understanding the rationale behind past design choices.
+
 ## Documentation
 
 Documentation can always be improved! See [docs/contribute/documentation.md](docs/contribute/documentation.md) or on our [Docs Site](https://asdf-vm.com/contribute/documentation.html).

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   title: "asdf",
   description: "Manage multiple runtime versions with a single CLI tool",
   lastUpdated: true,
+  srcExclude: ['adr/**'],
   locales: {
     root: {
       label: "English",

--- a/docs/adr/001-incomplete-install-marker.md
+++ b/docs/adr/001-incomplete-install-marker.md
@@ -1,0 +1,48 @@
+# ADR 001: Use marker file to signal incomplete installs
+
+## Status
+
+Accepted
+
+## Context
+
+Due to the initial implementation of asdf all plugin versions must be installed into a subdirectory inside the asdf installs directory. When an installation is terminated by `SIGTERM`, `SIGKILL`, a dropped network connection, or loss of power, the installation directory persists, even though the installation itself was interrupted and is likely in an incomplete or broken state. When a user later runs commands that check for installed versions asdf incorrectly treats these incomplete installations as installed. This happens because asdf considers every directory inside of `$ASDF_DATA_DIR/installs` as a valid installation. This leads to confusing behavior and errors the user may be unable to trace back to the root cause.
+
+## Decision
+
+We will implement a mechanism to mark incomplete version installation directories using a marker file stored in a dedicated directory. The mechanism will be robust and prevent any type of failure from resulting in an installation that asdf treats as valid when it is incomplete.
+
+Here is how the install process will work:
+
+1. Before beginning an installation asdf will check if the installation directory already exists along with a marker file in the install-locks directory with the same name. If it does, both the installation directory and marker are removed to clean up any stale incomplete installations.
+2. asdf creates a marker file in the install-locks directory first (e.g., `$ASDF_DATA_DIR/install-locks/<tool>/<version>`), then creates the installation directory itself (e.g., `$ASDF_DATA_DIR/installs/<tool>/<version>`). Using a separate top-level directory ensures that:
+   - Plugins which completely replace `$ASDF_INSTALL_PATH` contents do not inadvertently remove the marker
+   - The install-locks directory is completely separate from the installs directory
+3. The plugin's download and install callbacks are invoked, along with any pre-download and pre-install hooks. If the install callback fails the installation directory is removed.
+4. When the installation is finished asdf removes the marker file.
+
+Additionally, signal handlers will be registered for `SIGINT` and `SIGTERM` before installation that will trigger removal of the install directory.
+
+Commands that list installed versions or check for an installed version do this by reading directories. Now there will be an additional check for the marker file in the install-locks directory for each version directory.
+
+## Consequences
+
+### Positive
+
+* Signal interruption (Ctrl+C) properly cleans up partial installations
+* No manual cleanup required for failed installations
+* Clear distinction between complete and incomplete installations
+* Users no longer encounter confusing errors from partial installations
+* Backward compatibility is maintained, all plugins will continue to work
+* Marker files survive plugins that replace `$ASDF_INSTALL_PATH` contents (e.g., asdf-nim)
+* Simple implementation without temporary directory staging
+
+### Negative/Neutral
+
+* `install-locks` directory will be created at the top level of `$ASDF_DATA_DIR`
+* Requires creating install-locks directory structure on first incomplete marker creation
+
+## Related Issues
+
+* https://github.com/asdf-vm/asdf/issues/2184
+* https://github.com/asdf-vm/asdf/issues/2036

--- a/internal/data/data.go
+++ b/internal/data/data.go
@@ -9,6 +9,7 @@ import (
 const (
 	dataDirDownloads = "downloads"
 	dataDirInstalls  = "installs"
+	dataDirLocks     = "install-locks"
 	dataDirPlugins   = "plugins"
 )
 
@@ -32,4 +33,9 @@ func PluginsDirectory(dataDir string) string {
 // if it were installed
 func PluginDirectory(dataDir, pluginName string) string {
 	return filepath.Join(dataDir, dataDirPlugins, pluginName)
+}
+
+// InstallLocksDirectory returns the directory for install marker/lock files
+func InstallLocksDirectory(dataDir, pluginName string) string {
+	return filepath.Join(dataDir, dataDirLocks, pluginName)
 }

--- a/internal/installs/installs.go
+++ b/internal/installs/installs.go
@@ -4,6 +4,8 @@
 package installs
 
 import (
+	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -13,6 +15,12 @@ import (
 	"github.com/asdf-vm/asdf/internal/plugins"
 	"github.com/asdf-vm/asdf/internal/toolversions"
 )
+
+// IncompleteMarkerPath returns the path to the incomplete marker file for a version
+func IncompleteMarkerPath(conf config.Config, plugin plugins.Plugin, version toolversions.Version) string {
+	formattedVersion := toolversions.FormatForFS(version)
+	return filepath.Join(data.InstallLocksDirectory(conf.DataDir, plugin.Name), formattedVersion)
+}
 
 // Installed returns a slice of all installed versions for a given plugin
 func Installed(conf config.Config, plugin plugins.Plugin) (versions []string, err error) {
@@ -31,7 +39,18 @@ func Installed(conf config.Config, plugin plugins.Plugin) (versions []string, er
 			continue
 		}
 
-		versions = append(versions, toolversions.VersionStringFromFSFormat(file.Name()))
+		displayVersion := toolversions.VersionStringFromFSFormat(file.Name())
+		version := toolversions.Parse(displayVersion)
+		_, statErr := os.Stat(IncompleteMarkerPath(conf, plugin, version))
+		if statErr == nil {
+			continue
+		}
+		if !errors.Is(statErr, fs.ErrNotExist) {
+			err = fmt.Errorf("checking install marker for version %s: %w", displayVersion, statErr)
+			continue
+		}
+
+		versions = append(versions, displayVersion)
 	}
 
 	return versions, err
@@ -59,7 +78,14 @@ func DownloadPath(conf config.Config, plugin plugins.Plugin, version toolversion
 func IsInstalled(conf config.Config, plugin plugins.Plugin, version toolversions.Version) bool {
 	installDir := InstallPath(conf, plugin, version)
 
-	// Check if version already installed
 	_, err := os.Stat(installDir)
-	return !os.IsNotExist(err)
+	if err != nil {
+		return false
+	}
+
+	_, err = os.Stat(IncompleteMarkerPath(conf, plugin, version))
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, fs.ErrNotExist)
 }

--- a/internal/installs/installs_test.go
+++ b/internal/installs/installs_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/asdf-vm/asdf/internal/config"
+	"github.com/asdf-vm/asdf/internal/data"
 	"github.com/asdf-vm/asdf/internal/installtest"
 	"github.com/asdf-vm/asdf/internal/plugins"
 	"github.com/asdf-vm/asdf/internal/repotest"
@@ -63,6 +64,68 @@ func TestInstalled(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, installedVersions, []string{"1.0.0"})
 	})
+
+	t.Run("filters out directories with incomplete marker", func(t *testing.T) {
+		mockInstall(t, conf, plugin, "1.0.0")
+		mockInstall(t, conf, plugin, "2.0.0")
+		mockInstall(t, conf, plugin, "3.0.0")
+
+		version2 := toolversions.Version{Type: "version", Value: "2.0.0"}
+		err := markIncomplete(conf, plugin, version2)
+		assert.Nil(t, err)
+
+		installedVersions, err := Installed(conf, plugin)
+		assert.Nil(t, err)
+		assert.Equal(t, 2, len(installedVersions))
+		assert.Contains(t, installedVersions, "1.0.0")
+		assert.Contains(t, installedVersions, "3.0.0")
+		assert.NotContains(t, installedVersions, "2.0.0")
+	})
+
+	t.Run("continues scanning and reports error when a marker lookup fails", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("permission checks do not apply when running as root")
+		}
+
+		conf4, plugin4 := generateConfig(t)
+		mockInstall(t, conf4, plugin4, "1.0.0")
+		mockInstall(t, conf4, plugin4, "2.0.0")
+		mockInstall(t, conf4, plugin4, "3.0.0")
+
+		locksDir := data.InstallLocksDirectory(conf4.DataDir, plugin4.Name)
+		assert.Nil(t, os.MkdirAll(locksDir, 0o755))
+		assert.Nil(t, os.Chmod(locksDir, 0o000))
+		t.Cleanup(func() { _ = os.Chmod(locksDir, 0o755) })
+
+		installedVersions, err := Installed(conf4, plugin4)
+		assert.Empty(t, installedVersions)
+		assert.NotNil(t, err)
+	})
+
+	t.Run("returns all versions when none have incomplete marker", func(t *testing.T) {
+		conf2, plugin2 := generateConfig(t)
+		mockInstall(t, conf2, plugin2, "1.0.0")
+		mockInstall(t, conf2, plugin2, "2.0.0")
+
+		installedVersions, err := Installed(conf2, plugin2)
+		assert.Nil(t, err)
+		assert.Equal(t, 2, len(installedVersions))
+	})
+
+	t.Run("filters out ref installs with incomplete marker", func(t *testing.T) {
+		conf3, plugin3 := generateConfig(t)
+		refVersion := toolversions.Version{Type: "ref", Value: "foo"}
+		path := InstallPath(conf3, plugin3, refVersion)
+		err := os.MkdirAll(path, os.ModePerm)
+		assert.Nil(t, err)
+
+		err = markIncomplete(conf3, plugin3, refVersion)
+		assert.Nil(t, err)
+
+		installedVersions, err := Installed(conf3, plugin3)
+		assert.Nil(t, err)
+		assert.Empty(t, installedVersions)
+	})
 }
 
 func TestIsInstalled(t *testing.T) {
@@ -76,6 +139,16 @@ func TestIsInstalled(t *testing.T) {
 	t.Run("returns true when installed", func(t *testing.T) {
 		version := toolversions.Version{Type: "version", Value: "1.0.0"}
 		assert.True(t, IsInstalled(conf, plugin, version))
+	})
+
+	t.Run("returns false when directory exists but has incomplete marker", func(t *testing.T) {
+		version := toolversions.Version{Type: "version", Value: "2.0.0"}
+		mockInstall(t, conf, plugin, "2.0.0")
+
+		err := markIncomplete(conf, plugin, version)
+		assert.Nil(t, err)
+
+		assert.False(t, IsInstalled(conf, plugin, version))
 	})
 }
 
@@ -105,4 +178,18 @@ func installVersion(t *testing.T, conf config.Config, plugin plugins.Plugin, ver
 	t.Helper()
 	err := installtest.InstallOneVersion(conf, plugin, "version", version)
 	assert.Nil(t, err)
+}
+
+func markIncomplete(conf config.Config, plugin plugins.Plugin, version toolversions.Version) error {
+	markerPath := IncompleteMarkerPath(conf, plugin, version)
+	err := os.MkdirAll(filepath.Dir(markerPath), 0o755)
+	if err != nil {
+		return err
+	}
+	file, err := os.Create(markerPath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	return nil
 }

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -7,8 +7,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/signal"
+	"path/filepath"
 	"regexp"
 	"strings"
+	"syscall"
 
 	"github.com/asdf-vm/asdf/internal/config"
 	"github.com/asdf-vm/asdf/internal/hook"
@@ -20,11 +23,12 @@ import (
 )
 
 const (
-	systemVersion           = "system"
-	latestVersion           = "latest"
-	latestFilterRegex       = "(?i)(^Available versions:|-src|-dev|-latest|-stm|[-\\.]rc|-milestone|-alpha|-beta|[-\\.]pre|-next|(a|b|c)[0-9]+|snapshot|master|main)"
-	numericStartFilterRegex = "^\\s*[0-9]"
-	noLatestVersionErrMsg   = "no latest version found"
+	incompleteMarkerFilename = ".incomplete"
+	systemVersion            = "system"
+	latestVersion            = "latest"
+	latestFilterRegex        = "(?i)(^Available versions:|-src|-dev|-latest|-stm|[-\\.]rc|-milestone|-alpha|-beta|[-\\.]pre|-next|(a|b|c)[0-9]+|snapshot|master|main)"
+	numericStartFilterRegex  = "^\\s*[0-9]"
+	noLatestVersionErrMsg    = "no latest version found"
 )
 
 // UninstallableVersionError is an error returned if someone tries to install the
@@ -153,12 +157,60 @@ func InstallOneVersion(conf config.Config, plugin plugins.Plugin, versionStr str
 	if version.Type == "path" {
 		return UninstallableVersionError{toolName: plugin.Name, versionType: "path"}
 	}
-	downloadDir := installs.DownloadPath(conf, plugin, version)
+
 	installDir := installs.InstallPath(conf, plugin, version)
+	err = cleanupStaleIncomplete(conf, installDir)
+	if err != nil {
+		fmt.Fprintf(stdErr, "warning: failed to cleanup stale incomplete install: %s\n", err)
+	}
 
 	if installs.IsInstalled(conf, plugin, version) {
 		return VersionAlreadyInstalledError{version: version, toolName: plugin.Name}
 	}
+
+	tempDir := filepath.Join(conf.DataDir, "temp", "install", fmt.Sprintf("%s-%s", plugin.Name, version))
+	downloadDir := installs.DownloadPath(conf, plugin, version)
+
+	err = os.MkdirAll(tempDir, 0o777)
+	if err != nil {
+		return fmt.Errorf("unable to create temp dir: %w", err)
+	}
+
+	defer func() {
+		os.RemoveAll(tempDir)
+	}()
+
+	err = markIncomplete(tempDir)
+	if err != nil {
+		return fmt.Errorf("failed to mark installation as incomplete: %w", err)
+	}
+
+	installParentDir := filepath.Dir(installDir)
+	err = os.MkdirAll(installParentDir, 0o777)
+	if err != nil {
+		return fmt.Errorf("unable to create install parent dir: %w", err)
+	}
+
+	err = os.Rename(tempDir, installDir)
+	if err != nil {
+		return fmt.Errorf("failed to move temp dir to install location: %w", err)
+	}
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	cleanup := func() {
+		os.RemoveAll(installDir)
+		os.RemoveAll(tempDir)
+	}
+
+	go func() {
+		<-sigChan
+		cleanup()
+		os.Exit(1)
+	}()
+
+	defer signal.Stop(sigChan)
 
 	concurrency, _ := conf.Concurrency()
 	env := map[string]string{
@@ -189,17 +241,20 @@ func InstallOneVersion(conf config.Config, plugin plugins.Plugin, versionStr str
 		return fmt.Errorf("failed to run pre-install hook: %w", err)
 	}
 
-	err = os.MkdirAll(installDir, 0o777)
-	if err != nil {
-		return fmt.Errorf("unable to create install dir: %w", err)
-	}
-
 	err = plugin.RunCallback("install", []string{}, env, stdOut, stdErr)
 	if err != nil {
 		if rmErr := os.RemoveAll(installDir); rmErr != nil {
 			fmt.Fprintf(stdErr, "failed to clean up '%s' due to %s\n", installDir, rmErr)
 		}
 		return fmt.Errorf("failed to run install callback: %w", err)
+	}
+
+	err = markComplete(installDir)
+	if err != nil {
+		if rmErr := os.RemoveAll(installDir); rmErr != nil {
+			fmt.Fprintf(stdErr, "failed to clean up '%s' due to %s\n", installDir, rmErr)
+		}
+		return fmt.Errorf("failed to mark installation as complete: %w", err)
 	}
 
 	// Reshim
@@ -365,4 +420,46 @@ func parseVersions(rawVersions string) []string {
 		}
 	}
 	return versions
+}
+
+// markComplete removes the .incomplete marker file from the given directory
+func markComplete(installPath string) error {
+	markerPath := filepath.Join(installPath, incompleteMarkerFilename)
+	err := os.Remove(markerPath)
+	if err != nil {
+		return fmt.Errorf("failed to remove incomplete marker: %w", err)
+	}
+	return nil
+}
+
+// markIncomplete creates a .incomplete marker file in the given directory
+func markIncomplete(installPath string) error {
+	markerPath := filepath.Join(installPath, incompleteMarkerFilename)
+	file, err := os.Create(markerPath)
+	if err != nil {
+		return fmt.Errorf("failed to create incomplete marker: %w", err)
+	}
+	defer file.Close()
+	return nil
+}
+
+// cleanupStaleIncomplete removes an install directory if it has a .incomplete marker
+func cleanupStaleIncomplete(conf config.Config, installPath string) error {
+	_, err := os.Stat(installPath)
+	if os.IsNotExist(err) {
+		return nil
+	}
+
+	markerPath := filepath.Join(installPath, incompleteMarkerFilename)
+	_, err = os.Stat(markerPath)
+	if os.IsNotExist(err) {
+		return nil
+	}
+
+	err = os.RemoveAll(installPath)
+	if err != nil {
+		return fmt.Errorf("failed to remove stale incomplete directory: %w", err)
+	}
+
+	return nil
 }

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -6,9 +6,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
+	"os/signal"
+	"path/filepath"
 	"regexp"
 	"strings"
+	"syscall"
 
 	"github.com/asdf-vm/asdf/internal/config"
 	"github.com/asdf-vm/asdf/internal/hook"
@@ -153,12 +157,60 @@ func InstallOneVersion(conf config.Config, plugin plugins.Plugin, versionStr str
 	if version.Type == "path" {
 		return UninstallableVersionError{toolName: plugin.Name, versionType: "path"}
 	}
-	downloadDir := installs.DownloadPath(conf, plugin, version)
+
 	installDir := installs.InstallPath(conf, plugin, version)
+	err = cleanupStaleIncomplete(conf, plugin, version)
+	if err != nil {
+		return fmt.Errorf("failed to cleanup stale incomplete install: %w", err)
+	}
 
 	if installs.IsInstalled(conf, plugin, version) {
 		return VersionAlreadyInstalledError{version: version, toolName: plugin.Name}
 	}
+
+	downloadDir := installs.DownloadPath(conf, plugin, version)
+
+	installParentDir := filepath.Dir(installDir)
+	err = os.MkdirAll(installParentDir, 0o777)
+	if err != nil {
+		return fmt.Errorf("unable to create install parent dir: %w", err)
+	}
+
+	err = markIncomplete(conf, plugin, version)
+	if err != nil {
+		return fmt.Errorf("failed to mark installation as incomplete: %w", err)
+	}
+
+	err = os.MkdirAll(installDir, 0o777)
+	if err != nil {
+		return fmt.Errorf("unable to create install dir: %w", err)
+	}
+
+	// Set up signal handler to clean up on interrupt
+	sigChan := make(chan os.Signal, 1)
+	done := make(chan struct{})
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	stopCleanup := func() {
+		signal.Stop(sigChan)
+		select {
+		case <-done:
+		default:
+			close(done)
+		}
+	}
+
+	go func() {
+		select {
+		case <-sigChan:
+			os.RemoveAll(installDir)
+			os.Exit(1)
+		case <-done:
+			return
+		}
+	}()
+
+	defer stopCleanup()
 
 	concurrency, _ := conf.Concurrency()
 	env := map[string]string{
@@ -189,11 +241,6 @@ func InstallOneVersion(conf config.Config, plugin plugins.Plugin, versionStr str
 		return fmt.Errorf("failed to run pre-install hook: %w", err)
 	}
 
-	err = os.MkdirAll(installDir, 0o777)
-	if err != nil {
-		return fmt.Errorf("unable to create install dir: %w", err)
-	}
-
 	err = plugin.RunCallback("install", []string{}, env, stdOut, stdErr)
 	if err != nil {
 		if rmErr := os.RemoveAll(installDir); rmErr != nil {
@@ -201,6 +248,16 @@ func InstallOneVersion(conf config.Config, plugin plugins.Plugin, versionStr str
 		}
 		return fmt.Errorf("failed to run install callback: %w", err)
 	}
+
+	err = markComplete(conf, plugin, version)
+	if err != nil {
+		if rmErr := os.RemoveAll(installDir); rmErr != nil {
+			fmt.Fprintf(stdErr, "failed to clean up '%s' due to %s\n", installDir, rmErr)
+		}
+		return fmt.Errorf("failed to mark installation as complete: %w", err)
+	}
+
+	stopCleanup()
 
 	// Reshim
 	err = shims.GenerateAll(conf, stdOut, stdErr)
@@ -365,4 +422,54 @@ func parseVersions(rawVersions string) []string {
 		}
 	}
 	return versions
+}
+
+// markComplete removes the incomplete marker file
+func markComplete(conf config.Config, plugin plugins.Plugin, version toolversions.Version) error {
+	markerPath := installs.IncompleteMarkerPath(conf, plugin, version)
+	err := os.Remove(markerPath)
+	if err != nil {
+		return fmt.Errorf("failed to remove incomplete marker: %w", err)
+	}
+	return nil
+}
+
+// markIncomplete creates an incomplete marker file
+func markIncomplete(conf config.Config, plugin plugins.Plugin, version toolversions.Version) error {
+	markerPath := installs.IncompleteMarkerPath(conf, plugin, version)
+	err := os.MkdirAll(filepath.Dir(markerPath), 0o755)
+	if err != nil {
+		return fmt.Errorf("failed to create marker directory: %w", err)
+	}
+	file, err := os.Create(markerPath)
+	if err != nil {
+		return fmt.Errorf("failed to create incomplete marker: %w", err)
+	}
+	defer file.Close()
+	return nil
+}
+
+// cleanupStaleIncomplete removes an install directory if it has an incomplete marker
+func cleanupStaleIncomplete(conf config.Config, plugin plugins.Plugin, version toolversions.Version) error {
+	markerPath := installs.IncompleteMarkerPath(conf, plugin, version)
+	_, err := os.Stat(markerPath)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to check for incomplete marker: %w", err)
+	}
+
+	installPath := installs.InstallPath(conf, plugin, version)
+	err = os.RemoveAll(installPath)
+	if err != nil {
+		return fmt.Errorf("failed to remove stale incomplete directory: %w", err)
+	}
+
+	err = os.Remove(markerPath)
+	if err != nil {
+		return fmt.Errorf("failed to remove stale incomplete marker: %w", err)
+	}
+
+	return nil
 }

--- a/internal/versions/versions_test.go
+++ b/internal/versions/versions_test.go
@@ -320,6 +320,60 @@ func TestInstallOneVersion(t *testing.T) {
 		// no-download install script prints 'install'
 		assert.Equal(t, "install", stdout.String())
 	})
+
+	t.Run("install directory does not have .incomplete marker after successful install", func(t *testing.T) {
+		conf, plugin := generateConfig(t)
+		stdout, stderr := buildOutputs()
+		err := InstallOneVersion(conf, plugin, "1.0.0", false, &stdout, &stderr)
+		assert.Nil(t, err)
+
+		installPath := filepath.Join(conf.DataDir, "installs", plugin.Name, "1.0.0")
+		markerPath := filepath.Join(installPath, ".incomplete")
+		_, err = os.Stat(markerPath)
+		assert.True(t, os.IsNotExist(err), ".incomplete marker should not exist after successful install")
+	})
+
+	t.Run("temp directory is cleaned up after successful install", func(t *testing.T) {
+		conf, plugin := generateConfig(t)
+		stdout, stderr := buildOutputs()
+		err := InstallOneVersion(conf, plugin, "1.0.0", false, &stdout, &stderr)
+		assert.Nil(t, err)
+
+		tempDir := filepath.Join(conf.DataDir, "temp", "install")
+		entries, err := os.ReadDir(tempDir)
+		if !os.IsNotExist(err) {
+			assert.Nil(t, err)
+			assert.Empty(t, entries, "temp install directory should be empty after successful install")
+		}
+	})
+
+	t.Run("install directory is not visible during installation", func(t *testing.T) {
+		conf, plugin := generateConfig(t)
+		stdout, stderr := buildOutputs()
+		err := InstallOneVersion(conf, plugin, "1.0.0", false, &stdout, &stderr)
+		assert.Nil(t, err)
+		assertVersionInstalled(t, conf.DataDir, plugin.Name, "1.0.0")
+	})
+
+	t.Run("cleans up stale incomplete directory from previous failed install", func(t *testing.T) {
+		conf, plugin := generateConfig(t)
+		stdout, stderr := buildOutputs()
+
+		installPath := filepath.Join(conf.DataDir, "installs", plugin.Name, "1.0.0")
+		err := os.MkdirAll(installPath, 0o777)
+		assert.Nil(t, err)
+
+		markerPath := filepath.Join(installPath, ".incomplete")
+		err = os.WriteFile(markerPath, []byte{}, 0o644)
+		assert.Nil(t, err)
+
+		err = InstallOneVersion(conf, plugin, "1.0.0", false, &stdout, &stderr)
+		assert.Nil(t, err)
+
+		_, err = os.Stat(markerPath)
+		assert.True(t, os.IsNotExist(err), ".incomplete marker should not exist after successful retry")
+		assertVersionInstalled(t, conf.DataDir, plugin.Name, "1.0.0")
+	})
 }
 
 func TestLatest(t *testing.T) {
@@ -591,4 +645,80 @@ func writeVersionFile(t *testing.T, dir, contents string) {
 	t.Helper()
 	err := os.WriteFile(filepath.Join(dir, ".tool-versions"), []byte(contents), 0o666)
 	assert.Nil(t, err)
+}
+
+func TestCleanupStaleIncomplete(t *testing.T) {
+	conf, plugin := generateConfig(t)
+
+	t.Run("removes directory when .incomplete marker exists", func(t *testing.T) {
+		version := toolversions.Version{Type: "version", Value: "5.0.0"}
+		mockInstall(t, conf, plugin, "5.0.0")
+		installPath := InstallPath(conf, plugin, version)
+
+		err := MarkIncomplete(installPath)
+		assert.Nil(t, err)
+
+		err = CleanupStaleIncomplete(conf, plugin, version)
+		assert.Nil(t, err)
+
+		_, err = os.Stat(installPath)
+		assert.True(t, os.IsNotExist(err), "directory should be removed")
+	})
+
+	t.Run("does nothing when directory does not exist", func(t *testing.T) {
+		version := toolversions.Version{Type: "version", Value: "6.0.0"}
+		err := CleanupStaleIncomplete(conf, plugin, version)
+		assert.Nil(t, err)
+	})
+
+	t.Run("does nothing when directory exists without .incomplete marker", func(t *testing.T) {
+		version := toolversions.Version{Type: "version", Value: "7.0.0"}
+		mockInstall(t, conf, plugin, "7.0.0")
+		installPath := InstallPath(conf, plugin, version)
+
+		err := CleanupStaleIncomplete(conf, plugin, version)
+		assert.Nil(t, err)
+
+		_, err = os.Stat(installPath)
+		assert.Nil(t, err, "directory should still exist")
+	})
+}
+
+func TestMarkIncomplete(t *testing.T) {
+	t.Run("creates .incomplete marker file in directory", func(t *testing.T) {
+		dir := t.TempDir()
+		err := MarkIncomplete(dir)
+		assert.Nil(t, err)
+
+		markerPath := filepath.Join(dir, ".incomplete")
+		_, err = os.Stat(markerPath)
+		assert.Nil(t, err, "marker file should exist")
+	})
+
+	t.Run("returns error when directory does not exist", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "nonexistent")
+		err := MarkIncomplete(dir)
+		assert.NotNil(t, err)
+	})
+}
+
+func TestMarkComplete(t *testing.T) {
+	t.Run("removes .incomplete marker file from directory", func(t *testing.T) {
+		dir := t.TempDir()
+		markerPath := filepath.Join(dir, ".incomplete")
+		err := os.WriteFile(markerPath, []byte{}, 0644)
+		assert.Nil(t, err)
+
+		err = MarkComplete(dir)
+		assert.Nil(t, err)
+
+		_, err = os.Stat(markerPath)
+		assert.True(t, os.IsNotExist(err), "marker file should not exist")
+	})
+
+	t.Run("returns error when marker file does not exist", func(t *testing.T) {
+		dir := t.TempDir()
+		err := MarkComplete(dir)
+		assert.NotNil(t, err)
+	})
 }

--- a/internal/versions/versions_test.go
+++ b/internal/versions/versions_test.go
@@ -1,14 +1,17 @@
 package versions
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/asdf-vm/asdf/internal/config"
+	"github.com/asdf-vm/asdf/internal/installs"
 	"github.com/asdf-vm/asdf/internal/plugins"
 	"github.com/asdf-vm/asdf/internal/repotest"
 	"github.com/asdf-vm/asdf/internal/toolversions"
@@ -320,6 +323,29 @@ func TestInstallOneVersion(t *testing.T) {
 		// no-download install script prints 'install'
 		assert.Equal(t, "install", stdout.String())
 	})
+
+	t.Run("cleans up stale incomplete directory from previous failed install", func(t *testing.T) {
+		conf, plugin := generateConfig(t)
+		stdout, stderr := buildOutputs()
+
+		version := toolversions.Version{Type: "version", Value: "1.0.0"}
+		installPath := installs.InstallPath(conf, plugin, version)
+		err := os.MkdirAll(installPath, 0o777)
+		assert.Nil(t, err)
+
+		markerPath := installs.IncompleteMarkerPath(conf, plugin, version)
+		err = os.MkdirAll(filepath.Dir(markerPath), 0o755)
+		assert.Nil(t, err)
+		err = os.WriteFile(markerPath, []byte{}, 0o644)
+		assert.Nil(t, err)
+
+		err = InstallOneVersion(conf, plugin, "1.0.0", false, &stdout, &stderr)
+		assert.Nil(t, err)
+
+		_, err = os.Stat(markerPath)
+		assert.True(t, errors.Is(err, fs.ErrNotExist), "incomplete marker should not exist after successful retry")
+		assertVersionInstalled(t, conf.DataDir, plugin.Name, "1.0.0")
+	})
 }
 
 func TestLatest(t *testing.T) {
@@ -591,4 +617,106 @@ func writeVersionFile(t *testing.T, dir, contents string) {
 	t.Helper()
 	err := os.WriteFile(filepath.Join(dir, ".tool-versions"), []byte(contents), 0o666)
 	assert.Nil(t, err)
+}
+
+func TestCleanupStaleIncomplete(t *testing.T) {
+	conf, plugin := generateConfig(t)
+
+	t.Run("removes directory when incomplete marker exists", func(t *testing.T) {
+		version := toolversions.Version{Type: "version", Value: "5.0.0"}
+		installPath := installs.InstallPath(conf, plugin, version)
+		err := os.MkdirAll(installPath, 0o777)
+		assert.Nil(t, err)
+
+		err = markIncomplete(conf, plugin, version)
+		assert.Nil(t, err)
+
+		err = cleanupStaleIncomplete(conf, plugin, version)
+		assert.Nil(t, err)
+
+		_, err = os.Stat(installPath)
+		assert.True(t, errors.Is(err, fs.ErrNotExist), "directory should be removed")
+	})
+
+	t.Run("does nothing when directory does not exist", func(t *testing.T) {
+		version := toolversions.Version{Type: "version", Value: "6.0.0"}
+		err := cleanupStaleIncomplete(conf, plugin, version)
+		assert.Nil(t, err)
+	})
+
+	t.Run("does nothing when directory exists without incomplete marker", func(t *testing.T) {
+		version := toolversions.Version{Type: "version", Value: "7.0.0"}
+		installPath := installs.InstallPath(conf, plugin, version)
+		err := os.MkdirAll(installPath, 0o777)
+		assert.Nil(t, err)
+
+		err = cleanupStaleIncomplete(conf, plugin, version)
+		assert.Nil(t, err)
+
+		_, err = os.Stat(installPath)
+		assert.Nil(t, err, "directory should still exist")
+	})
+
+	t.Run("removes marker when install directory was never created", func(t *testing.T) {
+		version := toolversions.Version{Type: "version", Value: "8.0.0"}
+
+		err := markIncomplete(conf, plugin, version)
+		assert.Nil(t, err)
+
+		err = cleanupStaleIncomplete(conf, plugin, version)
+		assert.Nil(t, err, "should not error when install directory is missing")
+
+		markerPath := installs.IncompleteMarkerPath(conf, plugin, version)
+		_, err = os.Stat(markerPath)
+		assert.True(t, errors.Is(err, fs.ErrNotExist), "marker should be removed")
+	})
+}
+
+func TestMarkIncomplete(t *testing.T) {
+	conf, plugin := generateConfig(t)
+
+	t.Run("creates marker file in install-locks directory", func(t *testing.T) {
+		version := toolversions.Version{Type: "version", Value: "1.0.0"}
+		err := markIncomplete(conf, plugin, version)
+		assert.Nil(t, err)
+
+		markerPath := installs.IncompleteMarkerPath(conf, plugin, version)
+		_, err = os.Stat(markerPath)
+		assert.Nil(t, err, "marker file should exist")
+	})
+
+	t.Run("creates marker file even when directory does not exist", func(t *testing.T) {
+		version := toolversions.Version{Type: "version", Value: "2.0.0"}
+		err := markIncomplete(conf, plugin, version)
+		assert.Nil(t, err)
+
+		markerPath := installs.IncompleteMarkerPath(conf, plugin, version)
+		_, err = os.Stat(markerPath)
+		assert.Nil(t, err, "marker file should exist")
+	})
+}
+
+func TestMarkComplete(t *testing.T) {
+	conf, plugin := generateConfig(t)
+
+	t.Run("removes marker file from install-locks directory", func(t *testing.T) {
+		version := toolversions.Version{Type: "version", Value: "1.0.0"}
+		markerPath := installs.IncompleteMarkerPath(conf, plugin, version)
+		err := os.MkdirAll(filepath.Dir(markerPath), 0o755)
+		assert.Nil(t, err)
+		err = os.WriteFile(markerPath, []byte{}, 0o644)
+		assert.Nil(t, err)
+
+		err = markComplete(conf, plugin, version)
+		assert.Nil(t, err)
+
+		_, err = os.Stat(markerPath)
+		assert.True(t, errors.Is(err, fs.ErrNotExist), "marker file should not exist")
+	})
+
+	t.Run("returns error when marker file does not exist", func(t *testing.T) {
+		version := toolversions.Version{Type: "version", Value: "2.0.0"}
+		err := markComplete(conf, plugin, version)
+		assert.NotNil(t, err)
+	})
 }


### PR DESCRIPTION
Changes:

* Correct gitignore pattern so only ./asdf binary in project root is ignored
* Write ADR 1 for handling of incomplete installs
* Check for incomplete install marker file in installs.IsInstalled and installs.Installed functions
* Update install process to create directories for marker file and
  create marker file before beginning the installation process for a
  version.
* Add gorountine to properly cleanup when `SIGKILL` and `SIGTERM` are received

Fixes:

* https://github.com/asdf-vm/asdf/issues/2184
* https://github.com/asdf-vm/asdf/issues/2036

Related:

* https://github.com/asdf-vm/asdf/pull/2245