### PR TITLE
fix: search current directory with --parent

### DIFF
--- a/internal/cli/set/set.go
+++ b/internal/cli/set/set.go
@@ -99,8 +99,6 @@ func printError(stderr io.Writer, msg string) error {
 }
 
 func findVersionFileInParentDir(conf config.Config, directory string) (string, bool) {
-	directory = filepath.Dir(directory)
-
 	for {
 		path := filepath.Join(directory, conf.DefaultToolVersionsFilename)
 		if _, err := os.Stat(path); err == nil {

--- a/internal/cli/set/set_test.go
+++ b/internal/cli/set/set_test.go
@@ -78,6 +78,24 @@ func TestAll(t *testing.T) {
 		assert.Equal(t, "lua 5.2.3\n", string(bytes))
 	})
 
+	t.Run("sets version in current directory when --parent flag provided", func(t *testing.T) {
+		stdout, stderr := buildOutputs()
+		dir := t.TempDir()
+		assert.Nil(t, os.Chdir(dir))
+		assert.Nil(t, os.WriteFile(filepath.Join(dir, ".tool-versions"), []byte("lua 4.0.0"), 0o666))
+
+		err := Main(&stdout, &stderr, []string{"lua", "5.2.3"}, false, true, homeFunc)
+
+		assert.Nil(t, err)
+		assert.Equal(t, stdout.String(), "")
+		assert.Equal(t, stderr.String(), "")
+
+		path := filepath.Join(dir, ".tool-versions")
+		bytes, err := os.ReadFile(path)
+		assert.Nil(t, err)
+		assert.Equal(t, "lua 5.2.3\n", string(bytes))
+	})
+
 	t.Run("sets version in home directory when --home flag provided", func(t *testing.T) {
 		stdout, stderr := buildOutputs()
 		homedir := filepath.Join(t.TempDir(), "home")


### PR DESCRIPTION
# Summary

Make `asdf set --parent` inspect the current directory before walking through its ancestors. This allows it to update an existing `.tool-versions` in the working directory instead of silently skipping it.

Add a regression test covering the current-directory case while retaining the existing parent-directory coverage.

Fixes: #2224

## Other Information

Validation:

- `gofmt` on the changed Go files
- `git diff --check`

The Go test suite was attempted on Windows, but this Unix-oriented package does not compile natively there because `internal/shims` uses `unix.Access`; the repository CI provides the supported Linux test environment.
