### PR TITLE
fix: clean up plugins after failed plugin tests

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -276,8 +276,7 @@ func Execute(version string) {
 							toolVersion := cmd.String("asdf-tool-version")
 							gitRef := cmd.String("asdf-plugin-gitref")
 							args := cmd.Args().Slice()
-							pluginTestCommand(logger, args, toolVersion, gitRef)
-							return nil
+							return pluginTestCommand(logger, args, toolVersion, gitRef)
 						},
 					},
 				},
@@ -963,16 +962,15 @@ func pluginUpdateCommand(cCtx *cli.Command, logger *log.Logger, pluginName, ref 
 	return err
 }
 
-func pluginTestCommand(l *log.Logger, args []string, toolVersion, ref string) {
+func pluginTestCommand(l *log.Logger, args []string, toolVersion, ref string) error {
 	conf, err := config.LoadConfig()
 	if err != nil {
 		l.Printf("error loading config: %s", err)
-		cli.OsExiter(1)
-		return
+		return err
 	}
 
 	if len(args) < 2 {
-		failTest(l, "please provide a plugin name and url")
+		return failTest(l, "please provide a plugin name and url")
 	}
 
 	name := args[0]
@@ -982,7 +980,7 @@ func pluginTestCommand(l *log.Logger, args []string, toolVersion, ref string) {
 	// Install plugin
 	err = plugins.Add(conf, testName, url, ref)
 	if err != nil {
-		failTest(l, fmt.Sprintf("%s was not properly installed reason: %s", name, err))
+		return failTest(l, fmt.Sprintf("%s was not properly installed reason: %s", name, err))
 	}
 
 	// Remove plugin
@@ -993,7 +991,7 @@ func pluginTestCommand(l *log.Logger, args []string, toolVersion, ref string) {
 	plugin := plugins.New(conf, testName)
 	files, err := os.ReadDir(filepath.Join(plugin.Dir, "bin"))
 	if _, ok := err.(*fs.PathError); ok {
-		failTest(l, "bin/ directory does not exist")
+		return failTest(l, "bin/ directory does not exist")
 	}
 
 	callbacks := []string{}
@@ -1003,7 +1001,7 @@ func pluginTestCommand(l *log.Logger, args []string, toolVersion, ref string) {
 
 	for _, expectedCallback := range []string{"download", "install", "list-all"} {
 		if !slices.Contains(callbacks, expectedCallback) {
-			failTest(l, fmt.Sprintf("missing callback %s", expectedCallback))
+			return failTest(l, fmt.Sprintf("missing callback %s", expectedCallback))
 		}
 	}
 
@@ -1016,7 +1014,7 @@ func pluginTestCommand(l *log.Logger, args []string, toolVersion, ref string) {
 			// check if it is executable
 			info, _ := file.Info()
 			if !(info.Mode()&0o111 != 0) {
-				failTest(l, fmt.Sprintf("callback lacks executable permission: %s", file.Name()))
+				return failTest(l, fmt.Sprintf("callback lacks executable permission: %s", file.Name()))
 			}
 		}
 	}
@@ -1024,29 +1022,29 @@ func pluginTestCommand(l *log.Logger, args []string, toolVersion, ref string) {
 	// Assert has license
 	licensePath := filepath.Join(plugin.Dir, "LICENSE")
 	if _, err := os.Stat(licensePath); errors.Is(err, os.ErrNotExist) {
-		failTest(l, "LICENSE file must be present in the plugin repository")
+		return failTest(l, "LICENSE file must be present in the plugin repository")
 	}
 
 	bytes, err := os.ReadFile(licensePath)
 	if err != nil {
-		failTest(l, "LICENSE file must be present in the plugin repository")
+		return failTest(l, "LICENSE file must be present in the plugin repository")
 	}
 
 	// Validate license file not empty
 	if len(bytes) == 0 {
-		failTest(l, "LICENSE file in the plugin repository must not be empty")
+		return failTest(l, "LICENSE file in the plugin repository must not be empty")
 	}
 
 	// Validate it returns at least one available version
 	var output strings.Builder
 	err = plugin.RunCallback("list-all", []string{}, map[string]string{}, &output, &blackhole)
 	if err != nil {
-		failTest(l, "Unable to list available versions")
+		return failTest(l, "Unable to list available versions")
 	}
 
 	allVersions := strings.Fields(output.String())
 	if len(allVersions) < 1 {
-		failTest(l, "list-all did not return any version")
+		return failTest(l, "list-all did not return any version")
 	}
 
 	// Resolve version: if empty use first from list-all; if "latest" or
@@ -1058,20 +1056,22 @@ func pluginTestCommand(l *log.Logger, args []string, toolVersion, ref string) {
 		query = strings.TrimPrefix(query, ":")
 		resolved, err := versions.Latest(plugin, query, os.Stderr)
 		if err != nil {
-			failTest(l, "could not get latest version")
+			return failTest(l, "could not get latest version")
 		}
 		toolVersion = resolved
 	}
 
 	err = versions.InstallOneVersion(conf, plugin, toolVersion, false, os.Stdout, os.Stderr)
 	if err != nil {
-		failTest(l, "install exited with an error")
+		return failTest(l, "install exited with an error")
 	}
+
+	return nil
 }
 
-func failTest(logger *log.Logger, msg string) {
+func failTest(logger *log.Logger, msg string) error {
 	logger.Printf("FAILED: %s", msg)
-	cli.OsExiter(1)
+	return cli.Exit("", 1)
 }
 
 func formatUpdateResult(logger *log.Logger, pluginName, updatedToRef string, err error) {

--- a/test/plugin_test_command.bats
+++ b/test/plugin_test_command.bats
@@ -37,3 +37,21 @@ teardown() {
   run asdf plugin test dummy "${BASE_DIR}/repo-dummy" --asdf-tool-version latest
   [ "$status" -eq 0 ]
 }
+
+@test "plugin_test_command cleans up the test plugin after validation fails" {
+  rm "${BASE_DIR}/repo-dummy/bin/install"
+  git -C "${BASE_DIR}/repo-dummy" add -u
+  git -C "${BASE_DIR}/repo-dummy" commit -q -m "remove install callback"
+
+  run asdf plugin test dummy "${BASE_DIR}/repo-dummy"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"FAILED: missing callback install"* ]]
+  [[ "$output" != *"already added"* ]]
+  [ ! -d "${ASDF_DATA_DIR}/plugins/asdf-test-dummy" ]
+
+  run asdf plugin test dummy "${BASE_DIR}/repo-dummy"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"FAILED: missing callback install"* ]]
+  [[ "$output" != *"already added"* ]]
+  [ ! -d "${ASDF_DATA_DIR}/plugins/asdf-test-dummy" ]
+}


### PR DESCRIPTION
# Summary

Return plugin-test validation failures through the CLI action instead of exiting immediately. This lets the existing deferred `plugins.Remove` call run after both successful and failed tests.

Add a Bats regression that removes a required callback, runs the failing plugin test twice, and verifies after each run that:

- the expected validation error is preserved;
- the second run does not fail with `already added`;
- `asdf-test-dummy` is removed from the isolated data directory.

Fixes: #2130

## Other Information

Root cause: `failTest` called `cli.OsExiter(1)` inside `pluginTestCommand`. Process exit bypassed the deferred cleanup registered after the temporary plugin was added.

Validation run locally on Linux under WSL with Go 1.26.5 and the repository-declared Bats 1.8.2:

- `go test ./cmd/asdf -run TestBatsTests/plugin_test_command -count=1`
- `go test -timeout=30m -coverprofile=<E:-scratch-output> -bench= -race ./...`
- `scripts/lint.bash --check` with shfmt 3.6.0, ShellCheck 0.10.0, and the custom Python style checker
- `go run mvdan.cc/gofumpt -l .`
- `go mod verify`
- `go vet ./...`
- `go run github.com/mgechev/revive -set_exit_status ./...`
- `go run honnef.co/go/tools/cmd/staticcheck -tests -show-ignored ./...`
- `go build -v ./...`
- real CLI success and failure paths using local fixture repositories and isolated `ASDF_DATA_DIR` values, including two consecutive failed runs

Local `fish_indent` was not available, so the Fish formatting portion of `scripts/lint.bash --check` was skipped with the script's normal warning. No Fish files changed. The macOS test matrix was not run locally.

The fork-triggered Lint and Test workflow runs are currently `action_required` with zero jobs started and need maintainer approval before they can execute. `semantic-pr` passed. This is an external workflow gate, not a CI pass or test failure; the unrun Fish and macOS checks remain unverified until those workflows run.

This contribution was prepared with OpenAI Codex assistance under CAOShurong's direction; the diff and the checks run are reported here without claiming unrun validation.
