### PR TITLE
test: add zsh completion behavior coverage

### DIFF
--- a/internal/completions/completions_test.go
+++ b/internal/completions/completions_test.go
@@ -1,6 +1,8 @@
 package completions
 
 import (
+	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,4 +29,67 @@ func TestNames(t *testing.T) {
 	t.Run("returns slice of shell names for which completion is available", func(t *testing.T) {
 		assert.Equal(t, []string{"bash", "elvish", "fish", "nushell", "zsh"}, Names())
 	})
+}
+
+func TestZshCompletionCandidates(t *testing.T) {
+	zsh, err := exec.LookPath("zsh")
+	if err != nil {
+		t.Skip("zsh is not installed")
+	}
+
+	t.Run("completes top-level commands", func(t *testing.T) {
+		candidates := runZshCompletion(t, zsh, "asdf", "")
+
+		for _, candidate := range []string{"plugin", "install", "list", "set"} {
+			assert.Contains(t, candidates, candidate)
+		}
+	})
+
+	t.Run("completes plugin subcommands", func(t *testing.T) {
+		candidates := runZshCompletion(t, zsh, "asdf", "plugin", "")
+
+		assert.Equal(t, []string{"add", "list", "remove", "update"}, candidates)
+	})
+}
+
+func runZshCompletion(t *testing.T, zsh string, words ...string) []string {
+	t.Helper()
+
+	completion, found := Get("zsh")
+	if !found {
+		t.Fatal("zsh completion file not found")
+	}
+	defer func() {
+		assert.NoError(t, completion.Close())
+	}()
+
+	// Stub the Zsh completion system so candidates can be captured without an
+	// interactive shell while the asdf completion function itself runs unchanged.
+	const script = `
+_arguments() {
+  state=command
+}
+_describe() {
+  local values_name=$4
+  local -a values
+  values=("${(@P)values_name}")
+  print -l -- "${values[@]%%:*}"
+}
+_asdf() {
+  source /dev/stdin
+}
+words=("$@")
+CURRENT=${#words}
+_asdf
+`
+
+	args := []string{"-f", "-c", script, "asdf-completion-test"}
+	args = append(args, words...)
+	command := exec.Command(zsh, args...)
+	command.Stdin = completion
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running zsh completion: %v\n%s", err, output)
+	}
+	return strings.Fields(string(output))
 }


### PR DESCRIPTION
# Summary

Add behavioral coverage for the embedded Zsh completion script using a real Zsh process. The tests validate representative top-level candidates and the exact plugin subcommand candidates while stubbing only the interactive completion primitives.

Related: #2042

## Testing

- `go test -race ./internal/completions -count=1`
- focused completion test repeated 20 times
- `go test ./internal/... -count=1`
- repository-wide compilation with `go test ./... -run ^TestZshCompletionCandidates$ -count=1`
- Go vet, gofumpt, revive, and staticcheck for the completions package
- `go build ./...`
- `git diff --check`

The test skips on hosts without Zsh. The unrestricted repository test suite was not run locally because its legacy integration tests require `bats`, which is unavailable in this environment; the macOS CI job provides Zsh execution.

## Assistance

AI assistance was used during implementation and test analysis.