### PR TITLE
docs: explain env vars for dashed tool names

### DIFF
--- a/docs/manage/versions.md
+++ b/docs/manage/versions.md
@@ -96,6 +96,10 @@ When determining the version looks for an environment variable with the pattern
 `.tool-versions` file. If set, the value of this environment variable overrides
 any versions set in for the tool in any `.tool-versions` file. For example:
 
+For tool names that contain dashes, replace each dash with an underscore when
+constructing the environment variable name. For example, the `aws-sam-cli`
+tool uses `ASDF_AWS_SAM_CLI_VERSION`.
+
 ```shell
 export ASDF_ELIXIR_VERSION=1.18.1
 ```


### PR DESCRIPTION
Fixes #2299.

Document how to construct the `ASDF_<TOOL>_VERSION` environment variable for tool names containing dashes. Each dash is replaced with an underscore, so `aws-sam-cli` uses `ASDF_AWS_SAM_CLI_VERSION`.

The mapping matches the existing core implementation in `internal/resolve/resolve.go` (`strings.ReplaceAll(upper, "-", "_")`).

Validation:
- `go test ./internal/resolve -run 'TestVariableVersionName|TestFindVersionsInEnv' -count=1`
- `git diff --check`
- `npm run build` in `docs/` (VitePress build complete)

This documentation change was prepared with Codex assistance.