### PR TITLE
fix: report precisely when a configured version is not installed

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -684,7 +684,15 @@ func getExecutable(logger *log.Logger, conf config.Config, command string) (exec
 		toolVersions, _ := shims.GetToolsAndVersionsFromShimFile(shimPath)
 
 		if len(toolVersions) > 0 {
-			if anyInstalled(conf, toolVersions) {
+			if pluginName, configuredVersions, ok := configuredButNotInstalled(conf, toolVersions, currentDir); ok {
+				logger.Printf("version %s of %s is set for the current directory, but it is not installed", strings.Join(configuredVersions, ", "), pluginName)
+				for _, version := range configuredVersions {
+					logger.Printf("asdf install %s %s\n", pluginName, version)
+				}
+
+				os.Exit(126)
+				return executable, plugins.Plugin{}, "", err
+			} else if anyInstalled(conf, toolVersions) {
 				logger.Printf("No version is set for command %s", command)
 				logger.Printf("Consider adding one of the following versions in your config file at %s/.tool-versions\n", currentDir)
 			} else {
@@ -716,6 +724,44 @@ func getExecutable(logger *log.Logger, conf config.Config, command string) (exec
 	}
 
 	return executable, plugin, version, nil
+}
+
+// configuredButNotInstalled checks, for each plugin associated with a shim,
+// whether a version is actually configured for currentDir (via .tool-versions,
+// an env var, etc) but not installed. This lets getExecutable report that
+// precisely instead of the generic "No version is set" message, which is
+// printed even when a version *is* set -- just not installed yet.
+func configuredButNotInstalled(conf config.Config, toolVersions []toolversions.ToolVersions, currentDir string) (pluginName string, configuredVersions []string, found bool) {
+	for _, toolVersion := range toolVersions {
+		plugin := plugins.New(conf, toolVersion.Name)
+		resolved, ok, err := resolve.Version(conf, plugin, currentDir)
+		if err != nil || !ok || len(resolved.Versions) == 0 {
+			continue
+		}
+
+		anyConcreteVersionInstalled := false
+		anyConcreteVersion := false
+		for _, version := range resolved.Versions {
+			parsedVersion := toolversions.Parse(version)
+			if parsedVersion.Type != "version" {
+				// "system", "path:" and "ref:" versions don't have a
+				// meaningful "not installed" state to report here.
+				continue
+			}
+
+			anyConcreteVersion = true
+			if installs.IsInstalled(conf, plugin, parsedVersion) {
+				anyConcreteVersionInstalled = true
+				break
+			}
+		}
+
+		if anyConcreteVersion && !anyConcreteVersionInstalled {
+			return toolVersion.Name, resolved.Versions, true
+		}
+	}
+
+	return "", nil, false
 }
 
 func anyInstalled(conf config.Config, toolVersions []toolversions.ToolVersions) bool {

--- a/internal/cli/set/set.go
+++ b/internal/cli/set/set.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/asdf-vm/asdf/internal/config"
+	"github.com/asdf-vm/asdf/internal/installs"
 	"github.com/asdf-vm/asdf/internal/plugins"
 	"github.com/asdf-vm/asdf/internal/toolversions"
 	"github.com/asdf-vm/asdf/internal/versions"
@@ -52,6 +53,9 @@ func Main(_ io.Writer, stderr io.Writer, args []string, home bool, parent bool, 
 
 	tv := toolversions.ToolVersions{Name: args[0], Versions: resolvedVersions}
 
+	plugin := plugins.New(conf, args[0])
+	warnIfNotInstalled(stderr, conf, plugin, resolvedVersions)
+
 	if home {
 		homeDir, err := homeFunc()
 		if err != nil {
@@ -88,6 +92,24 @@ func Main(_ io.Writer, stderr io.Writer, args []string, home bool, parent bool, 
 	// Write new file in current dir
 	filepath := filepath.Join(currentDir, conf.DefaultToolVersionsFilename)
 	return toolversions.WriteToolVersionsToFile(filepath, []toolversions.ToolVersions{tv})
+}
+
+// warnIfNotInstalled prints a warning to stderr for any version being set
+// that is not currently installed for the plugin, so users are not left
+// wondering why a shim later reports no version resolves. It only warns for
+// concrete versions -- "system", "path:" and "ref:" versions have no
+// meaningful installed state to check.
+func warnIfNotInstalled(stderr io.Writer, conf config.Config, plugin plugins.Plugin, versions []string) {
+	for _, version := range versions {
+		parsedVersion := toolversions.Parse(version)
+		if parsedVersion.Type != "version" {
+			continue
+		}
+
+		if !installs.IsInstalled(conf, plugin, parsedVersion) {
+			fmt.Fprintf(stderr, "warning: version %s of %s is not installed, run `asdf install %s %s`\n", parsedVersion.Value, plugin.Name, plugin.Name, parsedVersion.Value)
+		}
+	}
 }
 
 func printError(stderr io.Writer, msg string) error {

--- a/internal/cli/set/set_test.go
+++ b/internal/cli/set/set_test.go
@@ -50,12 +50,45 @@ func TestAll(t *testing.T) {
 
 		assert.Nil(t, err)
 		assert.Equal(t, stdout.String(), "")
+		assert.Equal(t, stderr.String(), "warning: version 5.2.3 of lua is not installed, run `asdf install lua 5.2.3`\n")
+
+		path := filepath.Join(dir, ".tool-versions")
+		bytes, err := os.ReadFile(path)
+		assert.Nil(t, err)
+		assert.Equal(t, "lua 5.2.3\n", string(bytes))
+	})
+
+	t.Run("does not warn when the version being set is already installed", func(t *testing.T) {
+		dataDir := t.TempDir()
+		t.Setenv("ASDF_DATA_DIR", dataDir)
+		assert.Nil(t, os.MkdirAll(filepath.Join(dataDir, "installs", "lua", "5.2.3"), 0o777))
+
+		stdout, stderr := buildOutputs()
+		dir := t.TempDir()
+		assert.Nil(t, os.Chdir(dir))
+
+		err := Main(&stdout, &stderr, []string{"lua", "5.2.3"}, false, false, homeFunc)
+
+		assert.Nil(t, err)
+		assert.Equal(t, stdout.String(), "")
 		assert.Equal(t, stderr.String(), "")
 
 		path := filepath.Join(dir, ".tool-versions")
 		bytes, err := os.ReadFile(path)
 		assert.Nil(t, err)
 		assert.Equal(t, "lua 5.2.3\n", string(bytes))
+	})
+
+	t.Run("does not warn when setting a system version", func(t *testing.T) {
+		stdout, stderr := buildOutputs()
+		dir := t.TempDir()
+		assert.Nil(t, os.Chdir(dir))
+
+		err := Main(&stdout, &stderr, []string{"lua", "system"}, false, false, homeFunc)
+
+		assert.Nil(t, err)
+		assert.Equal(t, stdout.String(), "")
+		assert.Equal(t, stderr.String(), "")
 	})
 
 	t.Run("sets version in parent directory when --parent flag provided", func(t *testing.T) {
@@ -70,7 +103,7 @@ func TestAll(t *testing.T) {
 
 		assert.Nil(t, err)
 		assert.Equal(t, stdout.String(), "")
-		assert.Equal(t, stderr.String(), "")
+		assert.Equal(t, stderr.String(), "warning: version 5.2.3 of lua is not installed, run `asdf install lua 5.2.3`\n")
 
 		path := filepath.Join(dir, ".tool-versions")
 		bytes, err := os.ReadFile(path)
@@ -88,7 +121,7 @@ func TestAll(t *testing.T) {
 
 		assert.Nil(t, err)
 		assert.Equal(t, stdout.String(), "")
-		assert.Equal(t, stderr.String(), "")
+		assert.Equal(t, stderr.String(), "warning: version 5.2.3 of lua is not installed, run `asdf install lua 5.2.3`\n")
 
 		path := filepath.Join(homedir, ".tool-versions")
 		bytes, err := os.ReadFile(path)
@@ -106,7 +139,7 @@ func TestAll(t *testing.T) {
 
 		assert.Nil(t, err)
 		assert.Equal(t, stdout.String(), "")
-		assert.Equal(t, stderr.String(), "")
+		assert.Equal(t, stderr.String(), strings.Repeat("warning: version 5.2.3 of lua is not installed, run `asdf install lua 5.2.3`\n", 2))
 
 		path := filepath.Join(dir, ".tool-versions")
 		bytes, err := os.ReadFile(path)

--- a/test/set_command.bats
+++ b/test/set_command.bats
@@ -113,3 +113,22 @@ teardown() {
   run cat "$PROJECT_DIR/.tool-versions"
   [ "$output" = "dummy 1.0.0 1.1.0" ]
 }
+
+@test "set should warn when the version being set is not installed" {
+  run --separate-stderr asdf set "dummy" "9.9.9"
+  [ "$status" -eq 0 ]
+  [ -f "$PROJECT_DIR/.tool-versions" ]
+  run cat "$PROJECT_DIR/.tool-versions"
+  [ "$output" = "dummy 9.9.9" ]
+
+  run --separate-stderr asdf set "dummy" "9.9.9"
+  # shellcheck disable=SC2154
+  echo "${stderr:?}" | grep -q "warning: version 9.9.9 of dummy is not installed, run \`asdf install dummy 9.9.9\`" 2>/dev/null
+}
+
+@test "set should not warn when the version being set is already installed" {
+  run --separate-stderr asdf set "dummy" "1.0.0"
+  [ "$status" -eq 0 ]
+  # shellcheck disable=SC2154
+  [ "$stderr" = "" ]
+}

--- a/test/shim_exec.bats
+++ b/test/shim_exec.bats
@@ -122,22 +122,21 @@ teardown() {
   echo "$output" | grep -q "mummy 3.0" 2>/dev/null
 }
 
-# No longer possible for shim to specify version that isn't installed because
-# shims are re-generated after every install and uninstall.
-#@test "shim exec should suggest to install missing version" {
-#  run asdf install dummy 1.0
+@test "shim exec should report precisely when the configured version is not installed" {
+  # Installing 1.0 registers a shim for dummy, but .tool-versions asks for a
+  # different, never-installed version -- this used to be reported as
+  # "No version is set for command dummy" even though a version *is* set.
+  run asdf install dummy 1.0
 
-#  echo "dummy 2.0.0 1.3" >"$PROJECT_DIR/.tool-versions"
+  echo "dummy 2.0.0" >"$PROJECT_DIR/.tool-versions"
 
-#  run "$ASDF_DIR/shims/dummy" world hello
-#  [ "$status" -eq 126 ]
-#  echo "$output" | grep -q "No preset version installed for command dummy" 2>/dev/null
-#  echo "$output" | grep -q "Please install a version by running one of the following:" 2>/dev/null
-#  echo "$output" | grep -q "asdf install dummy 2.0.0" 2>/dev/null
-#  echo "$output" | grep -q "asdf install dummy 1.3" 2>/dev/null
-#  echo "$output" | grep -q "or add one of the following versions in your config file at $PROJECT_DIR/.tool-versions" 2>/dev/null
-#  echo "$output" | grep -q "dummy 1.0" 2>/dev/null
-#}
+  run --separate-stderr "$ASDF_DIR/shims/dummy" world hello
+  [ "$status" -eq 126 ]
+
+  # shellcheck disable=SC2154
+  echo "${stderr:?}" | grep -q "version 2.0.0 of dummy is set for the current directory, but it is not installed" 2>/dev/null
+  echo "${stderr:?}" | grep -q "asdf install dummy 2.0.0" 2>/dev/null
+}
 
 @test "shim exec should execute first plugin that is installed and set" {
   run asdf install dummy 2.0.0


### PR DESCRIPTION
## Summary

Two related bugs, both stemming from the same root confusion between "nothing configured" and "configured but not installed":

- `asdf set` (`internal/cli/set/set.go`) silently writes an uninstalled version to `.tool-versions` with no feedback. Running `asdf set just 1.58.0` when only `1.42.4`/`1.49.0`/`1.54.0` are installed succeeds with no warning at all.
- Running a shim afterwards then prints **"No version is set for command X"** (`internal/cli/cli.go`, `getExecutable`/`anyInstalled`) even though a version *is* set — the fallback path only checks whether *any* version ever shimmed for that command is installed, not whether the version actually configured for the current directory is installed. If a different version of the same tool happens to be installed and shimmed elsewhere, the message claims nothing is configured at all.

Together these left a real path with zero diagnostics: set an uninstalled version → run the tool → "no version is set" → dead end, even though `.tool-versions` clearly has a version in it.

## Changes

- `asdf set` now checks each concrete version it's about to write against `installs.IsInstalled` and prints a `warning: version X of Y is not installed, run \`asdf install Y X\`` to stderr. `system`/`path:`/`ref:` versions are skipped since "installed" isn't a meaningful concept for them.
- `getExecutable`'s shim-exec-failure fallback now resolves the version actually configured for the current directory (via `resolve.Version`, the same resolution shims use) before falling back to the existing "no version is set" / "no preset version installed" messages. When the configured version(s) exist but aren't installed, it reports that precisely with an `asdf install` suggestion, instead of the misleading generic message.

## Test plan

- [x] `go test -bench= -race ./...` (full suite, matches CI's `test-golang` job) — passes
- [x] `go run mvdan.cc/gofumpt -l .`, `go run github.com/mgechev/revive -set_exit_status ./...`, `go run honnef.co/go/tools/cmd/staticcheck -tests -show-ignored ./...` — all clean
- [x] Added unit tests in `internal/cli/set/set_test.go` (warn on uninstalled version, no warning when installed, no warning for `system`)
- [x] Added/updated bats coverage in `test/set_command.bats` and `test/shim_exec.bats` (replacing a stale commented-out test whose premise — "no longer possible for a shim to specify an uninstalled version" — turned out not to hold, since the shim file aggregates versions across the tool's whole install history, not just what's configured in the current directory)
- [x] Verified both new bats assertions actually fail without the fix (reverted `cli.go`/`set.go` locally, confirmed `not ok` on both, then restored)

Fixes #2044, fixes #2232.