### PR TITLE
fix: expand ~ in path: versions

### DIFF
--- a/internal/installs/installs.go
+++ b/internal/installs/installs.go
@@ -9,6 +9,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/asdf-vm/asdf/internal/config"
 	"github.com/asdf-vm/asdf/internal/data"
@@ -59,10 +60,27 @@ func Installed(conf config.Config, plugin plugins.Plugin) (versions []string, er
 // InstallPath returns the path to a tool installation
 func InstallPath(conf config.Config, plugin plugins.Plugin, version toolversions.Version) string {
 	if version.Type == "path" {
-		return version.Value
+		return resolveUserPath(version.Value)
 	}
 
 	return filepath.Join(data.InstallDirectory(conf.DataDir, plugin.Name), toolversions.FormatForFS(version))
+}
+
+// resolveUserPath expands a leading `~/` to the current user's home directory.
+// A `.tool-versions` file is read directly rather than by a shell, so nothing
+// else expands the `~` in a `path:~/src/elixir` version. Any other string is
+// returned unchanged.
+func resolveUserPath(path string) string {
+	if !strings.HasPrefix(path, "~/") {
+		return path
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+
+	return filepath.Join(homeDir, path[2:])
 }
 
 // DownloadPath returns the download path for a particular plugin and version

--- a/internal/installs/installs_test.go
+++ b/internal/installs/installs_test.go
@@ -41,6 +41,22 @@ func TestInstallPath(t *testing.T) {
 		assert.Equal(t, path, "foo/bar")
 	})
 
+	t.Run("expands leading ~/ in path version to home directory", func(t *testing.T) {
+		homeDir, err := os.UserHomeDir()
+		assert.Nil(t, err)
+
+		version := toolversions.Version{Type: "path", Value: "~/src/elixir"}
+		path := InstallPath(conf, plugin, version)
+		assert.Equal(t, path, filepath.Join(homeDir, "src", "elixir"))
+	})
+
+	t.Run("leaves a path version without a leading ~/ unchanged", func(t *testing.T) {
+		for _, value := range []string{"/opt/elixir", "foo/bar", "~elixir/src", "src/~/elixir"} {
+			version := toolversions.Version{Type: "path", Value: value}
+			assert.Equal(t, InstallPath(conf, plugin, version), value)
+		}
+	})
+
 	t.Run("returns install path when given regular version as version", func(t *testing.T) {
 		version := toolversions.Version{Type: "version", Value: "1.2.3"}
 		path := InstallPath(conf, plugin, version)


### PR DESCRIPTION
`.tool-versions` is read directly, not by a shell, so nothing expands the `~` in a `path:` version. `docs/manage/configuration.md` gives `path:~/src/elixir` as *the* example for path versions (same in all five translations), but on current `master` it resolves to a literal `~/src/elixir` directory.

asdf <= 0.15 did expand it: `parse_asdf_version_file` called `util_resolve_user_path` (`${path::2} == '~/'` -> `${HOME}/${path:2}`). The Go rewrite has no tilde expansion anywhere, and `upgrading-to-v0-16.md` does not list this among the breaking changes, so it looks unintended.

The fix is in `installs.InstallPath` -- the single choke point all consumers of a path install directory go through -- and not in `toolversions.Parse`. `Parse` feeds `Format`, which writes version strings back into shim tool-version records, so expanding there would persist an absolute path in place of the user's portable `~`. Measured: with expansion in `Parse`, `Format(Parse("path:~/src/elixir"))` returns `path:/home/you/src/elixir`; in `InstallPath` it round-trips unchanged.

Semantics match the legacy helper exactly: only a leading `~/`. `~user/`, relative and absolute paths pass through untouched, which the new test covers.

`go test ./...` passes. Reverting just the source change fails the new assertion and nothing else. The 22 `TestBatsTests` subtest failures I see locally are `bats` not being installed and are identical on pristine `master`.

AI-assisted (claude-opus-5).
